### PR TITLE
v0.10.0: Line filters and substitution filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6167,12 +6167,13 @@ dependencies = [
 
 [[package]]
 name = "winxmerge"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "arboard",
  "chardetng",
  "dirs",
  "encoding_rs",
+ "regex",
  "rfd",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winxmerge"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 
 [dependencies]
@@ -12,6 +12,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"
 arboard = "3"
+regex = "1"
 chardetng = "0.1"
 tree-sitter = "0.26"
 tree-sitter-highlight = "0.26"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ A cross-platform file diff comparison and merge tool inspired by WinMerge, built
 - Ignore line ending differences
 - Toggle moved line detection
 
+### Filters
+- **Line filters**: Exclude lines matching regex patterns from comparison (e.g., comments, timestamps)
+- **Substitution filters**: Apply regex find/replace before comparison (e.g., normalize dates, version numbers)
+- Configured via Edit → Options... → Filters
+- Settings persisted across sessions
+
 ### Encoding
 - Automatic character encoding detection (UTF-8, UTF-16, Shift_JIS, etc.)
 - BOM support

--- a/handover.md
+++ b/handover.md
@@ -7,9 +7,9 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 
 ## 現在の状態
 
-- **バージョン:** 0.9.0
-- **ブランチ:** `feature/v0.9.0`
-- **テスト:** 12件すべてパス
+- **バージョン:** 0.10.0
+- **ブランチ:** `feature/v0.10.0`
+- **テスト:** 16件すべてパス
 - **ビルド:** `cargo build` 成功
 - **CI:** GitHub Actions（ubuntu / macOS）
 
@@ -25,7 +25,8 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 | v0.6.0 | #6 | フォルダ比較強化（更新日時、.gitignore、フィルタ）、GitHub Actions CI |
 | v0.7.0 | #7 | テーマ切替（ライト/ダーク）、ThemeColors グローバルによるカラー一元管理 |
 | v0.8.0 | #8 | 国際化 (i18n)：日本語/英語切替、@tr() マクロ、gettext .po ファイル |
-| v0.9.0 | - | First/Last diff、Go to Line、ブックマーク、フォルダ操作、リリースCI、Windows CI |
+| v0.9.0 | #9 | First/Last diff、Go to Line、ブックマーク、フォルダ操作、リリースCI、Windows CI |
+| v0.10.0 | - | 行フィルタ、置換フィルタ（正規表現）、オプション画面拡張 |
 
 ## 実装済み機能一覧
 
@@ -110,6 +111,13 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 - GitHub Actions でタグ push 時に自動ビルド
 - Linux (x86_64), macOS (x86_64 + aarch64), Windows (x86_64)
 - GitHub Releases への自動アップロード
+
+### 行フィルタ / 置換フィルタ
+- 行フィルタ: 正規表現でマッチする行を比較から除外（`|` 区切りで複数指定可）
+- 置換フィルタ: 正規表現で比較前にテキスト置換（タイムスタンプ、バージョン番号等の無視に有用）
+- オプション画面の Filters セクションで設定
+- `regex` クレート使用、無効な正規表現は安全にスキップ
+- 設定は `settings.json` に永続化
 
 ### CI 拡張
 - Windows をビルド・テストマトリクスに追加
@@ -230,25 +238,21 @@ AppSettings (永続化)
 
 ---
 
-## 次にやるべき項目 (v0.10.0+)
+## 次にやるべき項目 (v0.11.0+)
 
 ### 優先度高
 
-1. **行フィルタ / 置換フィルタ**
-   - 正規表現で特定行を比較から除外
-   - 比較前の文字列置換（タイムスタンプ等を無視）
-
-2. **ワードレベル差分**
+1. **ワードレベル差分**
    - `similar` の文字レベル diff で変更位置を計算
    - Slint のリッチテキスト対応を待つか、複数 Text 要素で近似実装
 
 ### 優先度低
 
-3. **プラグインシステム**
+2. **プラグインシステム**
    - カスタム差分フィルタ（前処理）
    - 外部ツール連携
 
-4. **アクセシビリティ**
+3. **アクセシビリティ**
     - スクリーンリーダー対応
     - キーボードのみでの全操作対応
 
@@ -257,7 +261,7 @@ AppSettings (永続化)
 ```bash
 asdf install                             # Rust 1.94.0 をインストール
 cargo build                              # ビルド
-cargo test                               # 12件のテスト実行
+cargo test                               # 16件のテスト実行
 cargo run                                # アプリ起動（選択ダイアログ）
 cargo run -- file1.txt file2.txt         # 2-way 比較
 cargo run -- base.txt left.txt right.txt # 3-way マージ

--- a/src/app.rs
+++ b/src/app.rs
@@ -894,6 +894,28 @@ pub fn apply_options(window: &MainWindow, state: &mut AppState, settings: &mut A
     };
     let lang_code = if settings.language == "ja" { "ja" } else { "" };
     let _ = slint::select_bundled_translation(lang_code);
+
+    // Read filter settings
+    let line_filters_str = window.get_opt_line_filters().to_string();
+    settings.line_filters = line_filters_str
+        .split('|')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    let sub_patterns_str = window.get_opt_substitution_patterns().to_string();
+    let sub_replacements_str = window.get_opt_substitution_replacements().to_string();
+    let patterns: Vec<&str> = sub_patterns_str.split('|').collect();
+    let replacements: Vec<&str> = sub_replacements_str.split('|').collect();
+    settings.substitution_filters = patterns
+        .iter()
+        .zip(replacements.iter())
+        .filter(|(p, _)| !p.trim().is_empty())
+        .map(|(p, r)| crate::settings::SubstitutionFilter {
+            pattern: p.trim().to_string(),
+            replacement: r.trim().to_string(),
+        })
+        .collect();
+
     settings.save();
 
     // Apply diff options to current tab and re-run
@@ -903,6 +925,12 @@ pub fn apply_options(window: &MainWindow, state: &mut AppState, settings: &mut A
     tab.diff_options.ignore_blank_lines = settings.ignore_blank_lines;
     tab.diff_options.ignore_eol = settings.ignore_eol;
     tab.diff_options.detect_moved_lines = settings.detect_moved_lines;
+    tab.diff_options.line_filters = settings.line_filters.clone();
+    tab.diff_options.substitution_filters = settings
+        .substitution_filters
+        .iter()
+        .map(|f| (f.pattern.clone(), f.replacement.clone()))
+        .collect();
 
     if tab.left_path.is_some() && tab.right_path.is_some() {
         run_diff(window, state);

--- a/src/diff/engine.rs
+++ b/src/diff/engine.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use regex::Regex;
 use similar::{Algorithm, ChangeTag, TextDiff};
 
 use crate::models::diff_line::{DiffLine, DiffResult, LineStatus};
@@ -16,6 +17,10 @@ pub struct DiffOptions {
     pub ignore_blank_lines: bool,
     pub ignore_eol: bool,
     pub detect_moved_lines: bool,
+    /// Line filter: regex patterns to exclude matching lines from comparison
+    pub line_filters: Vec<String>,
+    /// Substitution filters: (pattern, replacement) pairs applied before comparison
+    pub substitution_filters: Vec<(String, String)>,
 }
 
 impl Default for DiffOptions {
@@ -26,6 +31,8 @@ impl Default for DiffOptions {
             ignore_blank_lines: false,
             ignore_eol: false,
             detect_moved_lines: true,
+            line_filters: Vec::new(),
+            substitution_filters: Vec::new(),
         }
     }
 }
@@ -196,7 +203,36 @@ fn detect_moved_lines(lines: &mut [DiffLine]) {
     }
 }
 
+fn compile_line_filters(patterns: &[String]) -> Vec<Regex> {
+    patterns
+        .iter()
+        .filter_map(|p| {
+            if p.trim().is_empty() {
+                None
+            } else {
+                Regex::new(p).ok()
+            }
+        })
+        .collect()
+}
+
+fn compile_substitution_filters(filters: &[(String, String)]) -> Vec<(Regex, String)> {
+    filters
+        .iter()
+        .filter_map(|(p, r)| {
+            if p.trim().is_empty() {
+                None
+            } else {
+                Regex::new(p).ok().map(|re| (re, r.clone()))
+            }
+        })
+        .collect()
+}
+
 fn normalize_text(text: &str, options: &DiffOptions) -> String {
+    let line_filters = compile_line_filters(&options.line_filters);
+    let sub_filters = compile_substitution_filters(&options.substitution_filters);
+
     let mut result = String::with_capacity(text.len());
     for line in text.lines() {
         let mut l = if options.ignore_eol {
@@ -206,6 +242,14 @@ fn normalize_text(text: &str, options: &DiffOptions) -> String {
         };
         if options.ignore_blank_lines && l.trim().is_empty() {
             continue;
+        }
+        // Line filter: skip lines matching any filter pattern
+        if line_filters.iter().any(|re| re.is_match(&l)) {
+            continue;
+        }
+        // Substitution filters: apply regex replacements
+        for (re, replacement) in &sub_filters {
+            l = re.replace_all(&l, replacement.as_str()).to_string();
         }
         if options.ignore_whitespace {
             l = l.split_whitespace().collect::<Vec<&str>>().join(" ");
@@ -306,5 +350,49 @@ mod tests {
         };
         let result = compute_diff_with_options("Hello   World\n", "hello world\n", &opts);
         assert_eq!(result.diff_count, 0);
+    }
+
+    #[test]
+    fn test_line_filter() {
+        let opts = DiffOptions {
+            line_filters: vec![r"^//.*".to_string()],
+            ..Default::default()
+        };
+        let left = "code\n// comment v1\n";
+        let right = "code\n// comment v2\n";
+        let result = compute_diff_with_options(left, right, &opts);
+        assert_eq!(result.diff_count, 0, "Comment lines should be filtered out");
+    }
+
+    #[test]
+    fn test_substitution_filter() {
+        let opts = DiffOptions {
+            substitution_filters: vec![(r"\d{4}-\d{2}-\d{2}".to_string(), "DATE".to_string())],
+            ..Default::default()
+        };
+        let left = "created: 2024-01-01\n";
+        let right = "created: 2025-06-15\n";
+        let result = compute_diff_with_options(left, right, &opts);
+        assert_eq!(result.diff_count, 0, "Date differences should be ignored");
+    }
+
+    #[test]
+    fn test_line_filter_empty_pattern() {
+        let opts = DiffOptions {
+            line_filters: vec!["".to_string(), "  ".to_string()],
+            ..Default::default()
+        };
+        let result = compute_diff_with_options("hello\n", "world\n", &opts);
+        assert_eq!(result.diff_count, 1, "Empty filters should be ignored");
+    }
+
+    #[test]
+    fn test_substitution_filter_invalid_regex() {
+        let opts = DiffOptions {
+            substitution_filters: vec![("[invalid".to_string(), "x".to_string())],
+            ..Default::default()
+        };
+        let result = compute_diff_with_options("hello\n", "hello\n", &opts);
+        assert_eq!(result.diff_count, 0, "Invalid regex should be skipped");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,9 +52,31 @@ fn main() {
         window.set_opt_language(lang_index);
         let lang_code = if s.language == "ja" { "ja" } else { "" };
         let _ = slint::select_bundled_translation(lang_code);
+        // Load filter settings into UI
+        window.set_opt_line_filters(SharedString::from(s.line_filters.join("|")));
+        let sub_patterns: Vec<&str> = s
+            .substitution_filters
+            .iter()
+            .map(|f| f.pattern.as_str())
+            .collect();
+        let sub_replacements: Vec<&str> = s
+            .substitution_filters
+            .iter()
+            .map(|f| f.replacement.as_str())
+            .collect();
+        window.set_opt_substitution_patterns(SharedString::from(sub_patterns.join("|")));
+        window.set_opt_substitution_replacements(SharedString::from(sub_replacements.join("|")));
+
         let mut app = state.borrow_mut();
-        app.current_tab_mut().diff_options.ignore_whitespace = s.ignore_whitespace;
-        app.current_tab_mut().diff_options.ignore_case = s.ignore_case;
+        let tab = app.current_tab_mut();
+        tab.diff_options.ignore_whitespace = s.ignore_whitespace;
+        tab.diff_options.ignore_case = s.ignore_case;
+        tab.diff_options.line_filters = s.line_filters.clone();
+        tab.diff_options.substitution_filters = s
+            .substitution_filters
+            .iter()
+            .map(|f| (f.pattern.clone(), f.replacement.clone()))
+            .collect();
     }
 
     // Load recent entries into UI

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -47,8 +47,20 @@ pub struct AppSettings {
     #[serde(default = "default_language")]
     pub language: String,
 
+    // Filters
+    #[serde(default)]
+    pub line_filters: Vec<String>,
+    #[serde(default)]
+    pub substitution_filters: Vec<SubstitutionFilter>,
+
     #[serde(default)]
     pub recent_files: Vec<RecentEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubstitutionFilter {
+    pub pattern: String,
+    pub replacement: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -99,6 +111,8 @@ impl Default for AppSettings {
             enable_context_menu: true,
             theme: default_theme(),
             language: default_language(),
+            line_filters: Vec::new(),
+            substitution_filters: Vec::new(),
             recent_files: Vec::new(),
         }
     }

--- a/translations/ja/LC_MESSAGES/winxmerge.po
+++ b/translations/ja/LC_MESSAGES/winxmerge.po
@@ -378,3 +378,22 @@ msgstr "開く"
 
 msgid "Delete"
 msgstr "削除"
+
+# Filters
+msgid "Filters"
+msgstr "フィルタ"
+
+msgid "Line filters (regex, one per line — matching lines are excluded):"
+msgstr "行フィルタ (正規表現、| 区切り — マッチする行を除外):"
+
+msgid "e.g. ^//.*|^#.*"
+msgstr "例: ^//.*|^#.*"
+
+msgid "Substitution filters (regex → replacement, applied before comparison):"
+msgstr "置換フィルタ (正規表現 → 置換文字列、比較前に適用):"
+
+msgid "Pattern regex"
+msgstr "パターン (正規表現)"
+
+msgid "Replacement text"
+msgstr "置換文字列"

--- a/ui/dialogs/options-dialog.slint
+++ b/ui/dialogs/options-dialog.slint
@@ -1,4 +1,4 @@
-import { Button, CheckBox, SpinBox, ComboBox, Palette } from "std-widgets.slint";
+import { Button, CheckBox, SpinBox, ComboBox, Palette, LineEdit, ScrollView } from "std-widgets.slint";
 
 export component OptionsDialog inherits Rectangle {
     in-out property <bool> visible-flag: false;
@@ -24,6 +24,11 @@ export component OptionsDialog inherits Rectangle {
     // Language: 0=English, 1=Japanese
     in-out property <int> opt-language: 0;
 
+    // Filters (newline-separated)
+    in-out property <string> opt-line-filters: "";
+    in-out property <string> opt-substitution-patterns: "";
+    in-out property <string> opt-substitution-replacements: "";
+
     callback apply();
     callback cancel();
 
@@ -37,7 +42,7 @@ export component OptionsDialog inherits Rectangle {
             x: (parent.width - self.width) / 2;
             y: (parent.height - self.height) / 2;
             width: 500px;
-            height: 580px;
+            height: 700px;
             background: Palette.background;
             border-color: Palette.border;
             border-width: 1px;
@@ -141,6 +146,56 @@ export component OptionsDialog inherits Rectangle {
                     text: @tr("Detect moved lines");
                     checked: root.opt-detect-moved-lines;
                     toggled => { root.opt-detect-moved-lines = self.checked; }
+                }
+
+                Rectangle { height: 8px; }
+
+                // Filters section
+                Text {
+                    text: @tr("Filters");
+                    font-size: 14px;
+                    font-weight: 600;
+                    color: Palette.foreground;
+                }
+                Rectangle {
+                    height: 1px;
+                    background: Palette.border;
+                }
+
+                Text {
+                    text: @tr("Line filters (regex, one per line — matching lines are excluded):");
+                    font-size: 12px;
+                    color: Palette.foreground.transparentize(0.3);
+                    wrap: word-wrap;
+                }
+                LineEdit {
+                    text <=> root.opt-line-filters;
+                    placeholder-text: @tr("e.g. ^//.*|^#.*");
+                }
+
+                Text {
+                    text: @tr("Substitution filters (regex → replacement, applied before comparison):");
+                    font-size: 12px;
+                    color: Palette.foreground.transparentize(0.3);
+                    wrap: word-wrap;
+                }
+                HorizontalLayout {
+                    spacing: 4px;
+                    LineEdit {
+                        text <=> root.opt-substitution-patterns;
+                        placeholder-text: @tr("Pattern regex");
+                        horizontal-stretch: 1;
+                    }
+                    Text {
+                        text: "→";
+                        font-size: 13px;
+                        vertical-alignment: center;
+                    }
+                    LineEdit {
+                        text <=> root.opt-substitution-replacements;
+                        placeholder-text: @tr("Replacement text");
+                        horizontal-stretch: 1;
+                    }
                 }
 
                 Rectangle { height: 8px; }

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -198,6 +198,11 @@ export component MainWindow inherits Window {
     in-out property <int> opt-tab-width: 4;
     in-out property <bool> opt-enable-context-menu: true;
 
+    // Filters
+    in-out property <string> opt-line-filters: "";
+    in-out property <string> opt-substitution-patterns: "";
+    in-out property <string> opt-substitution-replacements: "";
+
     // Theme: 0=Light, 1=Dark
     in-out property <int> opt-theme: 0;
 
@@ -690,6 +695,9 @@ export component MainWindow inherits Window {
         opt-enable-context-menu <=> root.opt-enable-context-menu;
         opt-theme <=> root.opt-theme;
         opt-language <=> root.opt-language;
+        opt-line-filters <=> root.opt-line-filters;
+        opt-substitution-patterns <=> root.opt-substitution-patterns;
+        opt-substitution-replacements <=> root.opt-substitution-replacements;
         apply => {
             root.show-options-dialog = false;
             root.set-theme(root.opt-theme);


### PR DESCRIPTION
## Summary
- Add **line filters**: regex patterns to exclude matching lines from comparison (e.g., comments, log timestamps)
- Add **substitution filters**: regex find/replace applied before comparison (e.g., normalize dates, version numbers)
- New "Filters" section in Options dialog with line filter input and substitution pattern/replacement fields
- Filter settings persisted in `settings.json`
- Added `regex` crate dependency
- 4 new tests (line filter, substitution filter, empty pattern, invalid regex)

## Test plan
- [ ] `cargo build` succeeds
- [ ] `cargo test` passes all 16 tests
- [ ] `cargo fmt -- --check` passes
- [ ] Line filter: enter `^//.*` in Options → Filters, compare files with different comments — comments excluded from diff
- [ ] Substitution filter: enter `\d{4}-\d{2}-\d{2}` → `DATE`, compare files with different dates — dates ignored
- [ ] Invalid regex patterns are silently skipped (no crash)
- [ ] Filter settings persist after app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)