### PR TITLE
v0.8.0: Internationalization (i18n) and English README

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6167,7 +6167,7 @@ dependencies = [
 
 [[package]]
 name = "winxmerge"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arboard",
  "chardetng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winxmerge"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,149 +1,153 @@
 # WinXMerge
 
-WinMerge にインスパイアされた、Rust + Slint UI によるクロスプラットフォームのファイル差分比較・マージツール。
+A cross-platform file diff comparison and merge tool inspired by WinMerge, built with Rust + Slint UI.
 
-## 機能
+## Features
 
-### ファイル比較 (2-way)
-- 行単位の差分表示（追加/削除/変更/移動を色分け）
-- 差分ナビゲーション（次/前の差分へジャンプ）
-- マージ操作（左→右 / 右→左のブロック単位コピー）
-- インライン差分マーカー付き2ペイン表示
-- ロケーションペイン（差分位置のミニマップ）
-- 行移動の自動検出（青色ハイライト）
-- 左右スクロール同期
-- 行番号クリックで差分選択
+### File Comparison (2-way)
+- Line-level diff display (additions/deletions/changes/moves with color coding)
+- Diff navigation (jump to next/previous diff)
+- Merge operations (block-level copy: left→right / right→left)
+- Two-pane display with inline diff markers
+- Location pane (minimap of diff positions)
+- Automatic detection of moved lines (blue highlight)
+- Synchronized left/right scrolling
+- Click line numbers to select diff blocks
 
-### 3-way マージ
-- 3ペイン表示（Left / Base / Right）
-- ベースファイルからの変更を自動検出
-- 衝突行のハイライト（赤色）と L/R ボタンによる衝突解決
-- 衝突ナビゲーション（次/前）
-- 自動マージ（両側が同じ変更の場合）
+### 3-way Merge
+- Three-pane display (Left / Base / Right)
+- Automatic detection of changes from base file
+- Conflict highlighting (red) with L/R buttons for conflict resolution
+- Conflict navigation (next/previous)
+- Auto-merge when both sides have identical changes
 
-### フォルダ比較
-- ディレクトリの再帰比較
-- ファイル状態表示（同一/異なる/片方のみ）
-- 左右の更新日時を表示
-- .gitignore パターンの自動読み込み（.git ディレクトリは自動除外）
-- ファイル拡張子フィルタ
-- ダブルクリックでファイル差分ビューを開く
-- 「< Back」ボタンでフォルダビューに戻る
+### Folder Comparison
+- Recursive directory comparison
+- File status display (identical / different / one-side only)
+- Left/right modification timestamps
+- Automatic .gitignore pattern loading (.git directories auto-excluded)
+- File extension filter
+- Double-click to open file diff view
+- "< Back" button to return to folder view
 
-### タブ
-- 複数の比較をタブで管理
-- 各タブが独立した状態を保持
-- Cmd+T で新規タブ、Cmd+W で閉じる
+### Tabs
+- Manage multiple comparisons with tabs
+- Each tab maintains independent state
+- Cmd+T to create new tab, Cmd+W to close
 
-### シンタックスハイライト
-- tree-sitter による行レベルのハイライト
-- 対応言語: Rust, JavaScript, Python, JSON, C, C++, Go, TypeScript, TSX, Ruby
-- ファイルタイプの自動検出
-- オプションでオン/オフ切替
+### Syntax Highlighting
+- Line-level highlighting via tree-sitter
+- Supported languages: Rust, JavaScript, Python, JSON, C, C++, Go, TypeScript, TSX, Ruby
+- Automatic file type detection
+- Toggle on/off in options
 
 ### Undo / Redo
-- マージ操作の取り消し・やり直し
+- Undo and redo merge operations
 - Cmd+Z / Cmd+Shift+Z
 
-### 差分オプション
-- 空白の無視
-- 大文字小文字の無視
-- 空行の無視
-- 行末の違いを無視
-- 行移動検出のオン/オフ
+### Diff Options
+- Ignore whitespace
+- Ignore case
+- Ignore blank lines
+- Ignore line ending differences
+- Toggle moved line detection
 
-### エンコーディング
-- 文字エンコーディング自動検出（UTF-8, UTF-16, Shift_JIS 等）
-- BOM 対応
-- 保存時に元のエンコーディングを維持
+### Encoding
+- Automatic character encoding detection (UTF-8, UTF-16, Shift_JIS, etc.)
+- BOM support
+- Preserves original encoding when saving
 
-### 検索・置換
-- テキスト検索（マッチ数表示、前/次ナビゲーション）
-- 置換 / 全置換
+### Search & Replace
+- Text search (match count display, previous/next navigation)
+- Replace / Replace All
 
-### キーボードショートカット
+### Keyboard Shortcuts
 
-| ショートカット | 動作 |
-|---------------|------|
-| Cmd+S | 左ファイル保存 |
-| Cmd+F | 検索・置換の表示切替 |
+| Shortcut | Action |
+|----------|--------|
+| Cmd+S | Save left file |
+| Cmd+F | Toggle search & replace |
 | Cmd+Z | Undo |
 | Cmd+Shift+Z | Redo |
-| Cmd+T | 新規タブ |
-| Cmd+W | タブを閉じる |
-| Cmd+N | 新規比較 |
-| Alt+↓ | 次の差分 |
-| Alt+↑ | 前の差分 |
+| Cmd+T | New tab |
+| Cmd+W | Close tab |
+| Cmd+N | New comparison |
+| Alt+↓ | Next diff |
+| Alt+↑ | Previous diff |
 
-### テーマ切替
-- ライト / ダーク テーマの切替（Edit → Options... → Appearance）
-- Slint Palette 連動で全ウィジェットが自動的にテーマに追従
-- 差分カラー・シンタックスハイライト色もテーマに最適化
-- 設定は永続化され、次回起動時にも反映
+### Internationalization (i18n)
+- Japanese / English UI switching (Edit → Options... → Appearance → Language)
+- Full translation support for menus, toolbar, dialogs, and status bar
 
-### その他
-- WinMerge 風の初期選択ダイアログ（最近のファイル一覧付き）
-- WinMerge 風のオプション設定画面（Edit → Options...）
-- 右クリックコンテキストメニュー（コピー、マージ、ナビゲーション）
-- 未保存変更の確認ダイアログ
-- HTML 差分レポートエクスポート（File → Export HTML Report...）
-- ネイティブメニューバー（macOS / Windows）
-- 設定の永続化（~/.config/winxmerge/settings.json）
-- 大きなファイル向けパフォーマンス最適化
-- GitHub Actions CI（ubuntu / macOS でビルド・テスト・lint）
+### Theme Switching
+- Light / Dark theme switching (Edit → Options... → Appearance)
+- All widgets automatically follow theme via Slint Palette integration
+- Diff colors and syntax highlighting colors optimized per theme
+- Settings persisted across sessions
 
-## 技術スタック
+### Other
+- WinMerge-style initial file selection dialog (with recent files list)
+- WinMerge-style options dialog (Edit → Options...)
+- Right-click context menu (copy, merge, navigation)
+- Unsaved changes confirmation dialog
+- HTML diff report export (File → Export HTML Report...)
+- Native menu bar (macOS / Windows)
+- Settings persistence (~/.config/winxmerge/settings.json)
+- Performance optimizations for large files
+- GitHub Actions CI (build, test, lint on Ubuntu / macOS)
 
-| 項目 | 技術 |
-|------|------|
-| 言語 | Rust 1.94.0 |
-| UI フレームワーク | [Slint](https://slint.dev/) 1.15 |
-| 差分アルゴリズム | [similar](https://crates.io/crates/similar) |
-| シンタックスハイライト | [tree-sitter](https://crates.io/crates/tree-sitter) |
-| ファイルダイアログ | [rfd](https://crates.io/crates/rfd) |
-| エンコーディング検出 | [chardetng](https://crates.io/crates/chardetng) + [encoding_rs](https://crates.io/crates/encoding_rs) |
-| クリップボード | [arboard](https://crates.io/crates/arboard) |
-| 設定永続化 | [serde](https://crates.io/crates/serde) + [serde_json](https://crates.io/crates/serde_json) |
+## Tech Stack
 
-## 環境構築
+| Component | Technology |
+|-----------|-----------|
+| Language | Rust 1.94.0 |
+| UI Framework | [Slint](https://slint.dev/) 1.15 |
+| Diff Algorithm | [similar](https://crates.io/crates/similar) |
+| Syntax Highlighting | [tree-sitter](https://crates.io/crates/tree-sitter) |
+| File Dialog | [rfd](https://crates.io/crates/rfd) |
+| Encoding Detection | [chardetng](https://crates.io/crates/chardetng) + [encoding_rs](https://crates.io/crates/encoding_rs) |
+| Clipboard | [arboard](https://crates.io/crates/arboard) |
+| Settings Persistence | [serde](https://crates.io/crates/serde) + [serde_json](https://crates.io/crates/serde_json) |
 
-### 前提条件
+## Setup
 
-- [asdf](https://asdf-vm.com/) がインストールされていること
-- macOS / Linux / Windows（WSL）
+### Prerequisites
 
-### セットアップ
+- [asdf](https://asdf-vm.com/) installed
+- macOS / Linux / Windows (WSL)
+
+### Getting Started
 
 ```bash
-# リポジトリをクローン
+# Clone the repository
 git clone git@github.com:masak1yu/winxmerge.git
 cd winxmerge
 
-# asdf で Rust をインストール
+# Install Rust via asdf
 asdf plugin add rust
 asdf install
 
-# ビルド
+# Build
 cargo build
 
-# テスト実行
+# Run tests
 cargo test
 
-# アプリ起動
+# Launch the app
 cargo run
 
-# 2-way 比較
+# 2-way comparison
 cargo run -- file1.txt file2.txt
 
-# 3-way マージ
+# 3-way merge
 cargo run -- base.txt left.txt right.txt
 ```
 
-## Git 連携
+## Git Integration
 
-WinXMerge を `git difftool` / `git mergetool` として使用できます。
+WinXMerge can be used as a `git difftool` / `git mergetool`.
 
-### difftool セットアップ
+### difftool Setup
 
 ```bash
 cargo build --release
@@ -154,7 +158,7 @@ git config --global difftool.winxmerge.cmd 'winxmerge "$LOCAL" "$REMOTE"'
 git config --global difftool.prompt false
 ```
 
-### mergetool セットアップ（3-way マージ）
+### mergetool Setup (3-way merge)
 
 ```bash
 git config --global merge.tool winxmerge
@@ -162,77 +166,79 @@ git config --global mergetool.winxmerge.cmd 'winxmerge "$BASE" "$LOCAL" "$REMOTE
 git config --global mergetool.winxmerge.trustExitCode true
 ```
 
-### 使い方
+### Usage
 
 ```bash
-# ワーキングツリーの変更を確認
+# View working tree changes
 git difftool
 
-# 特定のファイルの差分を確認
+# Diff a specific file
 git difftool -- path/to/file.rs
 
-# ブランチ間の差分を確認
+# Diff between branches
 git difftool main..feature-branch
 
-# マージ衝突の解決
+# Resolve merge conflicts
 git mergetool
 ```
 
-## プロジェクト構成
+## Project Structure
 
 ```
 winxmerge/
 ├── Cargo.toml
-├── build.rs                    # Slint コンパイル設定
-├── .tool-versions              # asdf バージョン管理
+├── build.rs                    # Slint build configuration
+├── .tool-versions              # asdf version management
 ├── ui/
-│   ├── main.slint              # メインウィンドウ
-│   ├── theme.slint             # テーマカラー定義（ライト/ダーク対応）
+│   ├── main.slint              # Main window
+│   ├── theme.slint             # Theme color definitions (light/dark)
 │   ├── dialogs/
-│   │   ├── open-dialog.slint   # ファイル/フォルダ選択ダイアログ
-│   │   └── options-dialog.slint # オプション設定ダイアログ
+│   │   ├── open-dialog.slint   # File/folder selection dialog
+│   │   └── options-dialog.slint # Options dialog
 │   └── widgets/
-│       ├── diff-view.slint     # 2-way 差分表示ウィジェット
-│       ├── diff-view-3way.slint # 3-way マージ表示ウィジェット
-│       ├── folder-view.slint   # フォルダ比較ウィジェット
-│       └── tab-bar.slint       # タブバーウィジェット
+│       ├── diff-view.slint     # 2-way diff display widget
+│       ├── diff-view-3way.slint # 3-way merge display widget
+│       ├── folder-view.slint   # Folder comparison widget
+│       └── tab-bar.slint       # Tab bar widget
 ├── src/
-│   ├── main.rs                 # エントリーポイント、CLI 引数処理
-│   ├── app.rs                  # アプリケーション状態管理（タブ対応）
-│   ├── encoding.rs             # エンコーディング検出・変換
-│   ├── export.rs               # HTML レポートエクスポート
-│   ├── highlight.rs            # シンタックスハイライト（10言語対応）
-│   ├── settings.rs             # 設定永続化
+│   ├── main.rs                 # Entry point, CLI argument handling
+│   ├── app.rs                  # Application state management (tab support)
+│   ├── encoding.rs             # Encoding detection and conversion
+│   ├── export.rs               # HTML report export
+│   ├── highlight.rs            # Syntax highlighting (10 languages)
+│   ├── settings.rs             # Settings persistence
 │   ├── diff/
-│   │   ├── engine.rs           # 2-way 差分計算エンジン
-│   │   ├── three_way.rs        # 3-way マージエンジン
-│   │   └── folder.rs           # フォルダ再帰比較
+│   │   ├── engine.rs           # 2-way diff engine
+│   │   ├── three_way.rs        # 3-way merge engine
+│   │   └── folder.rs           # Recursive folder comparison
 │   └── models/
-│       ├── diff_line.rs        # 差分行データモデル
-│       └── folder_item.rs      # フォルダ比較アイテムモデル
-└── testdata/                   # テスト用サンプルファイル
+│       ├── diff_line.rs        # Diff line data model
+│       └── folder_item.rs      # Folder comparison item model
+├── translations/               # Translation files (gettext .po)
+│   └── ja/LC_MESSAGES/         # Japanese translations
+└── testdata/                   # Test sample files
 ```
 
-## 使い方
+## Usage
 
-1. `cargo run` でアプリを起動
-2. 初期画面で左右のファイル/フォルダパスを入力し「Compare」
-   - 3-way マージ: 「3-way merge」をチェックしてベースファイルも指定
-   - 最近のファイル一覧からワンクリックで再オープン
-3. **差分ナビゲーション:** ツールバーの ◀ Prev / Next ▶ または Alt+↓/↑
-4. **マージ:** Copy → / ← Copy ボタン、または差分行間の ▶ / ◀ ボタン
-5. **3-way 衝突解決:** 赤い行の L / R ボタンで左右どちらを採用するか選択
-6. **Undo:** Cmd+Z で操作を元に戻す
-7. **検索:** Cmd+F で検索・置換バーを表示
-8. **タブ:** Cmd+T で新規タブ、複数の比較を並行管理
-9. **オプション:** Edit → Options... で各種設定を変更
+1. Launch the app with `cargo run`
+2. Enter left/right file or folder paths in the initial dialog and click "Compare"
+   - For 3-way merge: check "3-way merge" and specify a base file
+   - Re-open recent files from the list with one click
+3. **Diff navigation:** Use ◀ Prev / Next ▶ toolbar buttons or Alt+↓/↑
+4. **Merge:** Use Copy → / ← Copy buttons, or inline ▶ / ◀ buttons between diff lines
+5. **3-way conflict resolution:** Click L / R buttons on red (conflict) lines to choose left or right
+6. **Undo:** Cmd+Z to undo operations
+7. **Search:** Cmd+F to show the search & replace bar
+8. **Tabs:** Cmd+T for a new tab, manage multiple comparisons in parallel
+9. **Options:** Edit → Options... to configure settings
 
-## ライセンス
+## License
 
-本プロジェクトは [Slint Royalty-Free Desktop, Mobile, and Web Applications License v2.0](https://slint.dev/terms-and-conditions#royalty-free) の下で配布されます。
+This project is distributed under the [Slint Royalty-Free Desktop, Mobile, and Web Applications License v2.0](https://slint.dev/terms-and-conditions#royalty-free).
 
-Slint UI フレームワークを使用しているため、以下の条件が適用されます:
+Since this project uses the Slint UI framework, the following conditions apply:
 
-- デスクトップ / モバイル / Web アプリケーションとしての配布はロイヤリティフリー
-- 組み込みシステムでの使用は対象外
-- Slint の帰属表示（AboutSlint ウィジェットまたは Web バッジ）が必要
+- Distribution as desktop / mobile / web applications is royalty-free
+- Embedded system use is not covered
+- Slint attribution (AboutSlint widget or web badge) is required

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WinXMerge
 
+[![CI](https://github.com/masak1yu/winxmerge/actions/workflows/ci.yml/badge.svg)](https://github.com/masak1yu/winxmerge/actions/workflows/ci.yml)
+
 A cross-platform file diff comparison and merge tool inspired by WinMerge, built with Rust + Slint UI.
 
 ## Features

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
 fn main() {
-    slint_build::compile("ui/main.slint").unwrap();
+    let config =
+        slint_build::CompilerConfiguration::new().with_bundled_translations("translations/");
+    slint_build::compile_with_config("ui/main.slint", config).unwrap();
 }

--- a/handover.md
+++ b/handover.md
@@ -7,8 +7,8 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 
 ## 現在の状態
 
-- **バージョン:** 0.7.0
-- **ブランチ:** `feature/v0.7.0`
+- **バージョン:** 0.8.0
+- **ブランチ:** `feature/v0.8.0`
 - **テスト:** 12件すべてパス
 - **ビルド:** `cargo build` 成功
 - **CI:** GitHub Actions（ubuntu / macOS）
@@ -23,7 +23,8 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 | v0.4.0 | #4 | Git 連携、オプション画面、コンテキストメニュー、HTML エクスポート、スクロール同期、設定永続化 |
 | v0.5.0 | #5 | 3-way マージ UI 統合、オプション実効化、最近のファイル一覧 |
 | v0.6.0 | #6 | フォルダ比較強化（更新日時、.gitignore、フィルタ）、GitHub Actions CI |
-| v0.7.0 | - | テーマ切替（ライト/ダーク）、ThemeColors グローバルによるカラー一元管理 |
+| v0.7.0 | #7 | テーマ切替（ライト/ダーク）、ThemeColors グローバルによるカラー一元管理 |
+| v0.8.0 | - | 国際化 (i18n)：日本語/英語切替、@tr() マクロ、gettext .po ファイル |
 
 ## 実装済み機能一覧
 
@@ -106,6 +107,14 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 | Cmd+W | タブを閉じる |
 | Cmd+N | 新規比較 |
 | Alt+↓/↑ | 次/前の差分 |
+
+### 国際化 (i18n)
+- 日本語 / 英語の UI 切替（オプション画面の Appearance セクション）
+- Slint `@tr()` マクロによる全 UI 文字列の翻訳対応
+- GNU gettext `.po` ファイル形式（`translations/ja/LC_MESSAGES/winxmerge.po`）
+- `slint::select_bundled_translation()` による実行時言語切替
+- メニュー、ツールバー、ダイアログ、ステータスバー、コンテキストメニュー全対応
+- 設定は `~/.config/winxmerge/settings.json` に永続化
 
 ### テーマ切替
 - ライト / ダーク テーマ切替（オプション画面の Appearance セクション）
@@ -199,29 +208,25 @@ AppSettings (永続化)
 
 ---
 
-## 次にやるべき項目 (v0.8.0+)
+## 次にやるべき項目 (v0.9.0+)
 
 ### 優先度高
 
-1. **国際化 (i18n)**
-   - メニュー・ダイアログの日本語/英語切替
-   - Slint の `@tr()` マクロ活用
-
-2. **リリースバイナリの自動ビルド**
+1. **リリースバイナリの自動ビルド**
    - GitHub Actions で macOS / Linux / Windows のクロスコンパイル
    - GitHub Releases への自動アップロード
 
 ### 優先度低
 
-3. **行内（文字レベル）差分**
+2. **行内（文字レベル）差分**
    - `similar` の文字レベル diff で変更位置を計算
    - Slint のリッチテキスト対応を待つか、複数 Text 要素で近似実装
 
-4. **プラグインシステム**
+3. **プラグインシステム**
    - カスタム差分フィルタ（前処理）
    - 外部ツール連携
 
-5. **アクセシビリティ**
+4. **アクセシビリティ**
     - スクリーンリーダー対応
     - キーボードのみでの全操作対応
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -772,6 +772,13 @@ pub fn apply_options(window: &MainWindow, state: &mut AppState, settings: &mut A
     } else {
         "light".to_string()
     };
+    settings.language = if window.get_opt_language() == 1 {
+        "ja".to_string()
+    } else {
+        "en".to_string()
+    };
+    let lang_code = if settings.language == "ja" { "ja" } else { "" };
+    let _ = slint::select_bundled_translation(lang_code);
     settings.save();
 
     // Apply diff options to current tab and re-run

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,10 @@ fn main() {
         let theme_index = if s.theme == "dark" { 1 } else { 0 };
         window.set_opt_theme(theme_index);
         window.invoke_set_theme(theme_index);
+        let lang_index = if s.language == "ja" { 1 } else { 0 };
+        window.set_opt_language(lang_index);
+        let lang_code = if s.language == "ja" { "ja" } else { "" };
+        let _ = slint::select_bundled_translation(lang_code);
         let mut app = state.borrow_mut();
         app.current_tab_mut().diff_options.ignore_whitespace = s.ignore_whitespace;
         app.current_tab_mut().diff_options.ignore_case = s.ignore_case;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -43,6 +43,10 @@ pub struct AppSettings {
     #[serde(default = "default_theme")]
     pub theme: String,
 
+    // Language: "en", "ja"
+    #[serde(default = "default_language")]
+    pub language: String,
+
     #[serde(default)]
     pub recent_files: Vec<RecentEntry>,
 }
@@ -72,6 +76,9 @@ fn default_true() -> bool {
 fn default_theme() -> String {
     "light".to_string()
 }
+fn default_language() -> String {
+    "en".to_string()
+}
 
 impl Default for AppSettings {
     fn default() -> Self {
@@ -91,6 +98,7 @@ impl Default for AppSettings {
             syntax_highlighting: true,
             enable_context_menu: true,
             theme: default_theme(),
+            language: default_language(),
             recent_files: Vec::new(),
         }
     }

--- a/translations/ja/LC_MESSAGES/winxmerge.po
+++ b/translations/ja/LC_MESSAGES/winxmerge.po
@@ -1,0 +1,335 @@
+# Japanese translation for WinXMerge
+# Copyright (C) 2026 WinXMerge
+# This file is distributed under the same license as the winxmerge package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: winxmerge 0.8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-03-17 00:00+0000\n"
+"PO-Revision-Date: 2026-03-17 00:00+0000\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+# ConfirmDialog
+msgid "Discard"
+msgstr "破棄"
+
+msgid "Cancel"
+msgstr "キャンセル"
+
+msgid "You have unsaved changes. Discard and continue?"
+msgstr "未保存の変更があります。破棄して続行しますか？"
+
+# MenuBar - File
+msgid "File"
+msgstr "ファイル"
+
+msgid "New Tab"
+msgstr "新規タブ"
+
+msgid "New Compare..."
+msgstr "新規比較..."
+
+msgid "Open Left File..."
+msgstr "左ファイルを開く..."
+
+msgid "Open Right File..."
+msgstr "右ファイルを開く..."
+
+msgid "Open Left Folder..."
+msgstr "左フォルダを開く..."
+
+msgid "Open Right Folder..."
+msgstr "右フォルダを開く..."
+
+msgid "Save Left"
+msgstr "左を保存"
+
+msgid "Save Right"
+msgstr "右を保存"
+
+msgid "Export HTML Report..."
+msgstr "HTMLレポートをエクスポート..."
+
+# MenuBar - Edit
+msgid "Edit"
+msgstr "編集"
+
+msgid "Undo"
+msgstr "元に戻す"
+
+msgid "Redo"
+msgstr "やり直し"
+
+msgid "Find / Replace..."
+msgstr "検索 / 置換..."
+
+msgid "Options..."
+msgstr "オプション..."
+
+# MenuBar - View
+msgid "View"
+msgstr "表示"
+
+msgid "Hide Toolbar"
+msgstr "ツールバーを隠す"
+
+msgid "Show Toolbar"
+msgstr "ツールバーを表示"
+
+msgid "✓ Ignore Whitespace"
+msgstr "✓ 空白を無視"
+
+msgid "  Ignore Whitespace"
+msgstr "  空白を無視"
+
+msgid "✓ Ignore Case"
+msgstr "✓ 大文字小文字を無視"
+
+msgid "  Ignore Case"
+msgstr "  大文字小文字を無視"
+
+# MenuBar - Merge
+msgid "Merge"
+msgstr "マージ"
+
+msgid "Next Difference"
+msgstr "次の差分"
+
+msgid "Previous Difference"
+msgstr "前の差分"
+
+msgid "Copy Left to Right"
+msgstr "左から右へコピー"
+
+msgid "Copy Right to Left"
+msgstr "右から左へコピー"
+
+# Toolbar
+msgid "New..."
+msgstr "新規..."
+
+msgid "< Back"
+msgstr "< 戻る"
+
+msgid "Open Left..."
+msgstr "左を開く..."
+
+msgid "Open Right..."
+msgstr "右を開く..."
+
+msgid "◀ Prev"
+msgstr "◀ 前へ"
+
+msgid "Next ▶"
+msgstr "次へ ▶"
+
+msgid "Copy →"
+msgstr "コピー →"
+
+msgid "← Copy"
+msgstr "← コピー"
+
+msgid "Ignore WS"
+msgstr "空白無視"
+
+msgid "Ignore Case"
+msgstr "大文字小文字無視"
+
+# Search & Replace
+msgid "Find:"
+msgstr "検索:"
+
+msgid "Search text..."
+msgstr "検索テキスト..."
+
+msgid "Replace:"
+msgstr "置換:"
+
+msgid "Replace with..."
+msgstr "置換テキスト..."
+
+msgid "Replace"
+msgstr "置換"
+
+msgid "Replace All"
+msgstr "すべて置換"
+
+# Status bar
+msgid "Select files or folders to compare"
+msgstr "比較するファイルまたはフォルダを選択してください"
+
+msgid "● Modified"
+msgstr "● 変更あり"
+
+# Default titles
+msgid "Left file"
+msgstr "左ファイル"
+
+msgid "Right file"
+msgstr "右ファイル"
+
+msgid "Left (Mine)"
+msgstr "左 (自分)"
+
+msgid "Base"
+msgstr "ベース"
+
+msgid "Right (Theirs)"
+msgstr "右 (相手)"
+
+# Context menu
+msgid "Context"
+msgstr "コンテキスト"
+
+msgid "Copy to Right →"
+msgstr "右へコピー →"
+
+msgid "← Copy to Left"
+msgstr "← 左へコピー"
+
+msgid "Copy Text"
+msgstr "テキストをコピー"
+
+# Folder view
+msgid "Name"
+msgstr "名前"
+
+msgid "Status"
+msgstr "状態"
+
+msgid "Left Size"
+msgstr "左サイズ"
+
+msgid "Right Size"
+msgstr "右サイズ"
+
+msgid "Left Modified"
+msgstr "左更新日時"
+
+msgid "Right Modified"
+msgstr "右更新日時"
+
+msgid "Identical"
+msgstr "同一"
+
+msgid "Different"
+msgstr "異なる"
+
+msgid "Left only"
+msgstr "左のみ"
+
+msgid "Right only"
+msgstr "右のみ"
+
+# Open dialog
+msgid "Select files or folders to compare"
+msgstr "比較するファイルまたはフォルダを選択してください"
+
+msgid "Folder comparison"
+msgstr "フォルダ比較"
+
+msgid "3-way merge"
+msgstr "3-way マージ"
+
+msgid "Left Folder:"
+msgstr "左フォルダ:"
+
+msgid "Left File:"
+msgstr "左ファイル:"
+
+msgid "Select left folder..."
+msgstr "左フォルダを選択..."
+
+msgid "Select left file..."
+msgstr "左ファイルを選択..."
+
+msgid "Base File (common ancestor):"
+msgstr "ベースファイル (共通の祖先):"
+
+msgid "Select base file..."
+msgstr "ベースファイルを選択..."
+
+msgid "Right Folder:"
+msgstr "右フォルダ:"
+
+msgid "Right File:"
+msgstr "右ファイル:"
+
+msgid "Select right folder..."
+msgstr "右フォルダを選択..."
+
+msgid "Select right file..."
+msgstr "右ファイルを選択..."
+
+msgid "Browse..."
+msgstr "参照..."
+
+msgid "Compare"
+msgstr "比較"
+
+msgid "Recent Comparisons"
+msgstr "最近の比較"
+
+# Options dialog
+msgid "Options"
+msgstr "オプション"
+
+msgid "Appearance"
+msgstr "外観"
+
+msgid "Theme:"
+msgstr "テーマ:"
+
+msgid "Language:"
+msgstr "言語:"
+
+msgid "Compare"
+msgstr "比較"
+
+msgid "Ignore whitespace differences"
+msgstr "空白の違いを無視"
+
+msgid "Ignore case differences"
+msgstr "大文字小文字の違いを無視"
+
+msgid "Ignore blank lines"
+msgstr "空行を無視"
+
+msgid "Ignore line ending differences (CR/LF)"
+msgstr "改行コードの違いを無視 (CR/LF)"
+
+msgid "Detect moved lines"
+msgstr "移動した行を検出"
+
+msgid "Editor"
+msgstr "エディタ"
+
+msgid "Show line numbers"
+msgstr "行番号を表示"
+
+msgid "Word wrap"
+msgstr "折り返し"
+
+msgid "Syntax highlighting"
+msgstr "シンタックスハイライト"
+
+msgid "Enable right-click context menu"
+msgstr "右クリックメニューを有効にする"
+
+msgid "Font size:"
+msgstr "フォントサイズ:"
+
+msgid "Tab width:"
+msgstr "タブ幅:"
+
+msgid "Apply"
+msgstr "適用"
+
+# 3-way merge
+msgid "Resolve"
+msgstr "解決"

--- a/ui/dialogs/open-dialog.slint
+++ b/ui/dialogs/open-dialog.slint
@@ -41,7 +41,7 @@ export component OpenDialog inherits Rectangle {
             }
 
             Text {
-                text: "Select files or folders to compare";
+                text: @tr("Select files or folders to compare");
                 font-size: 14px;
                 horizontal-alignment: center;
                 color: Palette.foreground.transparentize(0.4);
@@ -54,7 +54,7 @@ export component OpenDialog inherits Rectangle {
                 alignment: center;
                 spacing: 16px;
                 CheckBox {
-                    text: "Folder comparison";
+                    text: @tr("Folder comparison");
                     checked: root.is-folder-mode;
                     toggled => {
                         root.is-folder-mode = self.checked;
@@ -62,7 +62,7 @@ export component OpenDialog inherits Rectangle {
                     }
                 }
                 CheckBox {
-                    text: "3-way merge";
+                    text: @tr("3-way merge");
                     checked: root.is-three-way;
                     enabled: !root.is-folder-mode;
                     toggled => { root.is-three-way = self.checked; }
@@ -77,7 +77,7 @@ export component OpenDialog inherits Rectangle {
                 HorizontalLayout {
                     alignment: start;
                     Text {
-                        text: root.is-folder-mode ? "Left Folder:" : "Left File:";
+                        text: root.is-folder-mode ? @tr("Left Folder:") : @tr("Left File:");
                         font-size: 13px;
                         font-weight: 600;
                         vertical-alignment: center;
@@ -88,11 +88,11 @@ export component OpenDialog inherits Rectangle {
                     LineEdit {
                         horizontal-stretch: 1;
                         text: root.left-path-input;
-                        placeholder-text: root.is-folder-mode ? "Select left folder..." : "Select left file...";
+                        placeholder-text: root.is-folder-mode ? @tr("Select left folder...") : @tr("Select left file...");
                         edited(text) => { root.left-path-input = text; }
                     }
                     Button {
-                        text: "Browse...";
+                        text: @tr("Browse...");
                         clicked => { root.browse-left(); }
                     }
                 }
@@ -104,7 +104,7 @@ export component OpenDialog inherits Rectangle {
                 HorizontalLayout {
                     alignment: start;
                     Text {
-                        text: "Base File (common ancestor):";
+                        text: @tr("Base File (common ancestor):");
                         font-size: 13px;
                         font-weight: 600;
                         vertical-alignment: center;
@@ -115,11 +115,11 @@ export component OpenDialog inherits Rectangle {
                     LineEdit {
                         horizontal-stretch: 1;
                         text: root.base-path-input;
-                        placeholder-text: "Select base file...";
+                        placeholder-text: @tr("Select base file...");
                         edited(text) => { root.base-path-input = text; }
                     }
                     Button {
-                        text: "Browse...";
+                        text: @tr("Browse...");
                         clicked => { root.browse-base(); }
                     }
                 }
@@ -131,7 +131,7 @@ export component OpenDialog inherits Rectangle {
                 HorizontalLayout {
                     alignment: start;
                     Text {
-                        text: root.is-folder-mode ? "Right Folder:" : "Right File:";
+                        text: root.is-folder-mode ? @tr("Right Folder:") : @tr("Right File:");
                         font-size: 13px;
                         font-weight: 600;
                         vertical-alignment: center;
@@ -142,11 +142,11 @@ export component OpenDialog inherits Rectangle {
                     LineEdit {
                         horizontal-stretch: 1;
                         text: root.right-path-input;
-                        placeholder-text: root.is-folder-mode ? "Select right folder..." : "Select right file...";
+                        placeholder-text: root.is-folder-mode ? @tr("Select right folder...") : @tr("Select right file...");
                         edited(text) => { root.right-path-input = text; }
                     }
                     Button {
-                        text: "Browse...";
+                        text: @tr("Browse...");
                         clicked => { root.browse-right(); }
                     }
                 }
@@ -158,7 +158,7 @@ export component OpenDialog inherits Rectangle {
             HorizontalLayout {
                 alignment: center;
                 Button {
-                    text: "Compare";
+                    text: @tr("Compare");
                     enabled: root.left-path-input != "" && root.right-path-input != "" && (!root.is-three-way || root.base-path-input != "");
                     clicked => { root.compare(); }
                 }
@@ -171,7 +171,7 @@ export component OpenDialog inherits Rectangle {
                 Rectangle { height: 8px; }
 
                 Text {
-                    text: "Recent Comparisons";
+                    text: @tr("Recent Comparisons");
                     font-size: 13px;
                     font-weight: 600;
                     color: Palette.foreground.transparentize(0.3);

--- a/ui/dialogs/options-dialog.slint
+++ b/ui/dialogs/options-dialog.slint
@@ -21,6 +21,9 @@ export component OptionsDialog inherits Rectangle {
     // Theme: 0=Light, 1=Dark
     in-out property <int> opt-theme: 0;
 
+    // Language: 0=English, 1=Japanese
+    in-out property <int> opt-language: 0;
+
     callback apply();
     callback cancel();
 
@@ -34,7 +37,7 @@ export component OptionsDialog inherits Rectangle {
             x: (parent.width - self.width) / 2;
             y: (parent.height - self.height) / 2;
             width: 500px;
-            height: 540px;
+            height: 580px;
             background: Palette.background;
             border-color: Palette.border;
             border-width: 1px;
@@ -48,7 +51,7 @@ export component OptionsDialog inherits Rectangle {
 
                 // Title
                 Text {
-                    text: "Options";
+                    text: @tr("Options");
                     font-size: 20px;
                     font-weight: 700;
                     horizontal-alignment: center;
@@ -58,7 +61,7 @@ export component OptionsDialog inherits Rectangle {
 
                 // Appearance section
                 Text {
-                    text: "Appearance";
+                    text: @tr("Appearance");
                     font-size: 14px;
                     font-weight: 600;
                     color: Palette.foreground;
@@ -72,7 +75,7 @@ export component OptionsDialog inherits Rectangle {
                     spacing: 8px;
                     alignment: start;
                     Text {
-                        text: "Theme:";
+                        text: @tr("Theme:");
                         font-size: 13px;
                         vertical-alignment: center;
                     }
@@ -84,11 +87,27 @@ export component OptionsDialog inherits Rectangle {
                     }
                 }
 
+                HorizontalLayout {
+                    spacing: 8px;
+                    alignment: start;
+                    Text {
+                        text: @tr("Language:");
+                        font-size: 13px;
+                        vertical-alignment: center;
+                    }
+                    ComboBox {
+                        width: 120px;
+                        model: ["English", "日本語"];
+                        current-index: root.opt-language;
+                        selected(val) => { root.opt-language = self.current-index; }
+                    }
+                }
+
                 Rectangle { height: 8px; }
 
                 // Compare section
                 Text {
-                    text: "Compare";
+                    text: @tr("Compare");
                     font-size: 14px;
                     font-weight: 600;
                     color: Palette.foreground;
@@ -99,27 +118,27 @@ export component OptionsDialog inherits Rectangle {
                 }
 
                 CheckBox {
-                    text: "Ignore whitespace differences";
+                    text: @tr("Ignore whitespace differences");
                     checked: root.opt-ignore-whitespace;
                     toggled => { root.opt-ignore-whitespace = self.checked; }
                 }
                 CheckBox {
-                    text: "Ignore case differences";
+                    text: @tr("Ignore case differences");
                     checked: root.opt-ignore-case;
                     toggled => { root.opt-ignore-case = self.checked; }
                 }
                 CheckBox {
-                    text: "Ignore blank lines";
+                    text: @tr("Ignore blank lines");
                     checked: root.opt-ignore-blank-lines;
                     toggled => { root.opt-ignore-blank-lines = self.checked; }
                 }
                 CheckBox {
-                    text: "Ignore line ending differences (CR/LF)";
+                    text: @tr("Ignore line ending differences (CR/LF)");
                     checked: root.opt-ignore-eol;
                     toggled => { root.opt-ignore-eol = self.checked; }
                 }
                 CheckBox {
-                    text: "Detect moved lines";
+                    text: @tr("Detect moved lines");
                     checked: root.opt-detect-moved-lines;
                     toggled => { root.opt-detect-moved-lines = self.checked; }
                 }
@@ -128,7 +147,7 @@ export component OptionsDialog inherits Rectangle {
 
                 // View section
                 Text {
-                    text: "Editor";
+                    text: @tr("Editor");
                     font-size: 14px;
                     font-weight: 600;
                     color: Palette.foreground;
@@ -139,22 +158,22 @@ export component OptionsDialog inherits Rectangle {
                 }
 
                 CheckBox {
-                    text: "Show line numbers";
+                    text: @tr("Show line numbers");
                     checked: root.opt-show-line-numbers;
                     toggled => { root.opt-show-line-numbers = self.checked; }
                 }
                 CheckBox {
-                    text: "Word wrap";
+                    text: @tr("Word wrap");
                     checked: root.opt-word-wrap;
                     toggled => { root.opt-word-wrap = self.checked; }
                 }
                 CheckBox {
-                    text: "Syntax highlighting";
+                    text: @tr("Syntax highlighting");
                     checked: root.opt-syntax-highlighting;
                     toggled => { root.opt-syntax-highlighting = self.checked; }
                 }
                 CheckBox {
-                    text: "Enable right-click context menu";
+                    text: @tr("Enable right-click context menu");
                     checked: root.opt-enable-context-menu;
                     toggled => { root.opt-enable-context-menu = self.checked; }
                 }
@@ -163,7 +182,7 @@ export component OptionsDialog inherits Rectangle {
                     spacing: 8px;
                     alignment: start;
                     Text {
-                        text: "Font size:";
+                        text: @tr("Font size:");
                         font-size: 13px;
                         vertical-alignment: center;
                     }
@@ -179,7 +198,7 @@ export component OptionsDialog inherits Rectangle {
                     spacing: 8px;
                     alignment: start;
                     Text {
-                        text: "Tab width:";
+                        text: @tr("Tab width:");
                         font-size: 13px;
                         vertical-alignment: center;
                     }
@@ -199,11 +218,11 @@ export component OptionsDialog inherits Rectangle {
                     spacing: 12px;
 
                     Button {
-                        text: "Apply";
+                        text: @tr("Apply");
                         clicked => { root.apply(); }
                     }
                     Button {
-                        text: "Cancel";
+                        text: @tr("Cancel");
                         clicked => { root.cancel(); }
                     }
                 }

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -55,12 +55,12 @@ component ConfirmDialog inherits Rectangle {
                     spacing: 12px;
 
                     Button {
-                        text: "Discard";
+                        text: @tr("Discard");
                         clicked => { root.confirmed(); }
                     }
 
                     Button {
-                        text: "Cancel";
+                        text: @tr("Cancel");
                         clicked => { root.cancelled(); }
                     }
                 }
@@ -81,7 +81,7 @@ export component MainWindow inherits Window {
     in-out property <int> current-diff-index: -1;
     in-out property <string> left-path: "";
     in-out property <string> right-path: "";
-    in-out property <string> status-text: "Select files or folders to compare";
+    in-out property <string> status-text: @tr("Select files or folders to compare");
     in-out property <bool> has-unsaved-changes: false;
     in-out property <bool> show-toolbar: true;
 
@@ -184,6 +184,9 @@ export component MainWindow inherits Window {
     // Theme: 0=Light, 1=Dark
     in-out property <int> opt-theme: 0;
 
+    // Language: 0=English, 1=Japanese
+    in-out property <int> opt-language: 0;
+
     // Apply the color scheme from opt-theme
     public function set-theme(theme-index: int) {
         Palette.color-scheme = theme-index == 1 ? ColorScheme.dark : ColorScheme.light;
@@ -202,57 +205,57 @@ export component MainWindow inherits Window {
 
     MenuBar {
         Menu {
-            title: "File";
-            MenuItem { title: "New Tab"; activated => { root.new-tab(); } }
-            MenuItem { title: "New Compare..."; activated => { root.request-action(5); } }
+            title: @tr("File");
+            MenuItem { title: @tr("New Tab"); activated => { root.new-tab(); } }
+            MenuItem { title: @tr("New Compare..."); activated => { root.request-action(5); } }
             MenuSeparator {}
-            MenuItem { title: "Open Left File..."; activated => { root.request-action(1); } }
-            MenuItem { title: "Open Right File..."; activated => { root.request-action(2); } }
-            MenuItem { title: "Open Left Folder..."; activated => { root.request-action(3); } }
-            MenuItem { title: "Open Right Folder..."; activated => { root.request-action(4); } }
+            MenuItem { title: @tr("Open Left File..."); activated => { root.request-action(1); } }
+            MenuItem { title: @tr("Open Right File..."); activated => { root.request-action(2); } }
+            MenuItem { title: @tr("Open Left Folder..."); activated => { root.request-action(3); } }
+            MenuItem { title: @tr("Open Right Folder..."); activated => { root.request-action(4); } }
             MenuSeparator {}
-            MenuItem { title: "Save Left"; enabled: root.has-unsaved-changes; activated => { root.save-left(); } }
-            MenuItem { title: "Save Right"; enabled: root.has-unsaved-changes; activated => { root.save-right(); } }
+            MenuItem { title: @tr("Save Left"); enabled: root.has-unsaved-changes; activated => { root.save-left(); } }
+            MenuItem { title: @tr("Save Right"); enabled: root.has-unsaved-changes; activated => { root.save-right(); } }
             MenuSeparator {}
-            MenuItem { title: "Export HTML Report..."; enabled: root.diff-count > 0; activated => { root.export-html(); } }
+            MenuItem { title: @tr("Export HTML Report..."); enabled: root.diff-count > 0; activated => { root.export-html(); } }
         }
         Menu {
-            title: "Edit";
-            MenuItem { title: "Undo"; enabled: root.can-undo; activated => { root.undo(); } }
-            MenuItem { title: "Redo"; enabled: root.can-redo; activated => { root.redo(); } }
+            title: @tr("Edit");
+            MenuItem { title: @tr("Undo"); enabled: root.can-undo; activated => { root.undo(); } }
+            MenuItem { title: @tr("Redo"); enabled: root.can-redo; activated => { root.redo(); } }
             MenuSeparator {}
             MenuItem {
-                title: "Find / Replace...";
+                title: @tr("Find / Replace...");
                 activated => { root.show-search = !root.show-search; }
             }
             MenuSeparator {}
             MenuItem {
-                title: "Options...";
+                title: @tr("Options...");
                 activated => { root.show-options-dialog = true; }
             }
         }
         Menu {
-            title: "View";
+            title: @tr("View");
             MenuItem {
-                title: root.show-toolbar ? "Hide Toolbar" : "Show Toolbar";
+                title: root.show-toolbar ? @tr("Hide Toolbar") : @tr("Show Toolbar");
                 activated => { root.show-toolbar = !root.show-toolbar; }
             }
             MenuItem {
-                title: root.ignore-whitespace ? "✓ Ignore Whitespace" : "  Ignore Whitespace";
+                title: root.ignore-whitespace ? @tr("✓ Ignore Whitespace") : @tr("  Ignore Whitespace");
                 activated => { root.toggle-ignore-whitespace(); }
             }
             MenuItem {
-                title: root.ignore-case ? "✓ Ignore Case" : "  Ignore Case";
+                title: root.ignore-case ? @tr("✓ Ignore Case") : @tr("  Ignore Case");
                 activated => { root.toggle-ignore-case(); }
             }
         }
         Menu {
-            title: "Merge";
-            MenuItem { title: "Next Difference"; enabled: root.diff-count > 0; activated => { root.next-diff(); } }
-            MenuItem { title: "Previous Difference"; enabled: root.diff-count > 0; activated => { root.prev-diff(); } }
+            title: @tr("Merge");
+            MenuItem { title: @tr("Next Difference"); enabled: root.diff-count > 0; activated => { root.next-diff(); } }
+            MenuItem { title: @tr("Previous Difference"); enabled: root.diff-count > 0; activated => { root.prev-diff(); } }
             MenuSeparator {}
-            MenuItem { title: "Copy Left to Right"; enabled: root.current-diff-index >= 0; activated => { root.copy-to-right(root.current-diff-index); } }
-            MenuItem { title: "Copy Right to Left"; enabled: root.current-diff-index >= 0; activated => { root.copy-to-left(root.current-diff-index); } }
+            MenuItem { title: @tr("Copy Left to Right"); enabled: root.current-diff-index >= 0; activated => { root.copy-to-right(root.current-diff-index); } }
+            MenuItem { title: @tr("Copy Right to Left"); enabled: root.current-diff-index >= 0; activated => { root.copy-to-left(root.current-diff-index); } }
         }
     }
 
@@ -279,37 +282,37 @@ export component MainWindow inherits Window {
                 alignment: start;
 
                 Button {
-                    text: "New...";
+                    text: @tr("New...");
                     clicked => { root.request-action(5); }
                 }
 
                 Rectangle { width: 4px; }
 
                 if root.view-mode == 0 && root.has-folder-context : Button {
-                    text: "< Back";
+                    text: @tr("< Back");
                     clicked => { root.back-to-folder-view(); }
                 }
 
                 Button {
-                    text: "Open Left...";
+                    text: @tr("Open Left...");
                     clicked => { root.request-action(1); }
                 }
 
                 Button {
-                    text: "Open Right...";
+                    text: @tr("Open Right...");
                     clicked => { root.request-action(2); }
                 }
 
                 Rectangle { width: 8px; }
 
                 if root.view-mode == 0 : Button {
-                    text: "Save Left";
+                    text: @tr("Save Left");
                     enabled: has-unsaved-changes;
                     clicked => { root.save-left(); }
                 }
 
                 if root.view-mode == 0 : Button {
-                    text: "Save Right";
+                    text: @tr("Save Right");
                     enabled: has-unsaved-changes;
                     clicked => { root.save-right(); }
                 }
@@ -317,13 +320,13 @@ export component MainWindow inherits Window {
                 if root.view-mode == 0 : Rectangle { width: 8px; }
 
                 if root.view-mode == 0 : Button {
-                    text: "◀ Prev";
+                    text: @tr("◀ Prev");
                     enabled: diff-count > 0;
                     clicked => { root.prev-diff(); }
                 }
 
                 if root.view-mode == 0 : Button {
-                    text: "Next ▶";
+                    text: @tr("Next ▶");
                     enabled: diff-count > 0;
                     clicked => { root.next-diff(); }
                 }
@@ -331,13 +334,13 @@ export component MainWindow inherits Window {
                 if root.view-mode == 0 : Rectangle { width: 8px; }
 
                 if root.view-mode == 0 : Button {
-                    text: "Copy →";
+                    text: @tr("Copy →");
                     enabled: current-diff-index >= 0;
                     clicked => { root.copy-to-right(root.current-diff-index); }
                 }
 
                 if root.view-mode == 0 : Button {
-                    text: "← Copy";
+                    text: @tr("← Copy");
                     enabled: current-diff-index >= 0;
                     clicked => { root.copy-to-left(root.current-diff-index); }
                 }
@@ -345,13 +348,13 @@ export component MainWindow inherits Window {
                 Rectangle { width: 8px; }
 
                 CheckBox {
-                    text: "Ignore WS";
+                    text: @tr("Ignore WS");
                     checked: root.ignore-whitespace;
                     toggled => { root.toggle-ignore-whitespace(); }
                 }
 
                 CheckBox {
-                    text: "Ignore Case";
+                    text: @tr("Ignore Case");
                     checked: root.ignore-case;
                     toggled => { root.toggle-ignore-case(); }
                 }
@@ -376,7 +379,7 @@ export component MainWindow inherits Window {
 
                     Text {
                         width: 60px;
-                        text: "Find:";
+                        text: @tr("Find:");
                         font-size: 12px;
                         vertical-alignment: center;
                         horizontal-alignment: right;
@@ -385,7 +388,7 @@ export component MainWindow inherits Window {
                     search-input := LineEdit {
                         width: 250px;
                         text: root.search-query;
-                        placeholder-text: "Search text...";
+                        placeholder-text: @tr("Search text...");
                         accepted(text) => {
                             root.search-query = text;
                             root.search(text);
@@ -434,7 +437,7 @@ export component MainWindow inherits Window {
 
                     Text {
                         width: 60px;
-                        text: "Replace:";
+                        text: @tr("Replace:");
                         font-size: 12px;
                         vertical-alignment: center;
                         horizontal-alignment: right;
@@ -442,17 +445,17 @@ export component MainWindow inherits Window {
 
                     replace-input := LineEdit {
                         width: 250px;
-                        placeholder-text: "Replace with...";
+                        placeholder-text: @tr("Replace with...");
                     }
 
                     Button {
-                        text: "Replace";
+                        text: @tr("Replace");
                         enabled: search-match-count > 0;
                         clicked => { root.replace(root.search-query, replace-input.text); }
                     }
 
                     Button {
-                        text: "Replace All";
+                        text: @tr("Replace All");
                         enabled: search-match-count > 0;
                         clicked => { root.replace-all(root.search-query, replace-input.text); }
                     }
@@ -492,8 +495,8 @@ export component MainWindow inherits Window {
         if root.view-mode == 0 : DiffView {
             diff-lines: root.diff-lines;
             current-diff-index: root.current-diff-index;
-            left-title: root.left-path != "" ? root.left-path : "Left file";
-            right-title: root.right-path != "" ? root.right-path : "Right file";
+            left-title: root.left-path != "" ? root.left-path : @tr("Left file");
+            right-title: root.right-path != "" ? root.right-path : @tr("Right file");
             context-menu-enabled: root.opt-enable-context-menu;
             show-line-numbers: root.opt-show-line-numbers;
             editor-font-size: root.opt-font-size;
@@ -516,9 +519,9 @@ export component MainWindow inherits Window {
         if root.view-mode == 3 : DiffView3Way {
             lines: root.three-way-lines;
             current-conflict-index: root.current-conflict-index;
-            left-title: root.left-path != "" ? root.left-path : "Left (Mine)";
-            base-title: root.base-path != "" ? root.base-path : "Base";
-            right-title: root.right-path != "" ? root.right-path : "Right (Theirs)";
+            left-title: root.left-path != "" ? root.left-path : @tr("Left (Mine)");
+            base-title: root.base-path != "" ? root.base-path : @tr("Base");
+            right-title: root.right-path != "" ? root.right-path : @tr("Right (Theirs)");
             show-line-numbers: root.opt-show-line-numbers;
             editor-font-size: root.opt-font-size;
             next-conflict => { root.next-conflict(); }
@@ -545,7 +548,7 @@ export component MainWindow inherits Window {
                 }
 
                 Text {
-                    text: root.has-unsaved-changes ? "● Modified" : "";
+                    text: root.has-unsaved-changes ? @tr("● Modified") : "";
                     font-size: 12px;
                     color: #b08800;
                     vertical-alignment: center;
@@ -622,6 +625,7 @@ export component MainWindow inherits Window {
         opt-tab-width <=> root.opt-tab-width;
         opt-enable-context-menu <=> root.opt-enable-context-menu;
         opt-theme <=> root.opt-theme;
+        opt-language <=> root.opt-language;
         apply => {
             root.show-options-dialog = false;
             root.set-theme(root.opt-theme);
@@ -637,7 +641,7 @@ export component MainWindow inherits Window {
         width: 100%;
         height: 100%;
         visible-flag: root.show-confirm-dialog;
-        message: "You have unsaved changes. Discard and continue?";
+        message: @tr("You have unsaved changes. Discard and continue?");
         confirmed => {
             root.show-confirm-dialog = false;
             root.has-unsaved-changes = false;

--- a/ui/widgets/diff-view-3way.slint
+++ b/ui/widgets/diff-view-3way.slint
@@ -138,7 +138,7 @@ export component DiffView3Way inherits Rectangle {
                 border-color: Palette.border;
                 border-width: 1px;
                 Text {
-                    text: "Resolve";
+                    text: @tr("Resolve");
                     font-size: 11px;
                     font-weight: 600;
                     horizontal-alignment: center;

--- a/ui/widgets/diff-view.slint
+++ b/ui/widgets/diff-view.slint
@@ -199,14 +199,14 @@ export component DiffView inherits Rectangle {
             Rectangle {
                 if root.context-menu-enabled : ContextMenuArea {
                     Menu {
-                        title: "Context";
-                        MenuItem { title: "Copy to Right →"; enabled: root.current-diff-index >= 0; activated => { root.copy-to-right(root.current-diff-index); } }
-                        MenuItem { title: "← Copy to Left"; enabled: root.current-diff-index >= 0; activated => { root.copy-to-left(root.current-diff-index); } }
+                        title: @tr("Context");
+                        MenuItem { title: @tr("Copy to Right →"); enabled: root.current-diff-index >= 0; activated => { root.copy-to-right(root.current-diff-index); } }
+                        MenuItem { title: @tr("← Copy to Left"); enabled: root.current-diff-index >= 0; activated => { root.copy-to-left(root.current-diff-index); } }
                         MenuSeparator {}
-                        MenuItem { title: "Copy Text"; activated => { root.copy-left-text(); } }
+                        MenuItem { title: @tr("Copy Text"); activated => { root.copy-left-text(); } }
                         MenuSeparator {}
-                        MenuItem { title: "Next Difference"; activated => { root.next-diff(); } }
-                        MenuItem { title: "Previous Difference"; activated => { root.prev-diff(); } }
+                        MenuItem { title: @tr("Next Difference"); activated => { root.next-diff(); } }
+                        MenuItem { title: @tr("Previous Difference"); activated => { root.prev-diff(); } }
                     }
                 }
 
@@ -285,14 +285,14 @@ export component DiffView inherits Rectangle {
             Rectangle {
                 if root.context-menu-enabled : ContextMenuArea {
                     Menu {
-                        title: "Context";
-                        MenuItem { title: "← Copy to Left"; enabled: root.current-diff-index >= 0; activated => { root.copy-to-left(root.current-diff-index); } }
-                        MenuItem { title: "Copy to Right →"; enabled: root.current-diff-index >= 0; activated => { root.copy-to-right(root.current-diff-index); } }
+                        title: @tr("Context");
+                        MenuItem { title: @tr("← Copy to Left"); enabled: root.current-diff-index >= 0; activated => { root.copy-to-left(root.current-diff-index); } }
+                        MenuItem { title: @tr("Copy to Right →"); enabled: root.current-diff-index >= 0; activated => { root.copy-to-right(root.current-diff-index); } }
                         MenuSeparator {}
-                        MenuItem { title: "Copy Text"; activated => { root.copy-right-text(); } }
+                        MenuItem { title: @tr("Copy Text"); activated => { root.copy-right-text(); } }
                         MenuSeparator {}
-                        MenuItem { title: "Next Difference"; activated => { root.next-diff(); } }
-                        MenuItem { title: "Previous Difference"; activated => { root.prev-diff(); } }
+                        MenuItem { title: @tr("Next Difference"); activated => { root.next-diff(); } }
+                        MenuItem { title: @tr("Previous Difference"); activated => { root.prev-diff(); } }
                     }
                 }
 

--- a/ui/widgets/folder-view.slint
+++ b/ui/widgets/folder-view.slint
@@ -56,10 +56,10 @@ component FolderItemRow inherits Rectangle {
         // Status
         Text {
             width: 80px;
-            text: item.status == 0 ? "Identical" :
-                  item.status == 1 ? "Different" :
-                  item.status == 2 ? "Left only" :
-                  "Right only";
+            text: item.status == 0 ? @tr("Identical") :
+                  item.status == 1 ? @tr("Different") :
+                  item.status == 2 ? @tr("Left only") :
+                  @tr("Right only");
             font-size: 11px;
             color: item.status == 0 ? Palette.foreground.transparentize(0.5) :
                    item.status == 2 ? ThemeColors.removed-fg :
@@ -137,14 +137,14 @@ export component FolderView inherits Rectangle {
 
                 Text {
                     horizontal-stretch: 1;
-                    text: "Name";
+                    text: @tr("Name");
                     font-size: 12px;
                     font-weight: 600;
                     vertical-alignment: center;
                 }
                 Text {
                     width: 80px;
-                    text: "Status";
+                    text: @tr("Status");
                     font-size: 12px;
                     font-weight: 600;
                     vertical-alignment: center;
@@ -152,7 +152,7 @@ export component FolderView inherits Rectangle {
                 }
                 Text {
                     width: 70px;
-                    text: "Left Size";
+                    text: @tr("Left Size");
                     font-size: 12px;
                     font-weight: 600;
                     horizontal-alignment: right;
@@ -160,7 +160,7 @@ export component FolderView inherits Rectangle {
                 }
                 Text {
                     width: 70px;
-                    text: "Right Size";
+                    text: @tr("Right Size");
                     font-size: 12px;
                     font-weight: 600;
                     horizontal-alignment: right;
@@ -168,7 +168,7 @@ export component FolderView inherits Rectangle {
                 }
                 Text {
                     width: 110px;
-                    text: "Left Modified";
+                    text: @tr("Left Modified");
                     font-size: 12px;
                     font-weight: 600;
                     horizontal-alignment: center;
@@ -176,7 +176,7 @@ export component FolderView inherits Rectangle {
                 }
                 Text {
                     width: 110px;
-                    text: "Right Modified";
+                    text: @tr("Right Modified");
                     font-size: 12px;
                     font-weight: 600;
                     horizontal-alignment: center;


### PR DESCRIPTION
## Summary
- Add Japanese/English UI switching via Slint `@tr()` macro and GNU gettext `.po` translation files
- All UI strings (menus, toolbar, dialogs, status bar, context menus) are fully translatable
- Language selection in Options → Appearance, persisted in `settings.json`
- Runtime language switching via `slint::select_bundled_translation()`
- README.md rewritten entirely in English

## Test plan
- [ ] `cargo build` succeeds
- [ ] `cargo test` passes all 12 tests
- [ ] App launches with default English UI
- [ ] Switching to Japanese in Options → Appearance → Language updates all UI strings
- [ ] Language setting persists across app restarts
- [ ] README displays correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)