### PR TITLE
v0.12.0: Splitter, inline editing, patch export, and 7 more features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4957,6 +4957,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67f06accca7b45351758663b8215089e643d53bd9a660ce0349314263737fcb0"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-cpp"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4989,6 +4999,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-javascript"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5013,6 +5033,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-md"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-python"
@@ -5045,10 +5075,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-toml-ng"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9adc2c898ae49730e857d75be403da3f92bb81d8e37a2f918a08dd10de5ebb1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-typescript"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -6203,7 +6253,7 @@ dependencies = [
 
 [[package]]
 name = "winxmerge"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arboard",
  "chardetng",
@@ -6219,15 +6269,20 @@ dependencies = [
  "slint-build",
  "tree-sitter",
  "tree-sitter-c",
+ "tree-sitter-c-sharp",
  "tree-sitter-cpp",
  "tree-sitter-go",
  "tree-sitter-highlight",
+ "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-json",
+ "tree-sitter-md",
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
+ "tree-sitter-toml-ng",
  "tree-sitter-typescript",
+ "tree-sitter-yaml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winxmerge"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 
 [dependencies]
@@ -26,6 +26,11 @@ tree-sitter-cpp = "0.23"
 tree-sitter-go = "0.23"
 tree-sitter-typescript = "0.23"
 tree-sitter-ruby = "0.23"
+tree-sitter-java = "0.23"
+tree-sitter-c-sharp = "0.23"
+tree-sitter-yaml = "0.7"
+tree-sitter-toml-ng = "0.7"
+tree-sitter-md = "0.5"
 
 [build-dependencies]
 slint-build = "1.15.1"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 fn main() {
-    let config =
-        slint_build::CompilerConfiguration::new().with_bundled_translations("translations/");
+    let config = slint_build::CompilerConfiguration::new()
+        .with_bundled_translations("translations/")
+        .with_default_translation_context(slint_build::DefaultTranslationContext::None);
     slint_build::compile_with_config("ui/main.slint", config).unwrap();
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,7 @@ use std::time::SystemTime;
 use slint::{Model, ModelRc, SharedString, VecModel};
 
 use crate::diff::engine::{DiffOptions, compute_diff_with_options};
-use crate::diff::folder::compare_folders;
+use crate::diff::folder::{FolderCompareOptions, compare_folders_with_options};
 use crate::diff::three_way::{ThreeWayStatus, compute_three_way_diff};
 use crate::encoding::{decode_file, encode_text};
 use crate::highlight::{detect_file_type, highlight_lines};
@@ -95,6 +95,7 @@ impl TabState {
 pub struct AppState {
     pub tabs: Vec<TabState>,
     pub active_tab: usize,
+    pub folder_exclude_patterns: Vec<String>,
 }
 
 impl AppState {
@@ -102,6 +103,7 @@ impl AppState {
         Self {
             tabs: vec![TabState::new()],
             active_tab: 0,
+            folder_exclude_patterns: Vec::new(),
         }
     }
 
@@ -435,15 +437,26 @@ pub fn recompute_diff_from_text_with_highlights(
             .unwrap_or_default(),
     ));
 
+    // Compute diff statistics
+    let mut added = 0u32;
+    let mut removed = 0u32;
+    let mut modified = 0u32;
+    for line in &result.lines {
+        match line.status {
+            LineStatus::Added => added += 1,
+            LineStatus::Removed => removed += 1,
+            LineStatus::Modified => modified += 1,
+            _ => {}
+        }
+    }
+    let stats = format!("+{} -{} ~{}", added, removed, modified);
+
     let status = if result.diff_count == 0 {
         "Files are identical".to_string()
     } else if tab.current_diff >= 0 {
-        format!(
-            "Difference 1 of {} ({} total)",
-            result.diff_count, result.diff_count
-        )
+        format!("Difference 1 of {} [{}]", result.diff_count, stats)
     } else {
-        format!("{} differences found", result.diff_count)
+        format!("{} differences found [{}]", result.diff_count, stats)
     };
     window.set_status_text(SharedString::from(status));
 }
@@ -504,7 +517,8 @@ pub fn goto_line(window: &MainWindow, state: &AppState, line_number: i32) {
         let left_no: i32 = data.left_line_no.parse().unwrap_or(0);
         let right_no: i32 = data.right_line_no.parse().unwrap_or(0);
         if left_no == line_number || right_no == line_number {
-            // Scroll to this position by setting status
+            // Scroll to this row
+            window.invoke_scroll_diff_to_row(idx as i32);
             window.set_status_text(SharedString::from(format!("Line {}", line_number)));
             // If this line is part of a diff, select it
             if data.diff_index >= 0 {
@@ -596,6 +610,9 @@ fn update_current_diff(window: &MainWindow, state: &mut AppState, new_index: i32
     let current_pos = tab.diff_positions[new_index as usize];
     let total = tab.diff_positions.len();
 
+    // Scroll to the diff position
+    window.invoke_scroll_diff_to_row(current_pos as i32);
+
     let model = window.get_diff_lines();
     if let Some(vec_model) = model.as_any().downcast_ref::<VecModel<DiffLineData>>() {
         for i in 0..vec_model.row_count() {
@@ -608,10 +625,28 @@ fn update_current_diff(window: &MainWindow, state: &mut AppState, new_index: i32
         }
     }
 
+    // Compute diff statistics
+    let mut added = 0u32;
+    let mut removed = 0u32;
+    let mut modified = 0u32;
+    if let Some(vec_model) = model.as_any().downcast_ref::<VecModel<DiffLineData>>() {
+        for i in 0..vec_model.row_count() {
+            let row = vec_model.row_data(i).unwrap();
+            match row.status {
+                1 => added += 1,
+                2 => removed += 1,
+                3 => modified += 1,
+                _ => {}
+            }
+        }
+    }
+    let stats = format!("+{} -{} ~{}", added, removed, modified);
+
     window.set_status_text(SharedString::from(format!(
-        "Difference {} of {}",
+        "Difference {} of {} [{}]",
         new_index + 1,
-        total
+        total,
+        stats
     )));
 }
 
@@ -800,6 +835,75 @@ fn rebuild_left_after_copy_from_right(vec_model: &VecModel<DiffLineData>) -> Str
     lines.join("\n") + "\n"
 }
 
+pub fn copy_all_text(window: &MainWindow, state: &AppState, is_left: bool) {
+    let tab = state.current_tab();
+    let text = if is_left {
+        tab.left_lines.join("\n")
+    } else {
+        tab.right_lines.join("\n")
+    };
+
+    if let Ok(mut clipboard) = arboard::Clipboard::new() {
+        let _ = clipboard.set_text(&text);
+        let side = if is_left { "Left" } else { "Right" };
+        window.set_status_text(SharedString::from(format!(
+            "{} file text copied to clipboard",
+            side
+        )));
+    }
+}
+
+pub fn edit_line(
+    window: &MainWindow,
+    state: &mut AppState,
+    line_index: i32,
+    new_text: &str,
+    is_left: bool,
+) {
+    let model = window.get_diff_lines();
+    let vec_model = match model.as_any().downcast_ref::<VecModel<DiffLineData>>() {
+        Some(m) => m,
+        None => return,
+    };
+
+    if line_index < 0 || line_index as usize >= vec_model.row_count() {
+        return;
+    }
+
+    // Push undo snapshot before edit
+    push_undo_snapshot(state, vec_model);
+
+    let mut row = vec_model.row_data(line_index as usize).unwrap();
+    if is_left {
+        row.left_text = SharedString::from(new_text);
+    } else {
+        row.right_text = SharedString::from(new_text);
+    }
+    vec_model.set_row_data(line_index as usize, row);
+
+    // Update the internal line data
+    let tab = state.current_tab_mut();
+    // Find the actual line number from the diff model to update left_lines/right_lines
+    let data = &vec_model.row_data(line_index as usize).unwrap();
+    if is_left {
+        if let Ok(line_no) = data.left_line_no.parse::<usize>() {
+            if line_no > 0 && line_no <= tab.left_lines.len() {
+                tab.left_lines[line_no - 1] = new_text.to_string();
+            }
+        }
+    } else {
+        if let Ok(line_no) = data.right_line_no.parse::<usize>() {
+            if line_no > 0 && line_no <= tab.right_lines.len() {
+                tab.right_lines[line_no - 1] = new_text.to_string();
+            }
+        }
+    }
+
+    tab.has_unsaved_changes = true;
+    window.set_has_unsaved_changes(true);
+    window.set_can_undo(true);
+}
+
 pub fn copy_current_line_text(window: &MainWindow, state: &AppState, is_left: bool) {
     let tab = state.current_tab();
     if tab.current_diff < 0 || tab.current_diff as usize >= tab.diff_positions.len() {
@@ -860,6 +964,46 @@ pub fn export_html_report(window: &MainWindow, state: &AppState) {
             Ok(_) => {
                 window.set_status_text(SharedString::from(format!(
                     "Exported to {}",
+                    path.to_string_lossy()
+                )));
+            }
+            Err(e) => {
+                window.set_status_text(SharedString::from(format!("Export error: {}", e)));
+            }
+        }
+    }
+}
+
+pub fn export_patch(window: &MainWindow, state: &AppState) {
+    let tab = state.current_tab();
+
+    let left_text = tab.left_lines.join("\n") + "\n";
+    let right_text = tab.right_lines.join("\n") + "\n";
+    let result = compute_diff_with_options(&left_text, &right_text, &tab.diff_options);
+
+    let left_title = tab
+        .left_path
+        .as_ref()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| "Left".to_string());
+    let right_title = tab
+        .right_path
+        .as_ref()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| "Right".to_string());
+
+    let patch = crate::export::export_unified_diff(&result, &left_title, &right_title);
+
+    if let Some(path) = rfd::FileDialog::new()
+        .set_title("Export Patch (Unified Diff)")
+        .set_file_name("diff.patch")
+        .add_filter("Patch", &["patch", "diff"])
+        .save_file()
+    {
+        match fs::write(&path, &patch) {
+            Ok(_) => {
+                window.set_status_text(SharedString::from(format!(
+                    "Exported patch to {}",
                     path.to_string_lossy()
                 )));
             }
@@ -932,9 +1076,20 @@ pub fn apply_options(window: &MainWindow, state: &mut AppState, settings: &mut A
         "en".to_string()
     };
     let lang_code = if settings.language == "ja" { "ja" } else { "" };
-    let _ = slint::select_bundled_translation(lang_code);
+    if let Err(e) = slint::select_bundled_translation(lang_code) {
+        eprintln!("Translation error: {}", e);
+    }
 
     settings.auto_rescan = window.get_opt_auto_rescan();
+
+    // Read folder exclude patterns
+    let folder_exclude_str = window.get_opt_folder_exclude_patterns().to_string();
+    settings.folder_exclude_patterns = folder_exclude_str.clone();
+    state.folder_exclude_patterns = folder_exclude_str
+        .split(';')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
 
     // Read filter settings
     let line_filters_str = window.get_opt_line_filters().to_string();
@@ -954,6 +1109,23 @@ pub fn apply_options(window: &MainWindow, state: &mut AppState, settings: &mut A
         .map(|(p, r)| crate::settings::SubstitutionFilter {
             pattern: p.trim().to_string(),
             replacement: r.trim().to_string(),
+        })
+        .collect();
+
+    // Parse plugin list from UI
+    let plugin_list_str = window.get_plugin_list().to_string();
+    settings.plugins = plugin_list_str
+        .split('|')
+        .filter(|s| !s.trim().is_empty())
+        .filter_map(|entry| {
+            let mut parts = entry.splitn(2, ':');
+            let name = parts.next()?.trim().to_string();
+            let command = parts.next()?.trim().to_string();
+            if name.is_empty() || command.is_empty() {
+                None
+            } else {
+                Some(crate::settings::PluginEntry { name, command })
+            }
         })
         .collect();
 
@@ -1278,7 +1450,11 @@ pub fn run_folder_compare(window: &MainWindow, state: &mut AppState) {
         _ => return,
     };
 
-    let items = compare_folders(&left_folder, &right_folder);
+    let options = FolderCompareOptions {
+        exclude_patterns: state.folder_exclude_patterns.clone(),
+        ..Default::default()
+    };
+    let items = compare_folders_with_options(&left_folder, &right_folder, &options);
 
     let folder_item_data: Vec<FolderItemData> = items
         .iter()

--- a/src/diff/folder.rs
+++ b/src/diff/folder.rs
@@ -12,10 +12,8 @@ pub struct FolderCompareOptions {
     pub extension_filter: Vec<String>,
     /// Whether to respect .gitignore files
     pub respect_gitignore: bool,
-}
-
-pub fn compare_folders(left_dir: &Path, right_dir: &Path) -> Vec<FolderItem> {
-    compare_folders_with_options(left_dir, right_dir, &FolderCompareOptions::default())
+    /// Exclude patterns (e.g., ["*.log", "build/", "node_modules"])
+    pub exclude_patterns: Vec<String>,
 }
 
 pub fn compare_folders_with_options(
@@ -137,6 +135,11 @@ fn collect_entries(
                 continue;
             }
 
+            // Check exclude patterns
+            if should_ignore(&rel, &options.exclude_patterns) {
+                continue;
+            }
+
             let metadata = entry.metadata();
             let is_dir = metadata.as_ref().map(|m| m.is_dir()).unwrap_or(false);
             let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
@@ -208,23 +211,31 @@ fn load_gitignore_patterns(dir: &Path) -> Vec<String> {
 }
 
 fn should_ignore(rel_path: &str, patterns: &[String]) -> bool {
+    let filename = rel_path.rsplit('/').next().unwrap_or(rel_path);
     for pattern in patterns {
         let pat = pattern.trim_start_matches('/');
+        if pat.is_empty() {
+            continue;
+        }
         // Simple glob matching: exact match, prefix match, or extension match
         if rel_path == pat || rel_path.starts_with(&format!("{}/", pat)) {
             return true;
         }
-        // *.ext pattern
+        // *.ext pattern — match against filename
         if let Some(ext) = pat.strip_prefix("*.") {
-            if rel_path.ends_with(&format!(".{}", ext)) {
+            if filename.ends_with(&format!(".{}", ext)) {
                 return true;
             }
         }
         // dir/ pattern
         if let Some(dir) = pat.strip_suffix('/') {
-            if rel_path == dir || rel_path.starts_with(&format!("{}/", dir)) {
+            if rel_path == dir || rel_path.starts_with(&format!("{}/", dir)) || filename == dir {
                 return true;
             }
+        }
+        // Exact filename match
+        if filename == pat {
+            return true;
         }
     }
     false

--- a/src/export.rs
+++ b/src/export.rs
@@ -76,6 +76,127 @@ pub fn export_html(diff_result: &DiffResult, left_title: &str, right_title: &str
     html
 }
 
+/// Export diff result as a unified diff (patch) file
+pub fn export_unified_diff(
+    diff_result: &DiffResult,
+    left_title: &str,
+    right_title: &str,
+) -> String {
+    let mut output = String::new();
+    output.push_str(&format!("--- {}\n", left_title));
+    output.push_str(&format!("+++ {}\n", right_title));
+
+    // Group consecutive changes into hunks
+    let lines = &diff_result.lines;
+    if lines.is_empty() {
+        return output;
+    }
+
+    let context_lines = 3usize;
+    let mut i = 0;
+    while i < lines.len() {
+        // Find the start of a change
+        if lines[i].status == LineStatus::Equal {
+            i += 1;
+            continue;
+        }
+
+        // Found a change; build a hunk with context
+        let hunk_start = i.saturating_sub(context_lines);
+        // Find the end of changes (merging nearby changes)
+        let mut hunk_end = i;
+        while hunk_end < lines.len() {
+            if lines[hunk_end].status != LineStatus::Equal {
+                hunk_end += 1;
+            } else {
+                // Check if another change is within context range
+                let lookahead = (hunk_end + context_lines * 2 + 1).min(lines.len());
+                let next_change =
+                    (hunk_end..lookahead).find(|&j| lines[j].status != LineStatus::Equal);
+                if let Some(nc) = next_change {
+                    hunk_end = nc + 1;
+                } else {
+                    break;
+                }
+            }
+        }
+        let hunk_end = (hunk_end + context_lines).min(lines.len());
+
+        // Count left/right lines in hunk
+        let mut left_count = 0u32;
+        let mut right_count = 0u32;
+        let mut left_start = 0u32;
+        let mut right_start = 0u32;
+        let mut left_start_set = false;
+        let mut right_start_set = false;
+
+        for line in &lines[hunk_start..hunk_end] {
+            if let Some(n) = line.left_line_no {
+                if !left_start_set {
+                    left_start = n as u32;
+                    left_start_set = true;
+                }
+                left_count += 1;
+            }
+            if let Some(n) = line.right_line_no {
+                if !right_start_set {
+                    right_start = n as u32;
+                    right_start_set = true;
+                }
+                right_count += 1;
+            }
+        }
+
+        if !left_start_set {
+            left_start = 1;
+        }
+        if !right_start_set {
+            right_start = 1;
+        }
+
+        output.push_str(&format!(
+            "@@ -{},{} +{},{} @@\n",
+            left_start, left_count, right_start, right_count
+        ));
+
+        for line in &lines[hunk_start..hunk_end] {
+            match line.status {
+                LineStatus::Equal => {
+                    output.push(' ');
+                    output.push_str(&line.left_text);
+                    output.push('\n');
+                }
+                LineStatus::Removed => {
+                    output.push('-');
+                    output.push_str(&line.left_text);
+                    output.push('\n');
+                }
+                LineStatus::Added => {
+                    output.push('+');
+                    output.push_str(&line.right_text);
+                    output.push('\n');
+                }
+                LineStatus::Modified | LineStatus::Moved => {
+                    if !line.left_text.is_empty() {
+                        output.push('-');
+                        output.push_str(&line.left_text);
+                        output.push('\n');
+                    }
+                    if !line.right_text.is_empty() {
+                        output.push('+');
+                        output.push_str(&line.right_text);
+                        output.push('\n');
+                    }
+                }
+            }
+        }
+
+        i = hunk_end;
+    }
+
+    output
+}
+
 fn escape_html(s: &str) -> String {
     s.replace('&', "&amp;")
         .replace('<', "&lt;")

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -116,6 +116,29 @@ pub fn highlight_lines(source: &str, file_path: &str) -> Vec<i32> {
     line_highlights
 }
 
+// C# highlights query (tree-sitter-c-sharp doesn't include one)
+const CSHARP_HIGHLIGHTS_QUERY: &str = r#"
+(using_directive) @keyword
+["if" "else" "switch" "case" "default" "while" "for" "foreach" "do" "return" "break" "continue" "throw" "try" "catch" "finally" "new" "class" "struct" "interface" "enum" "namespace" "public" "private" "protected" "internal" "static" "abstract" "virtual" "override" "sealed" "readonly" "const" "async" "await" "var" "void" "bool" "int" "string" "float" "double" "long" "byte" "char" "decimal" "object" "dynamic" "using" "null" "true" "false" "this" "base" "is" "as" "in" "out" "ref" "params" "get" "set" "value" "where" "yield" "partial" "event" "delegate" "operator" "implicit" "explicit" "checked" "unchecked" "fixed" "lock" "unsafe" "volatile" "extern" "sizeof" "typeof" "nameof" "stackalloc" "record" "init" "required" "file" "global" "scoped" "with" "when"] @keyword
+(comment) @comment
+(string_literal) @string
+(interpolated_string_expression) @string
+(character_literal) @string
+(integer_literal) @number
+(real_literal) @number
+(boolean_literal) @constant.builtin
+(null_literal) @constant.builtin
+(method_declaration name: (identifier) @function)
+(invocation_expression function: (identifier) @function)
+(type_parameter (identifier) @type)
+(generic_name (identifier) @type)
+(base_list (identifier) @type)
+(variable_declaration type: (identifier) @type)
+(parameter type: (identifier) @type)
+(object_creation_expression type: (identifier) @type)
+(attribute (identifier) @attribute)
+"#;
+
 fn get_highlight_config(ext: &str) -> Option<HighlightConfiguration> {
     let (language, highlights_query, injections_query, locals_query) = match ext {
         "rs" => (
@@ -177,6 +200,36 @@ fn get_highlight_config(ext: &str) -> Option<HighlightConfiguration> {
             tree_sitter_ruby::HIGHLIGHTS_QUERY,
             "",
             tree_sitter_ruby::LOCALS_QUERY,
+        ),
+        "java" => (
+            tree_sitter_java::LANGUAGE.into(),
+            tree_sitter_java::HIGHLIGHTS_QUERY,
+            "",
+            "",
+        ),
+        "cs" => (
+            tree_sitter_c_sharp::LANGUAGE.into(),
+            CSHARP_HIGHLIGHTS_QUERY,
+            "",
+            "",
+        ),
+        "yaml" | "yml" => (
+            tree_sitter_yaml::LANGUAGE.into(),
+            tree_sitter_yaml::HIGHLIGHTS_QUERY,
+            "",
+            "",
+        ),
+        "toml" => (
+            tree_sitter_toml_ng::LANGUAGE.into(),
+            tree_sitter_toml_ng::HIGHLIGHTS_QUERY,
+            "",
+            "",
+        ),
+        "md" | "markdown" => (
+            tree_sitter_md::LANGUAGE.into(),
+            tree_sitter_md::HIGHLIGHT_QUERY_BLOCK,
+            "",
+            "",
         ),
         _ => return None,
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,14 +12,15 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use app::{
-    AppState, add_tab, apply_options, check_files_changed, close_tab, copy_current_line_text,
-    copy_to_left, copy_to_right, discard_and_proceed, export_html_report, first_diff,
-    folder_copy_to_left, folder_copy_to_right, folder_delete_item, goto_line, last_diff,
-    navigate_bookmark, navigate_conflict, navigate_diff, navigate_search, open_file_dialog,
-    open_folder_dialog, open_folder_item, open_in_editor, redo, replace_all_text, replace_text,
-    rescan, resolve_conflict_use_left, resolve_conflict_use_right, run_folder_compare, run_plugin,
-    save_file, search_text, select_diff, start_compare, start_three_way_compare, switch_tab,
-    toggle_bookmark, toggle_ignore_case, toggle_ignore_whitespace, undo,
+    AppState, add_tab, apply_options, check_files_changed, close_tab, copy_all_text,
+    copy_current_line_text, copy_to_left, copy_to_right, discard_and_proceed, edit_line,
+    export_html_report, export_patch, first_diff, folder_copy_to_left, folder_copy_to_right,
+    folder_delete_item, goto_line, last_diff, navigate_bookmark, navigate_conflict, navigate_diff,
+    navigate_search, open_file_dialog, open_folder_dialog, open_folder_item, open_in_editor, redo,
+    replace_all_text, replace_text, rescan, resolve_conflict_use_left, resolve_conflict_use_right,
+    run_folder_compare, run_plugin, save_file, search_text, select_diff, start_compare,
+    start_three_way_compare, switch_tab, toggle_bookmark, toggle_ignore_case,
+    toggle_ignore_whitespace, undo,
 };
 use slint::{ModelRc, SharedString, VecModel};
 
@@ -51,7 +52,9 @@ fn main() {
         let lang_index = if s.language == "ja" { 1 } else { 0 };
         window.set_opt_language(lang_index);
         let lang_code = if s.language == "ja" { "ja" } else { "" };
-        let _ = slint::select_bundled_translation(lang_code);
+        if let Err(e) = slint::select_bundled_translation(lang_code) {
+            eprintln!("Translation init error: {}", e);
+        }
         // Load filter settings into UI
         window.set_opt_line_filters(SharedString::from(s.line_filters.join("|")));
         let sub_patterns: Vec<&str> = s
@@ -67,6 +70,7 @@ fn main() {
         window.set_opt_substitution_patterns(SharedString::from(sub_patterns.join("|")));
         window.set_opt_substitution_replacements(SharedString::from(sub_replacements.join("|")));
         window.set_opt_auto_rescan(s.auto_rescan);
+        window.set_opt_folder_exclude_patterns(SharedString::from(&s.folder_exclude_patterns));
         // Load plugin list as pipe-separated "name:command" pairs
         let plugin_str: Vec<String> = s
             .plugins
@@ -85,6 +89,12 @@ fn main() {
             .iter()
             .map(|f| (f.pattern.clone(), f.replacement.clone()))
             .collect();
+        app.folder_exclude_patterns = s
+            .folder_exclude_patterns
+            .split(';')
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty())
+            .collect();
     }
 
     // Load recent entries into UI
@@ -93,18 +103,65 @@ fn main() {
     // Initialize tab list
     app::sync_tab_list(&window, &state.borrow());
 
-    // Handle CLI arguments:
+    // Parse CLI flags and positional arguments
+    let mut positional: Vec<String> = Vec::new();
+    let mut cli_ignore_whitespace = false;
+    let mut cli_ignore_case = false;
+    let mut cli_ignore_blank_lines = false;
+    {
+        let mut i = 1;
+        while i < args.len() {
+            match args[i].as_str() {
+                "--ignore-whitespace" | "-w" => cli_ignore_whitespace = true,
+                "--ignore-case" | "-i" => cli_ignore_case = true,
+                "--ignore-blank-lines" | "-B" => cli_ignore_blank_lines = true,
+                _ => positional.push(args[i].clone()),
+            }
+            i += 1;
+        }
+    }
+
+    // Apply CLI flags to initial tab's diff options
+    if cli_ignore_whitespace || cli_ignore_case || cli_ignore_blank_lines {
+        let mut s = state.borrow_mut();
+        let tab = s.current_tab_mut();
+        if cli_ignore_whitespace {
+            tab.diff_options.ignore_whitespace = true;
+        }
+        if cli_ignore_case {
+            tab.diff_options.ignore_case = true;
+        }
+        if cli_ignore_blank_lines {
+            tab.diff_options.ignore_blank_lines = true;
+        }
+        // Sync UI toggles
+        drop(s);
+        if cli_ignore_whitespace {
+            window.set_ignore_whitespace(true);
+        }
+        if cli_ignore_case {
+            window.set_ignore_case(true);
+        }
+    }
+
+    // Handle positional arguments:
     //   winxmerge <left> <right>           — 2-way diff
     //   winxmerge <base> <left> <right>    — 3-way merge
-    if args.len() >= 4 {
+    if positional.len() >= 3 {
         // 3-way merge
         let mut s = state.borrow_mut();
-        start_three_way_compare(&window, &mut s, &args[1], &args[2], &args[3]);
+        start_three_way_compare(
+            &window,
+            &mut s,
+            &positional[0],
+            &positional[1],
+            &positional[2],
+        );
         app::sync_tab_list(&window, &s);
-    } else if args.len() >= 3 {
+    } else if positional.len() >= 2 {
         // 2-way diff
-        let left = std::path::PathBuf::from(&args[1]);
-        let right = std::path::PathBuf::from(&args[2]);
+        let left = std::path::PathBuf::from(&positional[0]);
+        let right = std::path::PathBuf::from(&positional[1]);
         let mut s = state.borrow_mut();
         {
             let tab = s.current_tab_mut();
@@ -538,6 +595,42 @@ fn main() {
         });
     }
 
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_copy_all_left(move || {
+            let window = window_weak.unwrap();
+            copy_all_text(&window, &state.borrow(), true);
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_copy_all_right(move || {
+            let window = window_weak.unwrap();
+            copy_all_text(&window, &state.borrow(), false);
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_edit_left_line(move |idx, text| {
+            let window = window_weak.unwrap();
+            edit_line(&window, &mut state.borrow_mut(), idx, &text, true);
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_edit_right_line(move |idx, text| {
+            let window = window_weak.unwrap();
+            edit_line(&window, &mut state.borrow_mut(), idx, &text, false);
+        });
+    }
+
     // Apply options
     {
         let window_weak = window.as_weak();
@@ -556,6 +649,15 @@ fn main() {
         window.on_export_html(move || {
             let window = window_weak.unwrap();
             export_html_report(&window, &state.borrow());
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_export_patch(move || {
+            let window = window_weak.unwrap();
+            export_patch(&window, &state.borrow());
         });
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -65,6 +65,10 @@ pub struct AppSettings {
     #[serde(default)]
     pub auto_rescan: bool,
 
+    // Folder comparison: exclude patterns (e.g., "*.log", "build/", "node_modules")
+    #[serde(default)]
+    pub folder_exclude_patterns: String,
+
     #[serde(default)]
     pub recent_files: Vec<RecentEntry>,
 }
@@ -134,6 +138,7 @@ impl Default for AppSettings {
             plugins: Vec::new(),
             external_editor: String::new(),
             auto_rescan: false,
+            folder_exclude_patterns: String::new(),
             recent_files: Vec::new(),
         }
     }

--- a/translations/ja/LC_MESSAGES/winxmerge.po
+++ b/translations/ja/LC_MESSAGES/winxmerge.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: winxmerge 0.11.0\n"
+"Project-Id-Version: winxmerge 0.12.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-03-17 00:00+0000\n"
 "PO-Revision-Date: 2026-03-17 00:00+0000\n"
@@ -419,3 +419,38 @@ msgstr "プラグインコマンドを実行..."
 # v0.11.0 - Auto-rescan
 msgid "Auto-rescan files on change"
 msgstr "ファイル変更時に自動再スキャン"
+
+# v0.12.0 - Folder exclude patterns
+msgid "Folder exclude patterns (semicolon-separated):"
+msgstr "フォルダ除外パターン (セミコロン区切り):"
+
+msgid "e.g. *.log;build/;node_modules"
+msgstr "例: *.log;build/;node_modules"
+
+# v0.12.0 - Patch export
+msgid "Export Patch (Unified Diff)..."
+msgstr "パッチをエクスポート (Unified Diff)..."
+
+# v0.12.0 - Copy all text
+msgid "Copy All Left Text"
+msgstr "左テキスト全体をコピー"
+
+msgid "Copy All Right Text"
+msgstr "右テキスト全体をコピー"
+
+# v0.12.0 - Plugin management UI
+msgid "Current plugins:"
+msgstr "現在のプラグイン:"
+
+msgid "Plugin name"
+msgstr "プラグイン名"
+
+# Plugin command placeholder (not @tr(), uses literal string)
+# msgid "Command (use {LEFT} {RIGHT})"
+# msgstr "コマンド ({LEFT} {RIGHT} を使用)"
+
+msgid "Add"
+msgstr "追加"
+
+msgid "Clear"
+msgstr "クリア"

--- a/ui/dialogs/options-dialog.slint
+++ b/ui/dialogs/options-dialog.slint
@@ -32,6 +32,14 @@ export component OptionsDialog inherits Rectangle {
     // Auto-rescan
     in-out property <bool> opt-auto-rescan: false;
 
+    // Folder exclude patterns
+    in-out property <string> opt-folder-exclude-patterns: "";
+
+    // Plugin management (pipe-separated "name:command" pairs)
+    in-out property <string> opt-plugin-list: "";
+    in-out property <string> plugin-name-input: "";
+    in-out property <string> plugin-command-input: "";
+
     callback apply();
     callback cancel();
 
@@ -45,7 +53,7 @@ export component OptionsDialog inherits Rectangle {
             x: (parent.width - self.width) / 2;
             y: (parent.height - self.height) / 2;
             width: 500px;
-            height: 700px;
+            height: Math.min(800px, parent.height - 40px);
             background: Palette.background;
             border-color: Palette.border;
             border-width: 1px;
@@ -53,6 +61,7 @@ export component OptionsDialog inherits Rectangle {
 
             TouchArea {} // Block overlay click
 
+            ScrollView {
             VerticalLayout {
                 padding: 24px;
                 spacing: 8px;
@@ -201,6 +210,17 @@ export component OptionsDialog inherits Rectangle {
                     }
                 }
 
+                Text {
+                    text: @tr("Folder exclude patterns (semicolon-separated):");
+                    font-size: 12px;
+                    color: Palette.foreground.transparentize(0.3);
+                    wrap: word-wrap;
+                }
+                LineEdit {
+                    text <=> root.opt-folder-exclude-patterns;
+                    placeholder-text: @tr("e.g. *.log;build/;node_modules");
+                }
+
                 Rectangle { height: 8px; }
 
                 // Auto-rescan
@@ -208,6 +228,61 @@ export component OptionsDialog inherits Rectangle {
                     text: @tr("Auto-rescan files on change");
                     checked: root.opt-auto-rescan;
                     toggled => { root.opt-auto-rescan = self.checked; }
+                }
+
+                Rectangle { height: 8px; }
+
+                // Plugins section
+                Text {
+                    text: @tr("Plugins");
+                    font-size: 14px;
+                    font-weight: 600;
+                    color: Palette.foreground;
+                }
+                Rectangle {
+                    height: 1px;
+                    background: Palette.border;
+                }
+
+                Text {
+                    text: @tr("Current plugins:") + " " + root.opt-plugin-list;
+                    font-size: 11px;
+                    color: Palette.foreground.transparentize(0.4);
+                    wrap: word-wrap;
+                }
+
+                HorizontalLayout {
+                    spacing: 4px;
+                    LineEdit {
+                        text <=> root.plugin-name-input;
+                        placeholder-text: @tr("Plugin name");
+                        horizontal-stretch: 1;
+                    }
+                    LineEdit {
+                        text <=> root.plugin-command-input;
+                        placeholder-text: "Command (use {LEFT} {RIGHT})";
+                        horizontal-stretch: 2;
+                    }
+                    Button {
+                        text: @tr("Add");
+                        clicked => {
+                            if root.plugin-name-input != "" && root.plugin-command-input != "" {
+                                if root.opt-plugin-list != "" {
+                                    root.opt-plugin-list = root.opt-plugin-list + "|" + root.plugin-name-input + ":" + root.plugin-command-input;
+                                } else {
+                                    root.opt-plugin-list = root.plugin-name-input + ":" + root.plugin-command-input;
+                                }
+                                root.plugin-name-input = "";
+                                root.plugin-command-input = "";
+                            }
+                        }
+                    }
+                    Button {
+                        text: @tr("Clear");
+                        clicked => {
+                            root.opt-plugin-list = "";
+                        }
+                    }
                 }
 
                 Rectangle { height: 8px; }
@@ -277,7 +352,7 @@ export component OptionsDialog inherits Rectangle {
                     }
                 }
 
-                Rectangle { vertical-stretch: 1; }
+                Rectangle { height: 16px; }
 
                 // Buttons
                 HorizontalLayout {
@@ -293,7 +368,10 @@ export component OptionsDialog inherits Rectangle {
                         clicked => { root.cancel(); }
                     }
                 }
+
+                Rectangle { height: 16px; }
             }
+            } // ScrollView
         }
     }
 }

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -127,6 +127,9 @@ export component MainWindow inherits Window {
     in-out property <bool> show-goto-dialog: false;
     in-out property <string> goto-line-input: "";
 
+    // Scroll control for diff view (in pixels, negative = scroll down)
+    in-out property <length> diff-scroll-y: 0px;
+
     // Bookmarks
     in-out property <string> bookmark-lines: ""; // comma-separated line indices
 
@@ -161,8 +164,13 @@ export component MainWindow inherits Window {
     callback undo();
     callback redo();
     callback export-html();
+    callback export-patch();
     callback copy-left-text();
     callback copy-right-text();
+    callback copy-all-left();
+    callback copy-all-right();
+    callback edit-left-line(/* line-index */ int, /* new-text */ string);
+    callback edit-right-line(/* line-index */ int, /* new-text */ string);
     callback open-recent(int);
     callback goto-line(int);
     callback toggle-bookmark(int);
@@ -219,6 +227,12 @@ export component MainWindow inherits Window {
     // Auto-rescan
     in-out property <bool> opt-auto-rescan: false;
 
+    // Folder exclude patterns
+    in-out property <string> opt-folder-exclude-patterns: "";
+
+    // Inline editing
+    in-out property <bool> opt-inline-edit: true;
+
     // Plugin list (pipe-separated "name:command" pairs)
     in-out property <string> plugin-list: "";
 
@@ -231,6 +245,11 @@ export component MainWindow inherits Window {
     // Apply the color scheme from opt-theme
     public function set-theme(theme-index: int) {
         Palette.color-scheme = theme-index == 1 ? ColorScheme.dark : ColorScheme.light;
+    }
+
+    // Scroll diff view to a specific row
+    public function scroll-diff-to-row(row: int) {
+        root.diff-scroll-y = -(row * 24px);
     }
 
     // Helper: check unsaved before action
@@ -264,6 +283,7 @@ export component MainWindow inherits Window {
             MenuItem { title: @tr("Rescan (F5)"); activated => { root.rescan(); } }
             MenuSeparator {}
             MenuItem { title: @tr("Export HTML Report..."); enabled: root.diff-count > 0; activated => { root.export-html(); } }
+            MenuItem { title: @tr("Export Patch (Unified Diff)..."); enabled: root.diff-count > 0; activated => { root.export-patch(); } }
         }
         Menu {
             title: @tr("Edit");
@@ -274,6 +294,9 @@ export component MainWindow inherits Window {
                 title: @tr("Find / Replace...");
                 activated => { root.show-search = !root.show-search; }
             }
+            MenuSeparator {}
+            MenuItem { title: @tr("Copy All Left Text"); enabled: root.view-mode == 0; activated => { root.copy-all-left(); } }
+            MenuItem { title: @tr("Copy All Right Text"); enabled: root.view-mode == 0; activated => { root.copy-all-right(); } }
             MenuSeparator {}
             MenuItem {
                 title: @tr("Options...");
@@ -567,6 +590,7 @@ export component MainWindow inherits Window {
         if root.view-mode == 0 : DiffView {
             diff-lines: root.diff-lines;
             current-diff-index: root.current-diff-index;
+            scroll-y <=> root.diff-scroll-y;
             left-title: root.left-path != "" ? root.left-path : @tr("Left file");
             right-title: root.right-path != "" ? root.right-path : @tr("Right file");
             context-menu-enabled: root.opt-enable-context-menu;
@@ -580,6 +604,9 @@ export component MainWindow inherits Window {
             prev-diff => { root.prev-diff(); }
             copy-left-text => { root.copy-left-text(); }
             copy-right-text => { root.copy-right-text(); }
+            inline-edit-enabled: root.opt-inline-edit;
+            edit-left-line(idx, text) => { root.edit-left-line(idx, text); }
+            edit-right-line(idx, text) => { root.edit-right-line(idx, text); }
         }
 
         if root.view-mode == 1 : FolderView {
@@ -732,6 +759,8 @@ export component MainWindow inherits Window {
         opt-substitution-patterns <=> root.opt-substitution-patterns;
         opt-substitution-replacements <=> root.opt-substitution-replacements;
         opt-auto-rescan <=> root.opt-auto-rescan;
+        opt-folder-exclude-patterns <=> root.opt-folder-exclude-patterns;
+        opt-plugin-list <=> root.plugin-list;
         apply => {
             root.show-options-dialog = false;
             root.set-theme(root.opt-theme);

--- a/ui/widgets/diff-view.slint
+++ b/ui/widgets/diff-view.slint
@@ -21,17 +21,19 @@ export struct DiffLineData {
 
 component DiffLineRow inherits Rectangle {
     in property <string> line-no;
-    in property <string> text;
+    in-out property <string> text;
     in property <int> status;
     in property <bool> is-current;
     in property <int> highlight-type: -1;
     in property <int> diff-idx: -1;
     in property <bool> show-line-no: true;
     in property <int> text-font-size: 13;
+    in property <bool> editable: false;
     // Word diff: shows only the changed characters (for Modified lines)
     in property <string> word-diff: "";
 
     callback line-clicked(int);
+    callback text-edited(string);
 
     background: is-current ? current-bg : status == 1 ? ThemeColors.added-bg : status == 2 ? ThemeColors.removed-bg : status == 3 ? ThemeColors.modified-bg : status == 4 ? ThemeColors.moved-bg : Palette.background;
 
@@ -81,13 +83,8 @@ component DiffLineRow inherits Rectangle {
         // Text content with word-level diff indicator
         VerticalLayout {
             spacing: 0;
-            Text {
-                text: text;
-                font-size: text-font-size * 1px;
-                font-family: "monospace";
-                vertical-alignment: center;
-                overflow: elide;
-                color: highlight-type == 0 ? ThemeColors.hl-keyword :
+
+            property <color> text-color: highlight-type == 0 ? ThemeColors.hl-keyword :
                        highlight-type == 1 ? ThemeColors.hl-string :
                        highlight-type == 2 ? ThemeColors.hl-comment :
                        highlight-type == 3 ? ThemeColors.hl-number :
@@ -99,7 +96,26 @@ component DiffLineRow inherits Rectangle {
                        highlight-type == 9 ? ThemeColors.hl-variable :
                        highlight-type == 10 ? ThemeColors.hl-operator :
                        Palette.foreground;
+
+            if !root.editable : Text {
+                text: root.text;
+                font-size: root.text-font-size * 1px;
+                font-family: "monospace";
+                vertical-alignment: center;
+                overflow: elide;
+                color: parent.text-color;
             }
+            if root.editable : TextInput {
+                text: root.text;
+                font-size: root.text-font-size * 1px;
+                font-family: "monospace";
+                vertical-alignment: center;
+                color: parent.text-color;
+                edited => {
+                    root.text-edited(self.text);
+                }
+            }
+
             // Word diff underline: shows changed characters with highlighting
             if word-diff != "" : Text {
                 text: word-diff;
@@ -147,13 +163,19 @@ export component DiffView inherits Rectangle {
     in property <bool> show-line-numbers: true;
     in property <int> editor-font-size: 13;
     in property <int> editor-tab-width: 4;
+    in property <bool> inline-edit-enabled: false;
 
     accessible-role: list;
     accessible-label: "File difference view";
 
+    // Expose viewport-y for external scroll control
+    in-out property <length> scroll-y <=> left-list.viewport-y;
+
     callback copy-to-right(/* diff-index */ int);
     callback copy-to-left(/* diff-index */ int);
     callback select-diff(/* diff-index */ int);
+    callback edit-left-line(/* line-index */ int, /* new-text */ string);
+    callback edit-right-line(/* line-index */ int, /* new-text */ string);
     callback next-diff();
     callback prev-diff();
     callback copy-left-text();
@@ -162,12 +184,22 @@ export component DiffView inherits Rectangle {
     border-color: Palette.border;
     border-width: 1px;
 
+    // Splitter ratio (0.0 to 1.0)
+    in-out property <float> split-ratio: 0.5;
+
+    // Computed widths
+    property <length> merge-col-width: 32px;
+    property <length> location-pane-width: root.diff-lines.length > 0 ? 14px : 0px;
+    property <length> available-pane-width: root.width - 2px - merge-col-width - location-pane-width;
+    property <length> left-pane-width: Math.max(80px, Math.min(available-pane-width - 80px, available-pane-width * root.split-ratio));
+
     VerticalLayout {
         // Header
         HorizontalLayout {
             height: 28px;
 
             Rectangle {
+                width: root.left-pane-width;
                 background: Palette.background.darker(0.05);
                 border-color: Palette.border;
                 border-width: 1px;
@@ -183,12 +215,32 @@ export component DiffView inherits Rectangle {
                 }
             }
 
-            // Spacer for merge button column
+            // Merge column header (drag handle for splitter)
             Rectangle {
-                width: 32px;
-                background: Palette.background.darker(0.05);
+                width: root.merge-col-width;
+                background: splitter-header-drag.has-hover ? Palette.background.darker(0.12) : Palette.background.darker(0.05);
                 border-color: Palette.border;
                 border-width: 1px;
+
+                // Drag grip indicator
+                Text {
+                    text: "⋮";
+                    font-size: 14px;
+                    color: Palette.foreground.transparentize(0.5);
+                    horizontal-alignment: center;
+                    vertical-alignment: center;
+                }
+
+                splitter-header-drag := TouchArea {
+                    mouse-cursor: col-resize;
+                    moved => {
+                        if self.pressed {
+                            root.split-ratio = Math.max(0.1, Math.min(0.9,
+                                (root.left-pane-width + self.mouse-x - self.pressed-x) / root.available-pane-width
+                            ));
+                        }
+                    }
+                }
             }
 
             Rectangle {
@@ -209,8 +261,10 @@ export component DiffView inherits Rectangle {
 
             // Spacer for location pane
             if root.diff-lines.length > 0 : Rectangle {
-                width: 12px;
+                width: root.location-pane-width;
                 background: Palette.background.darker(0.05);
+                border-color: Palette.border;
+                border-width: 1px;
             }
         }
 
@@ -218,6 +272,8 @@ export component DiffView inherits Rectangle {
         HorizontalLayout {
             // Left pane
             Rectangle {
+                width: root.left-pane-width;
+
                 if root.context-menu-enabled : ContextMenuArea {
                     Menu {
                         title: @tr("Context");
@@ -232,7 +288,7 @@ export component DiffView inherits Rectangle {
                 }
 
                 left-list := ListView {
-                    for line in diff-lines: DiffLineRow {
+                    for line[idx] in diff-lines: DiffLineRow {
                         height: line.left-word-diff != "" ? 36px : 24px;
                         line-no: line.left-line-no;
                         text: line.left-text;
@@ -243,14 +299,16 @@ export component DiffView inherits Rectangle {
                         show-line-no: root.show-line-numbers;
                         text-font-size: root.editor-font-size;
                         word-diff: line.left-word-diff;
-                        line-clicked(idx) => { root.select-diff(idx); }
+                        editable: root.inline-edit-enabled && line.left-line-no != "";
+                        line-clicked(didx) => { root.select-diff(didx); }
+                        text-edited(new-text) => { root.edit-left-line(idx, new-text); }
                     }
                 }
             }
 
             // Merge buttons column
             Rectangle {
-                width: 32px;
+                width: root.merge-col-width;
                 background: Palette.background.darker(0.01);
                 border-color: Palette.border;
                 border-width: 1px;
@@ -320,7 +378,7 @@ export component DiffView inherits Rectangle {
 
                 right-list := ListView {
                     viewport-y: left-list.viewport-y;
-                    for line in diff-lines: DiffLineRow {
+                    for line[idx] in diff-lines: DiffLineRow {
                         height: line.right-word-diff != "" ? 36px : 24px;
                         line-no: line.right-line-no;
                         text: line.right-text;
@@ -331,7 +389,9 @@ export component DiffView inherits Rectangle {
                         show-line-no: root.show-line-numbers;
                         text-font-size: root.editor-font-size;
                         word-diff: line.right-word-diff;
-                        line-clicked(idx) => { root.select-diff(idx); }
+                        editable: root.inline-edit-enabled && line.right-line-no != "";
+                        line-clicked(didx) => { root.select-diff(didx); }
+                        text-edited(new-text) => { root.edit-right-line(idx, new-text); }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- **Draggable splitter** for left/right pane resize via merge column header
- **Diff statistics** showing `[+N -N ~N]` counts in status bar
- **CLI options**: `--ignore-whitespace`/`-w`, `--ignore-case`/`-i`, `--ignore-blank-lines`/`-B`
- **Folder exclude patterns** (semicolon-separated in Options, e.g. `*.log;build/;node_modules`)
- **Unified diff (patch) export** via File → Export Patch (Unified Diff)
- **Scroll-to-line** on Go to Line and Next/Prev diff navigation
- **Copy All Left/Right Text** to clipboard via Edit menu
- **Syntax highlighting** for Java, C#, YAML, TOML, Markdown (tree-sitter grammars)
- **Inline editing** in diff view with undo support
- **Plugin management UI** in Options dialog (add/clear plugins)
- Scrollable Options dialog that fits within window height
- Fixed bundled translation context for proper i18n support

## Test plan
- [x] Build succeeds (`cargo build`)
- [x] All 16 tests pass (`cargo test`)
- [x] GUI launches and displays diff correctly
- [x] Language switching (Japanese) works after translation context fix
- [x] Theme switching works
- [ ] Verify splitter drag resizes panes
- [ ] Verify diff stats appear in status bar
- [ ] Verify CLI flags apply on startup
- [ ] Verify patch export produces valid unified diff
- [ ] Verify inline editing modifies text and marks unsaved

🤖 Generated with [Claude Code](https://claude.com/claude-code)