### PR TITLE
v0.21.0: ZIP archive comparison and Excel table view comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +234,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arboard"
@@ -628,6 +642,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +745,40 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "calamine"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138646b9af2c5d7f1804ea4bf93afc597737d2bd4f7341d67c48b03316976eb1"
+dependencies = [
+ "byteorder",
+ "codepage",
+ "encoding_rs",
+ "log",
+ "quick-xml 0.31.0",
+ "serde",
+ "zip",
+]
 
 [[package]]
 name = "calloop"
@@ -847,6 +904,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +940,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -920,6 +996,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -1059,6 +1141,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1220,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctor-lite"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1246,32 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "deflate64"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "derive_more"
@@ -1163,6 +1305,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1738,6 +1891,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,9 +1937,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1973,6 +2138,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "htmlparser"
@@ -2452,6 +2626,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "input"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2808,6 +2991,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,6 +3178,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -3531,6 +3741,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3668,6 +3888,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3773,6 +3999,16 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -4275,6 +4511,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4624,6 +4871,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "svgtypes"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4761,6 +5014,25 @@ dependencies = [
  "weezl",
  "zune-jpeg",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tiny-skia"
@@ -5128,6 +5400,12 @@ dependencies = [
  "bincode",
  "serde",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "udev"
@@ -6253,9 +6531,10 @@ dependencies = [
 
 [[package]]
 name = "winxmerge"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "arboard",
+ "calamine",
  "chardetng",
  "dirs",
  "encoding_rs",
@@ -6283,6 +6562,7 @@ dependencies = [
  "tree-sitter-toml-ng",
  "tree-sitter-typescript",
  "tree-sitter-yaml",
+ "zip",
 ]
 
 [[package]]
@@ -6493,6 +6773,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6683,6 +6972,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zerotrie"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6717,10 +7026,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winxmerge"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 
 [dependencies]
@@ -31,6 +31,8 @@ tree-sitter-c-sharp = "0.23"
 tree-sitter-yaml = "0.7"
 tree-sitter-toml-ng = "0.7"
 tree-sitter-md = "0.5"
+zip = "2"
+calamine = "0.26"
 
 [build-dependencies]
 slint-build = "1.15.1"

--- a/handover.md
+++ b/handover.md
@@ -7,8 +7,8 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 
 ## 現在の状態
 
-- **バージョン:** 0.20.0
-- **ブランチ:** `feature/v0.20.0`
+- **バージョン:** 0.21.0
+- **ブランチ:** `feature/v0.21.0`
 - **テスト:** 19件すべてパス
 - **ビルド:** `cargo build` 成功
 - **CI:** GitHub Actions（ubuntu / macOS / Windows）
@@ -36,7 +36,8 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 | v0.17.0 | #19 | 大ファイル非同期diff計算（30K行超をバックグラウンドスレッドで処理）、プラグイン実行修正（各メニュー項目が個別コマンドを実行） |
 | v0.18.0 | #20 | 差分行のみ表示モード、バイナリファイル検出、検索ハイライト（アンバー色）、セッション復元（前回の全タブを起動時に自動再オープン）、フォルダ比較最大深度設定 |
 | v0.19.0 | #21 | プラグイン非同期実行、差分統計常時表示、エンコーディング/行末文字のステータスバー表示、タブごとのdiffオプション独立化、フォルダ比較サイズ・日付フィルタ |
-| v0.20.0 | - | ステータス別差分ナビゲーション、複数行選択+ブロックコピー、CSV/TSVエクスポート+フォルダHTMLレポート、クリップボード比較、タブ並び替え、フォルダ比較サマリー |
+| v0.20.0 | #22 | ステータス別差分ナビゲーション、複数行選択+ブロックコピー、CSV/TSVエクスポート+フォルダHTMLレポート、クリップボード比較、タブ並び替え、フォルダ比較サマリー |
+| v0.21.0 | - | ZIPアーカイブ比較（仮想フォルダビューでエントリ差分表示）、Excelファイル比較（テーブルビューでセル差分表示） |
 
 ## 実装済み機能一覧
 
@@ -238,6 +239,8 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 - **エンコーディング/行末文字表示** — ステータスバー右側にファイル検出情報を表示（`UTF-8 | Shift_JIS`, `LF | CRLF`）
 - **タブごとのdiffオプション独立化** — タブ切替時に全diffオプション（ignore flags, line filters, 置換フィルタ）を独立保持・復元
 - **フォルダ比較サイズ/日付フィルタ** — 最小/最大ファイルサイズ、変更日付（YYYY-MM-DD）によるフィルタリング
+- **ZIPアーカイブ比較** — `.zip` ファイルを仮想フォルダとして比較。CRC+サイズ一致チェック、エントリの追加/削除/変更を FolderView に表示
+- **Excelファイル比較** — `.xlsx/.xls/.xlsm/.ods` を calamine で読み込み、セル値を差分比較。変更セルのみを ExcelView（テーブルビュー）に表示、シートセレクタ付き
 
 ## アーキテクチャ
 
@@ -256,6 +259,8 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 | `settings.rs` | 設定の永続化（serde_json） |
 | `models/diff_line.rs` | DiffLine, DiffResult, LineStatus |
 | `models/folder_item.rs` | FolderItem, FileCompareStatus |
+| `archive.rs` | ZIPアーカイブ比較（magic bytes検出、CRC+サイズベース差分） |
+| `excel.rs` | Excelファイル比較（calamine使用、セル差分抽出） |
 
 ### Slint UI 側 (ui/)
 
@@ -270,6 +275,7 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 | `dialogs/file-browser.slint` | 組み込みファイルブラウザ（WSL2 対応、rfd フォールバック） |
 | `theme.slint` | テーマカラー定義（ThemeColors グローバル、ライト/ダーク対応） |
 | `dialogs/options-dialog.slint` | オプション設定ダイアログ（テーマ選択含む） |
+| `widgets/excel-view.slint` | Excelセル差分テーブルビュー（シートセレクタ + ListView） |
 
 ### 状態管理の構造
 
@@ -285,7 +291,7 @@ AppState
     ├── undo_stack / redo_stack         # TextSnapshot のスタック
     ├── diff_options                    # 空白/大文字無視
     ├── search_matches                  # 検索結果
-    ├── view_mode                       # 0=diff, 1=folder, 2=open dialog
+    ├── view_mode                       # 0=diff, 1=folder, 2=open dialog, 3=3-way, 4=excel
     ├── diff_line_data                  # UI 表示用キャッシュ
     ├── folder_items / folder_item_data # フォルダ比較結果
     ├── left_encoding / right_encoding  # 検出されたエンコーディング
@@ -315,6 +321,8 @@ AppSettings (永続化)
 - **dirs 6** — 設定ファイルパス取得
 - **open 5** — 外部エディタ / デフォルトアプリでファイルを開く
 - **regex 1** — 行フィルタ・置換フィルタの正規表現
+- **zip 2** — ZIPアーカイブ読み込み・比較
+- **calamine 0.26** — Excel/ODS ファイル読み込み（xlsx, xls, xlsm, ods）
 
 ## 既知の問題・制限
 
@@ -324,18 +332,19 @@ AppSettings (永続化)
 
 ---
 
-## 次にやるべき項目 (v0.21.0+)
+## 次にやるべき項目 (v0.22.0+)
 
-1. **ドラッグ＆ドロップ** — Slint の D&D サポート待ち
-2. **差分コメント** — 差分ブロックにメモを付ける機能
-3. **比較結果フィルタ** — diff view でステータスを絞り込み表示（差分のみ/追加のみ等）
+1. **画像比較** — `image` クレートでピクセルレベル差分表示（v0.22.0 候補）
+2. **ドラッグ＆ドロップ** — Slint の D&D サポート待ち
+3. **差分コメント** — 差分ブロックにメモを付ける機能
+4. **比較結果フィルタ** — diff view でステータスを絞り込み表示（差分のみ/追加のみ等）
 
 ## ビルド・テスト手順
 
 ```bash
 asdf install                             # Rust 1.94.0 をインストール
 cargo build                              # ビルド
-cargo test                               # 16件のテスト実行
+cargo test                               # 19件のテスト実行
 cargo run                                # アプリ起動（選択ダイアログ）
 cargo run -- file1.txt file2.txt         # 2-way 比較
 cargo run -- base.txt left.txt right.txt # 3-way マージ

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,16 +5,21 @@ use std::time::SystemTime;
 
 use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 
+use crate::archive::{compare_zip_archives, is_zip_bytes, is_zip_path};
 use crate::diff::engine::{DiffOptions, compute_diff_with_options};
 use crate::diff::folder::{FolderCompareOptions, compare_folders_with_options};
 use crate::diff::three_way::{ThreeWayStatus, compute_three_way_diff};
 use crate::encoding::{decode_file, detect_eol, encode_text, is_binary};
+use crate::excel::{compare_excel, is_excel_path};
 use crate::highlight::{detect_file_type, highlight_lines};
 use crate::models::diff_line::DiffResult;
 use crate::models::diff_line::LineStatus;
 use crate::models::folder_item::FileCompareStatus;
 use crate::settings::AppSettings;
-use crate::{DiffLineData, FolderItemData, MainWindow, PluginEntryData, TabData, ThreeWayLineData};
+use crate::{
+    DiffLineData, ExcelCellData, FolderItemData, MainWindow, PluginEntryData, TabData,
+    ThreeWayLineData,
+};
 
 /// Line count threshold above which diff is computed on a background thread
 const ASYNC_DIFF_THRESHOLD: usize = 30_000;
@@ -85,6 +90,10 @@ pub struct TabState {
     pub selection_end: i32,
     /// Folder comparison summary text
     pub folder_summary: String,
+    /// Excel comparison cell diffs
+    pub excel_cells: Vec<ExcelCellData>,
+    /// Excel sheet names for the selector
+    pub excel_sheet_names: Vec<String>,
 }
 
 impl TabState {
@@ -125,6 +134,8 @@ impl TabState {
             selection_start: -1,
             selection_end: -1,
             folder_summary: String::new(),
+            excel_cells: Vec::new(),
+            excel_sheet_names: Vec::new(),
         }
     }
 }
@@ -303,6 +314,20 @@ fn restore_tab(window: &MainWindow, state: &AppState) {
         window.set_folder_summary_text(SharedString::from(&tab.folder_summary));
     }
 
+    if tab.view_mode == 4 {
+        let sheet_model: ModelRc<SharedString> = ModelRc::new(VecModel::from(
+            std::iter::once(SharedString::from(""))
+                .chain(
+                    tab.excel_sheet_names
+                        .iter()
+                        .map(|s| SharedString::from(s.as_str())),
+                )
+                .collect::<Vec<_>>(),
+        ));
+        window.set_excel_cells(ModelRc::new(VecModel::from(tab.excel_cells.clone())));
+        window.set_excel_sheet_names(sheet_model);
+    }
+
     if tab.view_mode == 2 {
         window.set_status_text(SharedString::from("Select files or folders to compare"));
         // Clear path inputs for a fresh open dialog state
@@ -356,6 +381,34 @@ pub fn run_diff(window: &MainWindow, state: &mut AppState) {
 
     let left_bytes = fs::read(&left_path).unwrap_or_default();
     let right_bytes = fs::read(&right_path).unwrap_or_default();
+
+    // ZIP archive comparison
+    if (is_zip_bytes(&left_bytes) || is_zip_path(&left_path))
+        && (is_zip_bytes(&right_bytes) || is_zip_path(&right_path))
+    {
+        run_zip_compare(
+            window,
+            state,
+            &left_bytes,
+            &right_bytes,
+            &left_path,
+            &right_path,
+        );
+        return;
+    }
+
+    // Excel comparison
+    if is_excel_path(&left_path) && is_excel_path(&right_path) {
+        run_excel_compare(
+            window,
+            state,
+            &left_bytes,
+            &right_bytes,
+            &left_path,
+            &right_path,
+        );
+        return;
+    }
 
     // Binary file detection
     if is_binary(&left_bytes) || is_binary(&right_bytes) {
@@ -2771,6 +2824,176 @@ pub fn reorder_tab(window: &MainWindow, state: &mut AppState, from: usize, to: u
     } else if from > state.active_tab && to <= state.active_tab {
         state.active_tab += 1;
     }
+    sync_tab_list(window, state);
+}
+
+fn run_zip_compare(
+    window: &MainWindow,
+    state: &mut AppState,
+    left_bytes: &[u8],
+    right_bytes: &[u8],
+    left_path: &std::path::Path,
+    right_path: &std::path::Path,
+) {
+    let left_str = left_path.to_string_lossy();
+    let right_str = right_path.to_string_lossy();
+    let items = compare_zip_archives(left_bytes, right_bytes, &left_str, &right_str);
+
+    let folder_item_data: Vec<FolderItemData> = items
+        .iter()
+        .map(|item| {
+            let status: i32 = match item.status {
+                crate::models::folder_item::FileCompareStatus::Identical => 0,
+                crate::models::folder_item::FileCompareStatus::Different => 1,
+                crate::models::folder_item::FileCompareStatus::LeftOnly => 2,
+                crate::models::folder_item::FileCompareStatus::RightOnly => 3,
+            };
+            let depth = item.relative_path.chars().filter(|&c| c == '/').count() as i32;
+            FolderItemData {
+                relative_path: SharedString::from(&item.relative_path),
+                is_directory: item.is_directory,
+                status,
+                left_size: item
+                    .left_size
+                    .map(|s| SharedString::from(format_size(s)))
+                    .unwrap_or_default(),
+                right_size: item
+                    .right_size
+                    .map(|s| SharedString::from(format_size(s)))
+                    .unwrap_or_default(),
+                left_modified: item
+                    .left_modified
+                    .as_ref()
+                    .map(|s| SharedString::from(s.as_str()))
+                    .unwrap_or_default(),
+                right_modified: item
+                    .right_modified
+                    .as_ref()
+                    .map(|s| SharedString::from(s.as_str()))
+                    .unwrap_or_default(),
+                depth,
+            }
+        })
+        .collect();
+
+    let identical = items
+        .iter()
+        .filter(|i| i.status == crate::models::folder_item::FileCompareStatus::Identical)
+        .count();
+    let different = items
+        .iter()
+        .filter(|i| i.status == crate::models::folder_item::FileCompareStatus::Different)
+        .count();
+    let left_only = items
+        .iter()
+        .filter(|i| i.status == crate::models::folder_item::FileCompareStatus::LeftOnly)
+        .count();
+    let right_only = items
+        .iter()
+        .filter(|i| i.status == crate::models::folder_item::FileCompareStatus::RightOnly)
+        .count();
+
+    let left_name = left_path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let right_name = right_path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let summary = format!(
+        "Identical: {} | Different: {} | Left only: {} | Right only: {} | Total: {}",
+        identical,
+        different,
+        left_only,
+        right_only,
+        items.len()
+    );
+
+    let tab = state.current_tab_mut();
+    tab.folder_items = items;
+    tab.folder_item_data = folder_item_data.clone();
+    tab.view_mode = 1;
+    tab.title = format!("{} ↔ {}", left_name, right_name);
+    tab.folder_summary = summary.clone();
+
+    let model = ModelRc::new(VecModel::from(folder_item_data));
+    window.set_folder_items(model);
+    window.set_view_mode(1);
+    window.set_folder_summary_text(SharedString::from(&summary));
+    window.set_status_text(SharedString::from(format!(
+        "[ZIP] {} ↔ {} — {}",
+        left_name, right_name, summary
+    )));
+    window.set_left_path(SharedString::from(left_path.to_string_lossy().to_string()));
+    window.set_right_path(SharedString::from(right_path.to_string_lossy().to_string()));
+    sync_tab_list(window, state);
+}
+
+fn run_excel_compare(
+    window: &MainWindow,
+    state: &mut AppState,
+    left_bytes: &[u8],
+    right_bytes: &[u8],
+    left_path: &std::path::Path,
+    right_path: &std::path::Path,
+) {
+    let diffs = compare_excel(left_bytes, right_bytes);
+
+    // Collect unique sheet names (preserve order via BTreeSet for determinism)
+    let mut sheet_set: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for d in &diffs {
+        sheet_set.insert(d.sheet.clone());
+    }
+    let sheet_names: Vec<String> = sheet_set.into_iter().collect();
+
+    let cell_data: Vec<ExcelCellData> = diffs
+        .iter()
+        .map(|d| ExcelCellData {
+            sheet_name: SharedString::from(&d.sheet),
+            row: d.row as i32,
+            col_name: SharedString::from(&d.col_name),
+            left_value: SharedString::from(&d.left_value),
+            right_value: SharedString::from(&d.right_value),
+            status: d.status,
+        })
+        .collect();
+
+    let left_name = left_path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let right_name = right_path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let diff_count = diffs.len();
+
+    let tab = state.current_tab_mut();
+    tab.excel_cells = cell_data.clone();
+    tab.excel_sheet_names = sheet_names.clone();
+    tab.view_mode = 4;
+    tab.title = format!("{} ↔ {}", left_name, right_name);
+
+    // Prepend empty string so user can select "All sheets"
+    let sheet_model: ModelRc<SharedString> = ModelRc::new(VecModel::from(
+        std::iter::once(SharedString::from(""))
+            .chain(sheet_names.iter().map(|s| SharedString::from(s.as_str())))
+            .collect::<Vec<_>>(),
+    ));
+
+    window.set_excel_cells(ModelRc::new(VecModel::from(cell_data)));
+    window.set_excel_sheet_names(sheet_model);
+    window.set_excel_active_sheet(SharedString::from(""));
+    window.set_view_mode(4);
+    window.set_left_path(SharedString::from(left_path.to_string_lossy().to_string()));
+    window.set_right_path(SharedString::from(right_path.to_string_lossy().to_string()));
+    window.set_status_text(SharedString::from(format!(
+        "[Excel] {} ↔ {} — {} cells changed",
+        left_name, right_name, diff_count
+    )));
     sync_tab_list(window, state);
 }
 

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,0 +1,137 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::models::folder_item::{FileCompareStatus, FolderItem};
+
+/// Returns true if the byte slice starts with the ZIP magic bytes PK\x03\x04
+pub fn is_zip_bytes(data: &[u8]) -> bool {
+    data.len() >= 4 && data[0] == 0x50 && data[1] == 0x4B && data[2] == 0x03 && data[3] == 0x04
+}
+
+/// Returns true if the path has a .zip extension
+pub fn is_zip_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("zip"))
+        .unwrap_or(false)
+}
+
+struct ZipEntry {
+    name: String,
+    size: u64,
+    crc: u32,
+}
+
+fn read_zip_entries(data: &[u8]) -> Vec<ZipEntry> {
+    let cursor = std::io::Cursor::new(data);
+    let mut archive = match zip::ZipArchive::new(cursor) {
+        Ok(a) => a,
+        Err(_) => return Vec::new(),
+    };
+    let mut entries = Vec::new();
+    for i in 0..archive.len() {
+        if let Ok(file) = archive.by_index(i) {
+            entries.push(ZipEntry {
+                name: file.name().to_string(),
+                size: file.size(),
+                crc: file.crc32(),
+            });
+        }
+    }
+    entries
+}
+
+/// Compare two ZIP archive byte slices and return FolderItem list for display in FolderView.
+pub fn compare_zip_archives(
+    left_data: &[u8],
+    right_data: &[u8],
+    left_path_str: &str,
+    right_path_str: &str,
+) -> Vec<FolderItem> {
+    let left_entries = read_zip_entries(left_data);
+    let right_entries = read_zip_entries(right_data);
+
+    let mut left_map: BTreeMap<String, &ZipEntry> = BTreeMap::new();
+    for e in &left_entries {
+        left_map.insert(e.name.clone(), e);
+    }
+    let mut right_map: BTreeMap<String, &ZipEntry> = BTreeMap::new();
+    for e in &right_entries {
+        right_map.insert(e.name.clone(), e);
+    }
+
+    let mut all_names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for e in &left_entries {
+        all_names.insert(e.name.clone());
+    }
+    for e in &right_entries {
+        all_names.insert(e.name.clone());
+    }
+
+    let mut items = Vec::new();
+    for name in &all_names {
+        let is_dir = name.ends_with('/');
+        let left = left_map.get(name);
+        let right = right_map.get(name);
+
+        let status = match (left, right) {
+            (Some(l), Some(r)) => {
+                if is_dir {
+                    FileCompareStatus::Identical
+                } else if l.crc == r.crc && l.size == r.size {
+                    FileCompareStatus::Identical
+                } else {
+                    FileCompareStatus::Different
+                }
+            }
+            (Some(_), None) => FileCompareStatus::LeftOnly,
+            (None, Some(_)) => FileCompareStatus::RightOnly,
+            (None, None) => unreachable!(),
+        };
+
+        // Compute depth from slashes
+        let depth = name.chars().filter(|&c| c == '/').count() as i32;
+        let _depth = if is_dir && depth > 0 {
+            depth - 1
+        } else {
+            depth
+        };
+
+        let left_size_str = left
+            .filter(|_| !is_dir)
+            .map(|e| format_size(e.size))
+            .unwrap_or_default();
+        let right_size_str = right
+            .filter(|_| !is_dir)
+            .map(|e| format_size(e.size))
+            .unwrap_or_default();
+
+        let left_full =
+            left.map(|_| std::path::PathBuf::from(format!("{}::{}", left_path_str, name)));
+        let right_full =
+            right.map(|_| std::path::PathBuf::from(format!("{}::{}", right_path_str, name)));
+
+        items.push(FolderItem {
+            relative_path: name.trim_end_matches('/').to_string(),
+            is_directory: is_dir,
+            status,
+            left_path: left_full,
+            right_path: right_full,
+            left_size: left.filter(|_| !is_dir).map(|e| e.size),
+            right_size: right.filter(|_| !is_dir).map(|e| e.size),
+            left_modified: left.map(|_| left_size_str.clone()),
+            right_modified: right.map(|_| right_size_str.clone()),
+        });
+    }
+    items
+}
+
+fn format_size(bytes: u64) -> String {
+    if bytes < 1024 {
+        format!("{} B", bytes)
+    } else if bytes < 1024 * 1024 {
+        format!("{:.1} KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+    }
+}

--- a/src/excel.rs
+++ b/src/excel.rs
@@ -1,0 +1,132 @@
+use calamine::{Reader, open_workbook_auto_from_rs};
+use std::io::Cursor;
+
+#[derive(Debug, Clone)]
+pub struct ExcelCellDiff {
+    pub sheet: String,
+    pub row: usize, // 1-based
+    pub col: usize, // 1-based
+    pub col_name: String,
+    pub left_value: String,
+    pub right_value: String,
+    /// 0=identical, 1=different, 2=left_only (cell/sheet exists only in left), 3=right_only
+    pub status: i32,
+}
+
+/// Returns true if the path extension is a supported Excel format
+pub fn is_excel_path(path: &std::path::Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| matches!(e.to_lowercase().as_str(), "xlsx" | "xls" | "xlsm" | "ods"))
+        .unwrap_or(false)
+}
+
+/// Convert column index (0-based) to Excel column name (A, B, ... Z, AA, AB, ...)
+pub fn col_to_name(mut col: usize) -> String {
+    let mut name = String::new();
+    loop {
+        name.insert(0, (b'A' + (col % 26) as u8) as char);
+        if col < 26 {
+            break;
+        }
+        col = col / 26 - 1;
+    }
+    name
+}
+
+fn read_workbook(data: &[u8]) -> std::collections::BTreeMap<String, Vec<Vec<String>>> {
+    let cursor = Cursor::new(data.to_vec());
+    let mut wb = match open_workbook_auto_from_rs(cursor) {
+        Ok(w) => w,
+        Err(_) => return std::collections::BTreeMap::new(),
+    };
+    let mut result = std::collections::BTreeMap::new();
+    let sheet_names = wb.sheet_names().to_vec();
+    for name in sheet_names {
+        if let Ok(range) = wb.worksheet_range(&name) {
+            let mut rows = Vec::new();
+            for row in range.rows() {
+                let cells: Vec<String> = row.iter().map(|c| c.to_string()).collect();
+                rows.push(cells);
+            }
+            result.insert(name, rows);
+        }
+    }
+    result
+}
+
+/// Compare two Excel files and return a list of cell differences.
+pub fn compare_excel(left_data: &[u8], right_data: &[u8]) -> Vec<ExcelCellDiff> {
+    let left_wb = read_workbook(left_data);
+    let right_wb = read_workbook(right_data);
+
+    let mut all_sheets: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for k in left_wb.keys() {
+        all_sheets.insert(k.clone());
+    }
+    for k in right_wb.keys() {
+        all_sheets.insert(k.clone());
+    }
+
+    let mut diffs = Vec::new();
+
+    for sheet in &all_sheets {
+        let left_rows = left_wb.get(sheet);
+        let right_rows = right_wb.get(sheet);
+
+        let max_rows = left_rows
+            .map(|r| r.len())
+            .unwrap_or(0)
+            .max(right_rows.map(|r| r.len()).unwrap_or(0));
+
+        for row_idx in 0..max_rows {
+            let left_row = left_rows.and_then(|r| r.get(row_idx));
+            let right_row = right_rows.and_then(|r| r.get(row_idx));
+
+            let max_cols = left_row
+                .map(|r| r.len())
+                .unwrap_or(0)
+                .max(right_row.map(|r| r.len()).unwrap_or(0));
+
+            for col_idx in 0..max_cols {
+                let left_val = left_row
+                    .and_then(|r| r.get(col_idx))
+                    .map(|s| s.as_str())
+                    .unwrap_or("");
+                let right_val = right_row
+                    .and_then(|r| r.get(col_idx))
+                    .map(|s| s.as_str())
+                    .unwrap_or("");
+
+                // Skip if both empty
+                if left_val.is_empty() && right_val.is_empty() {
+                    continue;
+                }
+
+                let status = if left_wb.contains_key(sheet) && !right_wb.contains_key(sheet) {
+                    2 // left_only (whole sheet)
+                } else if !left_wb.contains_key(sheet) && right_wb.contains_key(sheet) {
+                    3 // right_only (whole sheet)
+                } else if left_val == right_val {
+                    0 // identical
+                } else {
+                    1 // different
+                };
+
+                // Only emit non-identical cells
+                if status != 0 {
+                    diffs.push(ExcelCellDiff {
+                        sheet: sheet.clone(),
+                        row: row_idx + 1,
+                        col: col_idx + 1,
+                        col_name: col_to_name(col_idx),
+                        left_value: left_val.to_string(),
+                        right_value: right_val.to_string(),
+                        status,
+                    });
+                }
+            }
+        }
+    }
+    diffs
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 mod app;
+mod archive;
 mod diff;
 mod encoding;
+mod excel;
 mod export;
 mod highlight;
 mod models;

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -7,13 +7,14 @@ import { OpenDialog, RecentEntryData } from "dialogs/open-dialog.slint";
 import { OptionsDialog } from "dialogs/options-dialog.slint";
 import { FileBrowserDialog, FileEntryData } from "dialogs/file-browser.slint";
 import { ThemeColors } from "theme.slint";
+import { ExcelView, ExcelCellData } from "widgets/excel-view.slint";
 
 export struct PluginEntryData {
     name: string,
     command: string,
 }
 
-export { DiffLineData, FolderItemData, TabData, RecentEntryData, ThreeWayLineData, ThemeColors, FileEntryData }
+export { DiffLineData, ExcelCellData, FolderItemData, TabData, RecentEntryData, ThreeWayLineData, ThemeColors, FileEntryData }
 
 // Toolbar icon button: fixed 32x32 with image icon + optional overlay text
 component ToolBtn inherits Rectangle {
@@ -366,6 +367,11 @@ export component MainWindow inherits Window {
 
     // Folder comparison summary
     in-out property <string> folder-summary-text: "";
+
+    // Excel comparison (view_mode == 4)
+    in-out property <[ExcelCellData]> excel-cells;
+    in property <[string]> excel-sheet-names;
+    in-out property <string> excel-active-sheet: "";
 
     // Inline editing
     in-out property <bool> opt-inline-edit: true;
@@ -814,6 +820,14 @@ export component MainWindow inherits Window {
             prev-conflict => { root.prev-conflict(); }
             use-left(idx) => { root.use-left(idx); }
             use-right(idx) => { root.use-right(idx); }
+        }
+
+        // Excel compare view
+        if root.view-mode == 4 : ExcelView {
+            cells: root.excel-cells;
+            sheet-names: root.excel-sheet-names;
+            active-sheet <=> root.excel-active-sheet;
+            vertical-stretch: 1;
         }
 
         // Diff detail pane resize handle

--- a/ui/widgets/excel-view.slint
+++ b/ui/widgets/excel-view.slint
@@ -1,0 +1,167 @@
+import { ListView, ComboBox, Palette } from "std-widgets.slint";
+import { ThemeColors } from "../theme.slint";
+
+export struct ExcelCellData {
+    sheet-name: string,
+    row: int,
+    col-name: string,
+    left-value: string,
+    right-value: string,
+    // 0=identical, 1=different, 2=left-only, 3=right-only
+    status: int,
+}
+
+export component ExcelView inherits Rectangle {
+    in property <[ExcelCellData]> cells;
+    in property <[string]> sheet-names;
+    in-out property <string> active-sheet: "";
+
+    border-color: Palette.border;
+    border-width: 1px;
+
+    VerticalLayout {
+        // Sheet selector bar
+        Rectangle {
+            height: 36px;
+            background: Palette.background.darker(0.04);
+            border-color: Palette.border;
+            border-width: 1px;
+
+            HorizontalLayout {
+                padding-left: 8px;
+                padding-right: 8px;
+                spacing: 8px;
+                alignment: start;
+
+                Text {
+                    text: @tr("Sheet:");
+                    font-size: 12px;
+                    vertical-alignment: center;
+                }
+
+                ComboBox {
+                    width: 200px;
+                    model: root.sheet-names;
+                    current-value: root.active-sheet;
+                    selected(val) => { root.active-sheet = val; }
+                }
+            }
+        }
+
+        // Column header
+        Rectangle {
+            height: 28px;
+            background: Palette.background.darker(0.05);
+            border-color: Palette.border;
+            border-width: 1px;
+
+            HorizontalLayout {
+                padding-left: 8px;
+                padding-right: 8px;
+                spacing: 0;
+
+                Text {
+                    width: 80px;
+                    text: @tr("Sheet");
+                    font-size: 12px;
+                    font-weight: 600;
+                    vertical-alignment: center;
+                }
+                Text {
+                    width: 60px;
+                    text: @tr("Cell");
+                    font-size: 12px;
+                    font-weight: 600;
+                    vertical-alignment: center;
+                }
+                Text {
+                    width: 70px;
+                    text: @tr("Status");
+                    font-size: 12px;
+                    font-weight: 600;
+                    vertical-alignment: center;
+                    horizontal-alignment: center;
+                }
+                Text {
+                    horizontal-stretch: 1;
+                    text: @tr("Left Value");
+                    font-size: 12px;
+                    font-weight: 600;
+                    vertical-alignment: center;
+                }
+                Text {
+                    horizontal-stretch: 1;
+                    text: @tr("Right Value");
+                    font-size: 12px;
+                    font-weight: 600;
+                    vertical-alignment: center;
+                }
+            }
+        }
+
+        // Cell rows
+        ListView {
+            for cell in root.cells: Rectangle {
+                height: 24px;
+                visible: root.active-sheet == "" || root.active-sheet == cell.sheet-name;
+
+                background: ta.has-hover ? Palette.background.darker(0.04) : Palette.background;
+
+                ta := TouchArea {}
+
+                HorizontalLayout {
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    spacing: 0;
+
+                    Text {
+                        width: 80px;
+                        text: cell.sheet-name;
+                        font-size: 11px;
+                        color: Palette.foreground.transparentize(0.3);
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
+                    Text {
+                        width: 60px;
+                        text: cell.col-name + "\{cell.row}";
+                        font-size: 11px;
+                        font-family: "monospace";
+                        color: Palette.foreground;
+                        vertical-alignment: center;
+                    }
+                    Text {
+                        width: 70px;
+                        text: cell.status == 1 ? @tr("Changed") :
+                              cell.status == 2 ? @tr("Left only") :
+                              @tr("Right only");
+                        font-size: 11px;
+                        color: cell.status == 1 ? ThemeColors.modified-fg :
+                               cell.status == 2 ? ThemeColors.removed-fg :
+                               ThemeColors.added-fg;
+                        vertical-alignment: center;
+                        horizontal-alignment: center;
+                    }
+                    Text {
+                        horizontal-stretch: 1;
+                        text: cell.left-value;
+                        font-size: 11px;
+                        font-family: "monospace";
+                        color: cell.status == 2 ? ThemeColors.removed-fg : Palette.foreground;
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
+                    Text {
+                        horizontal-stretch: 1;
+                        text: cell.right-value;
+                        font-size: 11px;
+                        font-family: "monospace";
+                        color: cell.status == 3 ? ThemeColors.added-fg : Palette.foreground;
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **ZIP archive comparison**: detects `.zip` files by magic bytes (`50 4B 03 04`) or extension, compares entries by CRC + size, displays results via the existing FolderView (`view_mode=1`)
- **Excel file comparison**: reads `.xlsx` / `.xls` / `.xlsm` / `.ods` using calamine 0.26, performs cell-by-cell diff across all sheets, displays only non-identical cells in a new `ExcelView` component (`view_mode=4`) with a sheet-selector ComboBox
- ZIP/Excel detection is placed **before** the binary-detection guard in `run_diff` to avoid false-positive binary triggers
- Two new source files: `src/archive.rs`, `src/excel.rs`
- New Slint widget: `ui/widgets/excel-view.slint` with color-coded status (modified/left-only/right-only)

## New files

| File | Description |
|------|-------------|
| `src/archive.rs` | `is_zip_bytes()`, `is_zip_path()`, `compare_zip_archives()` |
| `src/excel.rs` | `is_excel_path()`, `col_to_name()`, `compare_excel()` using calamine |
| `ui/widgets/excel-view.slint` | `ExcelView` component — sheet ComboBox + column header + ListView |

## Test plan

- [ ] Open two `.zip` files → FolderView shows entries with correct Added/Removed/Modified/Identical status
- [ ] Open two `.xlsx` files → ExcelView shows only differing cells, sheet selector filters by sheet
- [ ] Open `.xls`, `.xlsm`, `.ods` files → handled correctly
- [ ] Binary files (non-ZIP) still trigger binary detection as before
- [ ] `cargo test` — 19/19 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)