### PR TITLE
v0.14.0: Built-in file browser, bidirectional scroll sync, and UX fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6253,7 +6253,7 @@ dependencies = [
 
 [[package]]
 name = "winxmerge"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arboard",
  "chardetng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winxmerge"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ A cross-platform file diff comparison and merge tool inspired by WinMerge, built
 - Diff colors and syntax highlighting colors optimized per theme
 - Settings persisted across sessions
 
+### Built-in File Browser
+- Native-dialog-independent file/folder picker (works on WSL2 and environments without GTK)
+- Directory navigation with folder/file icons, parent button, and editable path bar
+- Falls back automatically when the system file dialog is unavailable
+
 ### Other
 - WinMerge-style initial file selection dialog (with recent files list)
 - WinMerge-style options dialog (Edit → Options...)
@@ -249,6 +254,7 @@ winxmerge/
 │   ├── icons/                  # SVG toolbar icons
 │   ├── dialogs/
 │   │   ├── open-dialog.slint   # File/folder selection dialog
+│   │   ├── file-browser.slint  # Built-in file browser (WSL2-safe)
 │   │   └── options-dialog.slint # Options dialog
 │   └── widgets/
 │       ├── diff-view.slint     # 2-way diff display widget

--- a/handover.md
+++ b/handover.md
@@ -7,8 +7,8 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 
 ## 現在の状態
 
-- **バージョン:** 0.13.0
-- **ブランチ:** `feature/v0.13.0`
+- **バージョン:** 0.14.0
+- **ブランチ:** `feature/v0.14.0`
 - **テスト:** 16件すべてパス
 - **ビルド:** `cargo build` 成功
 - **CI:** GitHub Actions（ubuntu / macOS / Windows）
@@ -29,7 +29,8 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 | v0.10.0 | #10 | 行フィルタ、置換フィルタ（正規表現）、オプション画面拡張 |
 | v0.11.0 | #11 | ワードレベル差分、プラグインシステム、アクセシビリティ、自動再スキャン、フォルダツリー表示、外部エディタ連携 |
 | v0.12.0 | #12 | スプリッター、インライン編集、パッチエクスポート、スクロール同期、差分統計 |
-| v0.13.0 | - | SVGアイコンツールバー、差分詳細ペイン、コピーして次へ、全差分コピー、ウィンドウサイズ保存 |
+| v0.13.0 | #13 | SVGアイコンツールバー、差分詳細ペイン、コピーして次へ、全差分コピー、ウィンドウサイズ保存 |
+| v0.14.0 | - | 組み込みファイルブラウザ（WSL2対応）、左右スクロール双方向同期、絵文字→SVGアイコン化 |
 
 ## 実装済み機能一覧
 
@@ -40,7 +41,7 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 - マージ操作（左→右 / 右→左コピー、ツールバー + インラインボタン）
 - Undo/Redo（スナップショットベース、Cmd+Z / Cmd+Shift+Z）
 - 左右2ペイン + マージボタン列 + ロケーションペイン（ミニマップ）
-- 左右スクロール同期（viewport-y バインド）
+- 左右スクロール双方向同期（どちらのペインをスクロールしても両側が追従）
 - 行番号クリックで差分選択
 
 ### 3-way マージ
@@ -200,6 +201,12 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 - `window().on_close_requested()` でウィンドウサイズを `settings.json` に保存
 - 起動時に `window().set_size()` で復元
 
+### 組み込みファイルブラウザ
+- GTK 非依存のファイル/フォルダピッカー（WSL2 等でネイティブダイアログが使えない環境に対応）
+- ディレクトリナビゲーション（フォルダ/ファイル SVG アイコン、上のフォルダボタン、編集可能パスバー）
+- ネイティブダイアログ（rfd）が利用不可の場合に自動フォールバック
+- シングルクリックで選択、ダブルクリックでフォルダに入る/ファイルを確定
+
 ### その他
 - WinMerge 風の初期選択ダイアログ
 - 未保存変更の確認ダイアログ
@@ -235,6 +242,7 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 | `widgets/folder-view.slint` | フォルダ比較リスト表示 |
 | `widgets/tab-bar.slint` | タブバー |
 | `dialogs/open-dialog.slint` | 初期選択ダイアログ |
+| `dialogs/file-browser.slint` | 組み込みファイルブラウザ（WSL2 対応、rfd フォールバック） |
 | `theme.slint` | テーマカラー定義（ThemeColors グローバル、ライト/ダーク対応） |
 | `dialogs/options-dialog.slint` | オプション設定ダイアログ（テーマ選択含む） |
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -211,6 +211,19 @@ fn restore_tab(window: &MainWindow, state: &AppState) {
 
     if tab.view_mode == 2 {
         window.set_status_text(SharedString::from("Select files or folders to compare"));
+        // Clear path inputs for a fresh open dialog state
+        window.set_open_left_path_input(SharedString::from(
+            tab.left_path
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_default(),
+        ));
+        window.set_open_right_path_input(SharedString::from(
+            tab.right_path
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_default(),
+        ));
     }
 }
 
@@ -1466,7 +1479,11 @@ pub fn start_compare(
     }
 }
 
-pub fn discard_and_proceed(window: &MainWindow, state: &mut AppState) {
+pub fn discard_and_proceed(
+    window: &MainWindow,
+    state: &mut AppState,
+    show_picker: impl Fn(i32, &str),
+) {
     state.current_tab_mut().has_unsaved_changes = false;
     window.set_has_unsaved_changes(false);
 
@@ -1486,6 +1503,8 @@ pub fn discard_and_proceed(window: &MainWindow, state: &mut AppState) {
                 ));
                 window.set_view_mode(0);
                 run_diff(window, state);
+            } else {
+                show_picker(11, "Select left file");
             }
         }
         2 => {
@@ -1500,6 +1519,8 @@ pub fn discard_and_proceed(window: &MainWindow, state: &mut AppState) {
                 ));
                 window.set_view_mode(0);
                 run_diff(window, state);
+            } else {
+                show_picker(12, "Select right file");
             }
         }
         3 => {
@@ -1509,6 +1530,8 @@ pub fn discard_and_proceed(window: &MainWindow, state: &mut AppState) {
                     path.to_string_lossy().to_string(),
                 ));
                 run_folder_compare(window, state);
+            } else {
+                show_picker(13, "Select left folder");
             }
         }
         4 => {
@@ -1518,6 +1541,8 @@ pub fn discard_and_proceed(window: &MainWindow, state: &mut AppState) {
                     path.to_string_lossy().to_string(),
                 ));
                 run_folder_compare(window, state);
+            } else {
+                show_picker(14, "Select right folder");
             }
         }
         5 => {
@@ -2036,20 +2061,42 @@ pub fn run_plugin(window: &MainWindow, state: &AppState, command: &str) {
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_default();
 
-    // Replace placeholders in command
     let cmd = command.replace("{LEFT}", &left).replace("{RIGHT}", &right);
 
     #[cfg(target_os = "windows")]
-    let result = std::process::Command::new("cmd").args(["/C", &cmd]).spawn();
+    let result = std::process::Command::new("cmd")
+        .args(["/C", &cmd])
+        .output();
     #[cfg(not(target_os = "windows"))]
-    let result = std::process::Command::new("sh").args(["-c", &cmd]).spawn();
+    let result = std::process::Command::new("sh").args(["-c", &cmd]).output();
 
     match result {
-        Ok(_) => {
-            window.set_status_text(SharedString::from(format!("Plugin executed: {}", command)));
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            let combined = match (stdout.trim().is_empty(), stderr.trim().is_empty()) {
+                (false, false) => format!("{}\n---\n{}", stdout.trim(), stderr.trim()),
+                (false, true) => stdout.trim().to_string(),
+                (true, false) => stderr.trim().to_string(),
+                (true, true) => "(no output)".to_string(),
+            };
+            let title = format!(
+                "Plugin: {} (exit {})",
+                command,
+                output.status.code().unwrap_or(-1)
+            );
+            window.set_plugin_output_title(SharedString::from(title));
+            window.set_plugin_output_text(SharedString::from(combined));
+            window.set_show_plugin_output(true);
+            window.set_status_text(SharedString::from(format!(
+                "Plugin finished: exit {}",
+                output.status.code().unwrap_or(-1)
+            )));
         }
         Err(e) => {
-            window.set_status_text(SharedString::from(format!("Plugin error: {}", e)));
+            window.set_plugin_output_title(SharedString::from(format!("Plugin error")));
+            window.set_plugin_output_text(SharedString::from(e.to_string()));
+            window.set_show_plugin_output(true);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod settings;
 
 slint::include_modules!();
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use app::{
@@ -19,7 +19,7 @@ use app::{
     folder_delete_item, goto_line, last_diff, navigate_bookmark, navigate_conflict, navigate_diff,
     navigate_search, open_file_dialog, open_folder_dialog, open_folder_item, open_in_editor, redo,
     replace_all_text, replace_text, rescan, resolve_conflict_use_left, resolve_conflict_use_right,
-    run_folder_compare, run_plugin, save_file, search_text, select_diff, start_compare,
+    run_diff, run_folder_compare, run_plugin, save_file, search_text, select_diff, start_compare,
     start_three_way_compare, switch_tab, toggle_bookmark, toggle_ignore_case,
     toggle_ignore_whitespace, undo,
 };
@@ -31,6 +31,10 @@ fn main() {
     let window = MainWindow::new().unwrap();
     let state = Rc::new(RefCell::new(AppState::new()));
     let settings = Rc::new(RefCell::new(settings::AppSettings::load()));
+    // browse_ctx: tracks which Browse action is pending when path picker dialog is shown
+    // 1=open-left-file, 2=open-right-file, 3=open-left-folder, 4=open-right-folder, 5=browse-base
+    // 11=direct-open-left, 12=direct-open-right, 13=direct-open-left-folder, 14=direct-open-right-folder
+    let browse_ctx: Rc<Cell<i32>> = Rc::new(Cell::new(0));
 
     // Restore window size
     {
@@ -79,6 +83,9 @@ fn main() {
         window.set_opt_substitution_replacements(SharedString::from(sub_replacements.join("|")));
         window.set_opt_auto_rescan(s.auto_rescan);
         window.set_opt_folder_exclude_patterns(SharedString::from(&s.folder_exclude_patterns));
+        window.set_show_location_pane(s.show_location_pane);
+        window.set_show_word_diff(s.show_word_diff);
+        window.set_show_detail_pane(s.show_detail_pane);
         // Load plugin list as pipe-separated "name:command" pairs
         let plugin_str: Vec<String> = s
             .plugins
@@ -210,10 +217,76 @@ fn main() {
         });
     }
 
+    // Helper: populate file browser listing from a directory path
+    fn populate_file_browser(window: &MainWindow, dir: &std::path::Path) {
+        let dir_str = dir.to_string_lossy();
+        let display_dir = dir_str.trim_end_matches('/').to_string();
+        window.set_file_browser_current_dir(SharedString::from(display_dir));
+        window.set_file_browser_selected_index(-1);
+
+        let mut dirs: Vec<String> = Vec::new();
+        let mut files: Vec<String> = Vec::new();
+        if let Ok(rd) = std::fs::read_dir(dir) {
+            for entry in rd.flatten() {
+                let name = entry.file_name().to_string_lossy().to_string();
+                if name.starts_with('.') {
+                    continue;
+                }
+                if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                    dirs.push(name);
+                } else {
+                    files.push(name);
+                }
+            }
+        }
+        dirs.sort();
+        files.sort();
+        let entries: Vec<FileEntryData> = dirs
+            .into_iter()
+            .map(|n| FileEntryData {
+                name: SharedString::from(n),
+                is_dir: true,
+            })
+            .chain(files.into_iter().map(|n| FileEntryData {
+                name: SharedString::from(n),
+                is_dir: false,
+            }))
+            .collect();
+        window.set_file_browser_entries(ModelRc::new(VecModel::from(entries)));
+    }
+
+    // Helper: show file browser as fallback when native dialog unavailable
+    fn show_file_browser(
+        window: &MainWindow,
+        browse_ctx: &Cell<i32>,
+        ctx: i32,
+        current: SharedString,
+        is_folder: bool,
+    ) {
+        browse_ctx.set(ctx);
+        window.set_file_browser_ctx(ctx);
+        window.set_file_browser_is_folder_mode(is_folder);
+        let start = if current.is_empty() {
+            dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/"))
+        } else {
+            let p = std::path::PathBuf::from(current.as_str());
+            if p.is_dir() {
+                p
+            } else {
+                p.parent().map(|x| x.to_path_buf()).unwrap_or_else(|| {
+                    dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/"))
+                })
+            }
+        };
+        populate_file_browser(window, &start);
+        window.set_file_browser_visible(true);
+    }
+
     // --- File operations ---
     {
         let window_weak = window.as_weak();
         let state = state.clone();
+        let browse_ctx = browse_ctx.clone();
         window.on_open_left_file(move || {
             let window = window_weak.unwrap();
             let is_folder = window.get_open_is_folder_mode();
@@ -223,14 +296,28 @@ fn main() {
                         path.to_string_lossy().to_string(),
                     ));
                     state.borrow_mut().current_tab_mut().left_folder = Some(path);
+                } else {
+                    show_file_browser(
+                        &window,
+                        &browse_ctx,
+                        3,
+                        window.get_open_left_path_input(),
+                        true,
+                    );
                 }
+            } else if let Some(path) = open_file_dialog("Select left file") {
+                window.set_open_left_path_input(SharedString::from(
+                    path.to_string_lossy().to_string(),
+                ));
+                state.borrow_mut().current_tab_mut().left_path = Some(path);
             } else {
-                if let Some(path) = open_file_dialog("Select left file") {
-                    window.set_open_left_path_input(SharedString::from(
-                        path.to_string_lossy().to_string(),
-                    ));
-                    state.borrow_mut().current_tab_mut().left_path = Some(path);
-                }
+                show_file_browser(
+                    &window,
+                    &browse_ctx,
+                    1,
+                    window.get_open_left_path_input(),
+                    false,
+                );
             }
         });
     }
@@ -238,6 +325,7 @@ fn main() {
     {
         let window_weak = window.as_weak();
         let state = state.clone();
+        let browse_ctx = browse_ctx.clone();
         window.on_open_right_file(move || {
             let window = window_weak.unwrap();
             let is_folder = window.get_open_is_folder_mode();
@@ -247,14 +335,28 @@ fn main() {
                         path.to_string_lossy().to_string(),
                     ));
                     state.borrow_mut().current_tab_mut().right_folder = Some(path);
+                } else {
+                    show_file_browser(
+                        &window,
+                        &browse_ctx,
+                        4,
+                        window.get_open_right_path_input(),
+                        true,
+                    );
                 }
+            } else if let Some(path) = open_file_dialog("Select right file") {
+                window.set_open_right_path_input(SharedString::from(
+                    path.to_string_lossy().to_string(),
+                ));
+                state.borrow_mut().current_tab_mut().right_path = Some(path);
             } else {
-                if let Some(path) = open_file_dialog("Select right file") {
-                    window.set_open_right_path_input(SharedString::from(
-                        path.to_string_lossy().to_string(),
-                    ));
-                    state.borrow_mut().current_tab_mut().right_path = Some(path);
-                }
+                show_file_browser(
+                    &window,
+                    &browse_ctx,
+                    2,
+                    window.get_open_right_path_input(),
+                    false,
+                );
             }
         });
     }
@@ -262,13 +364,22 @@ fn main() {
     {
         let window_weak = window.as_weak();
         let state = state.clone();
+        let browse_ctx = browse_ctx.clone();
         window.on_open_folder_left(move || {
+            let window = window_weak.unwrap();
             if let Some(path) = open_folder_dialog("Select left folder") {
-                let window = window_weak.unwrap();
                 window.set_open_left_path_input(SharedString::from(
                     path.to_string_lossy().to_string(),
                 ));
                 state.borrow_mut().current_tab_mut().left_folder = Some(path);
+            } else {
+                show_file_browser(
+                    &window,
+                    &browse_ctx,
+                    3,
+                    window.get_open_left_path_input(),
+                    true,
+                );
             }
         });
     }
@@ -276,13 +387,22 @@ fn main() {
     {
         let window_weak = window.as_weak();
         let state = state.clone();
+        let browse_ctx = browse_ctx.clone();
         window.on_open_folder_right(move || {
+            let window = window_weak.unwrap();
             if let Some(path) = open_folder_dialog("Select right folder") {
-                let window = window_weak.unwrap();
                 window.set_open_right_path_input(SharedString::from(
                     path.to_string_lossy().to_string(),
                 ));
                 state.borrow_mut().current_tab_mut().right_folder = Some(path);
+            } else {
+                show_file_browser(
+                    &window,
+                    &browse_ctx,
+                    4,
+                    window.get_open_right_path_input(),
+                    true,
+                );
             }
         });
     }
@@ -312,9 +432,16 @@ fn main() {
     {
         let window_weak = window.as_weak();
         let state = state.clone();
+        let browse_ctx = browse_ctx.clone();
         window.on_discard_and_proceed(move || {
             let window = window_weak.unwrap();
-            discard_and_proceed(&window, &mut state.borrow_mut());
+            let ww = window.as_weak();
+            let bc = browse_ctx.clone();
+            discard_and_proceed(&window, &mut state.borrow_mut(), move |ctx, _title| {
+                let w = ww.unwrap();
+                let is_folder = ctx == 13 || ctx == 14;
+                show_file_browser(&w, &bc, ctx, SharedString::from(""), is_folder);
+            });
         });
     }
 
@@ -708,12 +835,117 @@ fn main() {
     // Browse base file (for 3-way)
     {
         let window_weak = window.as_weak();
+        let browse_ctx = browse_ctx.clone();
         window.on_browse_base(move || {
+            let window = window_weak.unwrap();
             if let Some(path) = open_file_dialog("Select base file") {
-                let window = window_weak.unwrap();
                 window.set_open_base_path_input(SharedString::from(
                     path.to_string_lossy().to_string(),
                 ));
+            } else {
+                show_file_browser(
+                    &window,
+                    &browse_ctx,
+                    5,
+                    window.get_open_base_path_input(),
+                    false,
+                );
+            }
+        });
+    }
+
+    // File browser dialog callbacks
+    {
+        let window_weak = window.as_weak();
+        window.on_file_browser_navigate(move |path| {
+            let window = window_weak.unwrap();
+            let p = std::path::PathBuf::from(path.as_str());
+            if p.is_dir() {
+                populate_file_browser(&window, &p);
+            }
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        window.on_file_browser_go_parent(move || {
+            let window = window_weak.unwrap();
+            let current = window.get_file_browser_current_dir().to_string();
+            let p = std::path::PathBuf::from(&current);
+            if let Some(parent) = p.parent() {
+                populate_file_browser(&window, &parent.to_path_buf());
+            }
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        window.on_file_browser_cancelled(move || {
+            window_weak.unwrap().set_file_browser_visible(false);
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        let browse_ctx = browse_ctx.clone();
+        window.on_file_browser_confirmed(move |path| {
+            let window = window_weak.unwrap();
+            window.set_file_browser_visible(false);
+            let path_str = path.to_string();
+            if path_str.is_empty() {
+                return;
+            }
+            // Normalize path (remove double slashes from string concat)
+            let path_buf = std::path::PathBuf::from(&path_str);
+            let normalized = SharedString::from(path_buf.to_string_lossy().to_string());
+            let ctx = browse_ctx.get();
+            browse_ctx.set(0);
+            match ctx {
+                1 => {
+                    window.set_open_left_path_input(normalized);
+                    state.borrow_mut().current_tab_mut().left_path = Some(path_buf);
+                }
+                2 => {
+                    window.set_open_right_path_input(normalized);
+                    state.borrow_mut().current_tab_mut().right_path = Some(path_buf);
+                }
+                3 => {
+                    window.set_open_left_path_input(normalized);
+                    state.borrow_mut().current_tab_mut().left_folder = Some(path_buf);
+                }
+                4 => {
+                    window.set_open_right_path_input(normalized);
+                    state.borrow_mut().current_tab_mut().right_folder = Some(path_buf);
+                }
+                5 => {
+                    window.set_open_base_path_input(normalized);
+                }
+                11 => {
+                    let mut s = state.borrow_mut();
+                    s.current_tab_mut().left_path = Some(path_buf);
+                    s.current_tab_mut().view_mode = 0;
+                    drop(s);
+                    window.set_view_mode(0);
+                    run_diff(&window, &mut state.borrow_mut());
+                }
+                12 => {
+                    let mut s = state.borrow_mut();
+                    s.current_tab_mut().right_path = Some(path_buf);
+                    s.current_tab_mut().view_mode = 0;
+                    drop(s);
+                    window.set_view_mode(0);
+                    run_diff(&window, &mut state.borrow_mut());
+                }
+                13 => {
+                    state.borrow_mut().current_tab_mut().left_folder = Some(path_buf);
+                    run_folder_compare(&window, &mut state.borrow_mut());
+                }
+                14 => {
+                    state.borrow_mut().current_tab_mut().right_folder = Some(path_buf);
+                    run_folder_compare(&window, &mut state.borrow_mut());
+                }
+                _ => {}
             }
         });
     }
@@ -866,6 +1098,10 @@ fn main() {
             let mut s = settings.borrow_mut();
             s.window_width = size.width;
             s.window_height = size.height;
+            s.show_toolbar = window.get_show_toolbar();
+            s.show_location_pane = window.get_show_location_pane();
+            s.show_word_diff = window.get_show_word_diff();
+            s.show_detail_pane = window.get_show_detail_pane();
             s.save();
             slint::CloseRequestResponse::HideWindow
         });

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -69,6 +69,14 @@ pub struct AppSettings {
     #[serde(default)]
     pub folder_exclude_patterns: String,
 
+    // View panel visibility
+    #[serde(default = "default_true")]
+    pub show_location_pane: bool,
+    #[serde(default = "default_true")]
+    pub show_word_diff: bool,
+    #[serde(default = "default_true")]
+    pub show_detail_pane: bool,
+
     #[serde(default)]
     pub recent_files: Vec<RecentEntry>,
 }
@@ -139,6 +147,9 @@ impl Default for AppSettings {
             external_editor: String::new(),
             auto_rescan: false,
             folder_exclude_patterns: String::new(),
+            show_location_pane: true,
+            show_word_diff: true,
+            show_detail_pane: true,
             recent_files: Vec::new(),
         }
     }

--- a/translations/ja/LC_MESSAGES/winxmerge.po
+++ b/translations/ja/LC_MESSAGES/winxmerge.po
@@ -81,6 +81,42 @@ msgstr "ツールバーを隠す"
 msgid "Show Toolbar"
 msgstr "ツールバーを表示"
 
+msgid "✓ Toolbar"
+msgstr "✓ ツールバー"
+
+msgid "  Toolbar"
+msgstr "  ツールバー"
+
+msgid "✓ Line Numbers"
+msgstr "✓ 行番号"
+
+msgid "  Line Numbers"
+msgstr "  行番号"
+
+msgid "✓ Location Pane"
+msgstr "✓ ロケーションペイン"
+
+msgid "  Location Pane"
+msgstr "  ロケーションペイン"
+
+msgid "✓ Word Diff"
+msgstr "✓ ワードレベル差分"
+
+msgid "  Word Diff"
+msgstr "  ワードレベル差分"
+
+msgid "✓ Diff Detail Pane"
+msgstr "✓ 差分詳細ペイン"
+
+msgid "  Diff Detail Pane"
+msgstr "  差分詳細ペイン"
+
+msgid "Close"
+msgstr "閉じる"
+
+msgid "Plugin error"
+msgstr "プラグインエラー"
+
 msgid "✓ Ignore Whitespace"
 msgstr "✓ 空白を無視"
 
@@ -480,3 +516,25 @@ msgstr "すべて左から右にコピー"
 
 msgid "Copy All Right to Left"
 msgstr "すべて右から左にコピー"
+
+# File browser / path picker dialog
+msgid "OK"
+msgstr "OK"
+
+msgid "Parent"
+msgstr "上のフォルダ"
+
+msgid "Select left file"
+msgstr "左ファイルを選択"
+
+msgid "Select right file"
+msgstr "右ファイルを選択"
+
+msgid "Select left folder"
+msgstr "左フォルダを選択"
+
+msgid "Select right folder"
+msgstr "右フォルダを選択"
+
+msgid "Select base file"
+msgstr "ベースファイルを選択"

--- a/ui/dialogs/file-browser.slint
+++ b/ui/dialogs/file-browser.slint
@@ -1,0 +1,166 @@
+import { Button, LineEdit, ListView, Palette } from "std-widgets.slint";
+
+export global FileBrowserIcons {
+    out property <image> folder: @image-url("../icons/folder.svg");
+    out property <image> file: @image-url("../icons/file.svg");
+    out property <image> up: @image-url("../icons/up.svg");
+}
+
+export struct FileEntryData {
+    name: string,
+    is-dir: bool,
+}
+
+export component FileBrowserDialog inherits Rectangle {
+    in property <bool> visible-flag: false;
+    in-out property <string> current-dir: "";
+    in property <[FileEntryData]> entries;
+    in property <bool> is-folder-mode: false;
+    in-out property <int> selected-index: -1;
+
+    callback navigate(string);  // navigate to given path
+    callback go-parent();
+    callback confirmed(string);
+    callback cancelled();
+
+    if visible-flag : Rectangle {
+        background: #00000060;
+
+        TouchArea {
+            clicked => { root.cancelled(); }
+        }
+
+        Rectangle {
+            x: (parent.width - self.width) / 2;
+            y: (parent.height - self.height) / 2;
+            width: Math.min(600px, parent.width - 40px);
+            height: Math.min(500px, parent.height - 40px);
+            background: Palette.background;
+            border-color: Palette.border;
+            border-width: 1px;
+            border-radius: 8px;
+            drop-shadow-blur: 16px;
+            drop-shadow-color: #00000050;
+
+            TouchArea { } // absorb backdrop click
+
+            VerticalLayout {
+                padding: 12px;
+                spacing: 8px;
+
+                // Path bar
+                HorizontalLayout {
+                    spacing: 6px;
+
+                    LineEdit {
+                        horizontal-stretch: 1;
+                        text: root.current-dir;
+                        edited(t) => { root.current-dir = t; }
+                        accepted(t) => { root.navigate(t); }
+                    }
+
+                    Rectangle {
+                        width: 32px;
+                        height: 32px;
+                        border-radius: 4px;
+                        background: up-ta.has-hover ? Palette.background.darker(0.12) : transparent;
+                        border-color: Palette.border;
+                        border-width: 1px;
+
+                        Image {
+                            width: 18px;
+                            height: 18px;
+                            x: (parent.width - self.width) / 2;
+                            y: (parent.height - self.height) / 2;
+                            source: FileBrowserIcons.up;
+                            colorize: Palette.foreground;
+                        }
+
+                        up-ta := TouchArea {
+                            clicked => { root.go-parent(); }
+                        }
+                    }
+                }
+
+                Rectangle { height: 1px; background: Palette.border; }
+
+                // File / folder listing
+                ListView {
+                    vertical-stretch: 1;
+
+                    for entry[idx] in root.entries : Rectangle {
+                        height: 28px;
+                        background: idx == root.selected-index
+                            ? Palette.accent-background
+                            : row-ta.has-hover
+                                ? Palette.background.darker(0.07)
+                                : transparent;
+
+                        row-ta := TouchArea {
+                            clicked => { root.selected-index = idx; }
+                            double-clicked => {
+                                if entry.is-dir {
+                                    root.navigate(root.current-dir + "/" + entry.name);
+                                } else {
+                                    root.confirmed(root.current-dir + "/" + entry.name);
+                                }
+                            }
+                        }
+
+                        HorizontalLayout {
+                            padding-left: 8px;
+                            padding-right: 8px;
+                            spacing: 6px;
+                            alignment: start;
+
+                            Image {
+                                width: 16px;
+                                height: 16px;
+                                source: entry.is-dir ? FileBrowserIcons.folder : FileBrowserIcons.file;
+                                colorize: Palette.foreground;
+                                vertical-alignment: center;
+                            }
+
+                            Text {
+                                horizontal-stretch: 1;
+                                text: entry.name;
+                                font-size: 13px;
+                                font-family: "monospace";
+                                vertical-alignment: center;
+                                overflow: elide;
+                                color: entry.is-dir
+                                    ? Palette.foreground
+                                    : Palette.foreground.transparentize(0.2);
+                            }
+                        }
+                    }
+                }
+
+                Rectangle { height: 1px; background: Palette.border; }
+
+                // Footer buttons
+                HorizontalLayout {
+                    alignment: end;
+                    spacing: 8px;
+
+                    Button {
+                        text: @tr("Cancel");
+                        clicked => { root.cancelled(); }
+                    }
+
+                    Button {
+                        text: @tr("OK");
+                        enabled: root.is-folder-mode || root.selected-index >= 0;
+                        clicked => {
+                            if root.is-folder-mode {
+                                root.confirmed(root.current-dir);
+                            } else {
+                                root.confirmed(root.current-dir + "/" + root.entries[root.selected-index].name);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ui/dialogs/open-dialog.slint
+++ b/ui/dialogs/open-dialog.slint
@@ -1,4 +1,5 @@
 import { Button, LineEdit, Palette, CheckBox, ListView } from "std-widgets.slint";
+import { FileBrowserIcons } from "file-browser.slint";
 
 export struct RecentEntryData {
     left-path: string,
@@ -202,9 +203,11 @@ export component OpenDialog inherits Rectangle {
 
                             HorizontalLayout {
                                 spacing: 8px;
-                                Text {
-                                    text: entry.is-folder ? "📁" : "📄";
-                                    font-size: 11px;
+                                Image {
+                                    width: 14px;
+                                    height: 14px;
+                                    source: entry.is-folder ? FileBrowserIcons.folder : FileBrowserIcons.file;
+                                    colorize: Palette.foreground.transparentize(0.3);
                                     vertical-alignment: center;
                                 }
                                 Text {

--- a/ui/icons/file.svg
+++ b/ui/icons/file.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none">
+  <path d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6H6z" fill="#333333" opacity="0.12"/>
+  <path d="M14 2v6h6" stroke="#333333" stroke-width="1.5" fill="none" stroke-linejoin="round"/>
+  <path d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6H6z" stroke="#333333" stroke-width="1.5" fill="none" stroke-linejoin="round"/>
+  <line x1="8" y1="13" x2="16" y2="13" stroke="#333333" stroke-width="1.2" opacity="0.5"/>
+  <line x1="8" y1="16" x2="14" y2="16" stroke="#333333" stroke-width="1.2" opacity="0.5"/>
+</svg>

--- a/ui/icons/folder.svg
+++ b/ui/icons/folder.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none">
+  <path d="M2 6a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v2H2V6z" fill="#333333" opacity="0.3"/>
+  <path d="M2 6a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6z" fill="#333333" opacity="0.15"/>
+  <path d="M2 6a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6z" stroke="#333333" stroke-width="1.5" fill="none" stroke-linejoin="round"/>
+</svg>

--- a/ui/icons/up.svg
+++ b/ui/icons/up.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none">
+  <path d="M12 5l-7 7h4v7h6v-7h4z" fill="#333333" opacity="0.2"/>
+  <path d="M12 5l-7 7h4v7h6v-7h4z" stroke="#333333" stroke-width="1.5" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -5,9 +5,10 @@ import { FolderView, FolderItemData } from "widgets/folder-view.slint";
 import { TabBar, TabData } from "widgets/tab-bar.slint";
 import { OpenDialog, RecentEntryData } from "dialogs/open-dialog.slint";
 import { OptionsDialog } from "dialogs/options-dialog.slint";
+import { FileBrowserDialog, FileEntryData } from "dialogs/file-browser.slint";
 import { ThemeColors } from "theme.slint";
 
-export { DiffLineData, FolderItemData, TabData, RecentEntryData, ThreeWayLineData, ThemeColors }
+export { DiffLineData, FolderItemData, TabData, RecentEntryData, ThreeWayLineData, ThemeColors, FileEntryData }
 
 // Toolbar icon button: fixed 32x32 with image icon + optional overlay text
 component ToolBtn inherits Rectangle {
@@ -195,6 +196,8 @@ export component MainWindow inherits Window {
     in-out property <string> detail-left-highlights: ""; // pipe-separated char indices of changed chars
     in-out property <string> detail-right-highlights: "";
     in-out property <bool> show-detail-pane: true;
+    in-out property <bool> show-location-pane: true;
+    in-out property <bool> show-word-diff: true;
 
     // Bookmarks
     in-out property <string> bookmark-lines: ""; // comma-separated line indices
@@ -278,6 +281,23 @@ export component MainWindow inherits Window {
     callback use-left(int);
     callback use-right(int);
     callback apply-options();
+
+    // File browser dialog (WSL2-safe Browse fallback)
+    in-out property <bool> file-browser-visible: false;
+    in-out property <int> file-browser-ctx: 0; // 1=left-file 2=right-file 3=left-folder 4=right-folder 5=base
+    in-out property <bool> file-browser-is-folder-mode: false;
+    in-out property <string> file-browser-current-dir: "";
+    in property <[FileEntryData]> file-browser-entries;
+    in-out property <int> file-browser-selected-index: -1;
+    callback file-browser-navigate(string);
+    callback file-browser-go-parent();
+    callback file-browser-confirmed(string);
+    callback file-browser-cancelled();
+
+    // Plugin output dialog
+    in-out property <bool> show-plugin-output: false;
+    in-out property <string> plugin-output-title: "";
+    in-out property <string> plugin-output-text: "";
 
     // Options dialog state
     in-out property <bool> show-options-dialog: false;
@@ -378,9 +398,26 @@ export component MainWindow inherits Window {
         Menu {
             title: @tr("View");
             MenuItem {
-                title: root.show-toolbar ? @tr("Hide Toolbar") : @tr("Show Toolbar");
+                title: root.show-toolbar ? @tr("✓ Toolbar") : @tr("  Toolbar");
                 activated => { root.show-toolbar = !root.show-toolbar; }
             }
+            MenuItem {
+                title: root.opt-show-line-numbers ? @tr("✓ Line Numbers") : @tr("  Line Numbers");
+                activated => { root.opt-show-line-numbers = !root.opt-show-line-numbers; }
+            }
+            MenuItem {
+                title: root.show-location-pane ? @tr("✓ Location Pane") : @tr("  Location Pane");
+                activated => { root.show-location-pane = !root.show-location-pane; }
+            }
+            MenuItem {
+                title: root.show-word-diff ? @tr("✓ Word Diff") : @tr("  Word Diff");
+                activated => { root.show-word-diff = !root.show-word-diff; }
+            }
+            MenuItem {
+                title: root.show-detail-pane ? @tr("✓ Diff Detail Pane") : @tr("  Diff Detail Pane");
+                activated => { root.show-detail-pane = !root.show-detail-pane; }
+            }
+            MenuSeparator {}
             MenuItem {
                 title: root.ignore-whitespace ? @tr("✓ Ignore Whitespace") : @tr("  Ignore Whitespace");
                 activated => { root.toggle-ignore-whitespace(); }
@@ -653,6 +690,8 @@ export component MainWindow inherits Window {
             right-title: root.right-path != "" ? root.right-path : @tr("Right file");
             context-menu-enabled: root.opt-enable-context-menu;
             show-line-numbers: root.opt-show-line-numbers;
+            show-location-pane: root.show-location-pane;
+            show-word-diff: root.show-word-diff;
             editor-font-size: root.opt-font-size;
             editor-tab-width: root.opt-tab-width;
             copy-to-right(idx) => { root.copy-to-right(idx); }
@@ -965,6 +1004,86 @@ export component MainWindow inherits Window {
                 }
             }
         }
+    }
+
+    // Plugin output dialog
+    if root.show-plugin-output : Rectangle {
+        width: 100%; height: 100%;
+        background: #00000070;
+        TouchArea { clicked => { root.show-plugin-output = false; } }
+
+        Rectangle {
+            width: Math.min(700px, parent.width - 40px);
+            height: Math.min(500px, parent.height - 40px);
+            x: (parent.width - self.width) / 2;
+            y: (parent.height - self.height) / 2;
+            background: Palette.background;
+            border-color: Palette.border;
+            border-width: 1px;
+            border-radius: 6px;
+            drop-shadow-blur: 12px;
+            drop-shadow-color: #00000040;
+
+            VerticalLayout {
+                padding: 16px;
+                spacing: 8px;
+
+                HorizontalLayout {
+                    Text {
+                        text: root.plugin-output-title;
+                        font-size: 14px;
+                        font-weight: 700;
+                        color: Palette.foreground;
+                        horizontal-stretch: 1;
+                    }
+                    Button {
+                        text: "✕";
+                        clicked => { root.show-plugin-output = false; }
+                    }
+                }
+
+                Rectangle {
+                    vertical-stretch: 1;
+                    border-color: Palette.border;
+                    border-width: 1px;
+                    border-radius: 4px;
+                    background: Palette.background.darker(0.03);
+
+                    ScrollView {
+                        Text {
+                            text: root.plugin-output-text;
+                            font-size: 12px;
+                            font-family: "monospace";
+                            color: Palette.foreground;
+                            wrap: word-wrap;
+                        }
+                    }
+                }
+
+                HorizontalLayout {
+                    alignment: end;
+                    Button {
+                        text: @tr("Close");
+                        clicked => { root.show-plugin-output = false; }
+                    }
+                }
+            }
+        }
+    }
+
+    // File browser dialog (WSL2-safe Browse fallback)
+    FileBrowserDialog {
+        width: 100%;
+        height: 100%;
+        visible-flag: root.file-browser-visible;
+        is-folder-mode: root.file-browser-is-folder-mode;
+        current-dir <=> root.file-browser-current-dir;
+        entries: root.file-browser-entries;
+        selected-index <=> root.file-browser-selected-index;
+        navigate(path) => { root.file-browser-navigate(path); }
+        go-parent() => { root.file-browser-go-parent(); }
+        confirmed(path) => { root.file-browser-confirmed(path); }
+        cancelled() => { root.file-browser-cancelled(); }
     }
 
     // Unsaved changes confirmation overlay

--- a/ui/widgets/diff-view.slint
+++ b/ui/widgets/diff-view.slint
@@ -164,12 +164,32 @@ export component DiffView inherits Rectangle {
     in property <int> editor-font-size: 13;
     in property <int> editor-tab-width: 4;
     in property <bool> inline-edit-enabled: false;
+    in property <bool> show-location-pane: true;
+    in property <bool> show-word-diff: true;
 
     accessible-role: list;
     accessible-label: "File difference view";
 
     // Expose viewport-y for external scroll control
     in-out property <length> scroll-y <=> left-list.viewport-y;
+    // Right list scroll — exposed so we can detect user-initiated right-pane scroll
+    in-out property <length> right-scroll-y <=> right-list.viewport-y;
+
+    // Bidirectional sync: left → right (skip if already equal to avoid loops)
+    changed scroll-y => {
+        if right-list.viewport-y != scroll-y {
+            right-list.viewport-y = scroll-y;
+            mid-list.viewport-y = scroll-y;
+        }
+    }
+
+    // Bidirectional sync: right → left (skip if already equal to avoid loops)
+    changed right-scroll-y => {
+        if left-list.viewport-y != right-scroll-y {
+            left-list.viewport-y = right-scroll-y;
+            mid-list.viewport-y = right-scroll-y;
+        }
+    }
 
     callback copy-to-right(/* diff-index */ int);
     callback copy-to-left(/* diff-index */ int);
@@ -189,7 +209,7 @@ export component DiffView inherits Rectangle {
 
     // Computed widths
     property <length> merge-col-width: 32px;
-    property <length> location-pane-width: root.diff-lines.length > 0 ? 14px : 0px;
+    property <length> location-pane-width: root.diff-lines.length > 0 && root.show-location-pane ? 14px : 0px;
     property <length> available-pane-width: root.width - 2px - merge-col-width - location-pane-width;
     property <length> left-pane-width: Math.max(80px, Math.min(available-pane-width - 80px, available-pane-width * root.split-ratio));
 
@@ -289,7 +309,7 @@ export component DiffView inherits Rectangle {
 
                 left-list := ListView {
                     for line[idx] in diff-lines: DiffLineRow {
-                        height: line.left-word-diff != "" ? 36px : 24px;
+                        height: line.left-word-diff != "" && root.show-word-diff ? 36px : 24px;
                         line-no: line.left-line-no;
                         text: line.left-text;
                         status: line.status == 1 ? 0 : line.status;
@@ -298,7 +318,7 @@ export component DiffView inherits Rectangle {
                         diff-idx: line.diff-index;
                         show-line-no: root.show-line-numbers;
                         text-font-size: root.editor-font-size;
-                        word-diff: line.left-word-diff;
+                        word-diff: root.show-word-diff ? line.left-word-diff : "";
                         editable: root.inline-edit-enabled && line.left-line-no != "";
                         line-clicked(didx) => { root.select-diff(didx); }
                         text-edited(new-text) => { root.edit-left-line(idx, new-text); }
@@ -314,9 +334,8 @@ export component DiffView inherits Rectangle {
                 border-width: 1px;
 
                 mid-list := ListView {
-                    viewport-y: left-list.viewport-y;
                     for line in diff-lines: Rectangle {
-                        height: line.left-word-diff != "" || line.right-word-diff != "" ? 36px : 24px;
+                        height: (line.left-word-diff != "" || line.right-word-diff != "") && root.show-word-diff ? 36px : 24px;
                         if line.status != 0 : HorizontalLayout {
                             padding: 1px;
                             spacing: 1px;
@@ -377,9 +396,8 @@ export component DiffView inherits Rectangle {
                 }
 
                 right-list := ListView {
-                    viewport-y: left-list.viewport-y;
                     for line[idx] in diff-lines: DiffLineRow {
-                        height: line.right-word-diff != "" ? 36px : 24px;
+                        height: line.right-word-diff != "" && root.show-word-diff ? 36px : 24px;
                         line-no: line.right-line-no;
                         text: line.right-text;
                         status: line.status == 2 ? 0 : line.status;
@@ -388,7 +406,7 @@ export component DiffView inherits Rectangle {
                         diff-idx: line.diff-index;
                         show-line-no: root.show-line-numbers;
                         text-font-size: root.editor-font-size;
-                        word-diff: line.right-word-diff;
+                        word-diff: root.show-word-diff ? line.right-word-diff : "";
                         editable: root.inline-edit-enabled && line.right-line-no != "";
                         line-clicked(didx) => { root.select-diff(didx); }
                         text-edited(new-text) => { root.edit-right-line(idx, new-text); }
@@ -396,8 +414,8 @@ export component DiffView inherits Rectangle {
                 }
             }
 
-            // Location pane (minimap) - only show when there are lines
-            if root.diff-lines.length > 0 : LocationPane {
+            // Location pane (minimap)
+            if root.diff-lines.length > 0 && root.show-location-pane : LocationPane {
                 diff-lines: root.diff-lines;
                 current-diff-index: root.current-diff-index;
             }


### PR DESCRIPTION
## Summary

- **Built-in file browser**: GTK-independent file/folder picker that auto-activates when rfd/native dialog is unavailable (WSL2, headless environments). Features directory navigation, SVG folder/file icons, editable path bar, and parent directory button.
- **Bidirectional scroll sync**: Both diff panes now scroll in sync regardless of which pane the user scrolls — matches WinMerge behavior. Implemented via `changed` property handlers with equality guards to prevent infinite loops.
- **SVG icon fixes**: Replaced broken emoji icons (📁/📄) with SVG Image elements in open dialog and file browser, fixing rendering on WSL2 and environments with limited font support.
- **UX fix**: Replaced overflowing "上のフォルダ" text button with a compact 32×32 icon button (up.svg).

## Test plan

- [ ] Launch with `cargo run` — open dialog shows; Browse buttons open file browser when GTK unavailable
- [ ] Launch with `cargo run -- file1 file2` — new tab → Compare opens file browser correctly
- [ ] File browser: navigate directories, select file, confirm with OK
- [ ] File browser: folder mode (for folder comparison) — OK enabled without selecting a file
- [ ] Scroll left diff pane — right pane follows
- [ ] Scroll right diff pane — left pane follows
- [ ] Diff navigation (Alt+↓) — both panes scroll to the selected diff
- [ ] Open dialog shows folder/file icons correctly (no emoji artifacts)
- [ ] `cargo test` — all 16 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)