### PR TITLE
v0.25.0: Diff detail pane rework, view menu enhancements, window resizing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6549,7 +6549,7 @@ dependencies = [
 
 [[package]]
 name = "winxmerge"
-version = "0.23.0"
+version = "0.25.0"
 dependencies = [
  "arboard",
  "calamine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winxmerge"
-version = "0.23.0"
+version = "0.25.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ A cross-platform file diff comparison and merge tool inspired by WinMerge, built
 - Side-by-side left/right panels + diff overlay (changed pixels in red, identical pixels in gray)
 - Continuous zoom slider (10–400%) with Fit mode and diff panel toggle
 
+### Diff Detail Pane (WinMerge-style)
+- Shows only the currently selected diff block (not the whole file)
+- Left panel for removed/modified lines, Right panel for added/modified lines
+- Single panel when only one side has changes; both panels with inner resize handle when both sides differ
+- Character-level background highlighting on changed segments within modified lines
+- Pane height resizable by dragging the top handle; inner split resizable by dragging between panels
+
 ### Diff Comments
 - Add per-block notes in the detail pane (Note field)
 - Comments persisted to session and embedded in HTML export reports
@@ -173,6 +180,15 @@ A cross-platform file diff comparison and merge tool inspired by WinMerge, built
 
 ### Session Persistence Improvements
 - Tabs restored with encoding, EOL type, tab width, diff-only mode, status filter, and diff comments
+
+### View Menu Enhancements
+- **Zoom In / Zoom Out / Reset Zoom**: adjust editor font size from the View menu (range 8–32pt)
+- **Wrap Lines**: toggle line wrapping at the window edge (View → Wrap Lines, default off)
+- Row height adapts to font size in both normal and wrap modes
+
+### Window Resizing
+- Window is now properly resizable (initial size 1200×800, minimum 600×400)
+- Diff view panes use proportional layout (no fixed-width binding loops)
 
 ### Other
 - WinMerge-style initial file selection dialog (with recent files list)

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,8 +19,8 @@ use crate::models::diff_line::LineStatus;
 use crate::models::folder_item::FileCompareStatus;
 use crate::settings::AppSettings;
 use crate::{
-    DiffLineData, ExcelCellData, FolderItemData, MainWindow, PluginEntryData, TabData,
-    ThreeWayLineData,
+    DetailLineData, DiffLineData, ExcelCellData, FolderItemData, MainWindow, PluginEntryData,
+    TabData, ThreeWayLineData, WordSegment,
 };
 
 /// Line count threshold above which diff is computed on a background thread
@@ -710,29 +710,12 @@ fn apply_diff_result(
                 .and_then(|n| right_highlights.get((n - 1) as usize).copied())
                 .unwrap_or(-1);
 
-            // Build word-diff display strings for modified lines
-            let left_word_diff =
-                if line.status == LineStatus::Modified && !line.left_word_segments.is_empty() {
-                    line.left_word_segments
-                        .iter()
-                        .filter(|s| s.changed)
-                        .map(|s| s.text.as_str())
-                        .collect::<Vec<&str>>()
-                        .join("")
-                } else {
-                    String::new()
-                };
-            let right_word_diff =
-                if line.status == LineStatus::Modified && !line.right_word_segments.is_empty() {
-                    line.right_word_segments
-                        .iter()
-                        .filter(|s| s.changed)
-                        .map(|s| s.text.as_str())
-                        .collect::<Vec<&str>>()
-                        .join("")
-                } else {
-                    String::new()
-                };
+            // Build word-diff segment strings for the detail pane.
+            // Format: \x01-separated list of ALL segments (changed and unchanged),
+            // where even indices (0,2,4,...) = unchanged, odd indices (1,3,5,...) = changed.
+            // If the first segment is changed, an empty unchanged prefix is prepended.
+            let left_word_diff = build_word_diff_string(&line.left_word_segments);
+            let right_word_diff = build_word_diff_string(&line.right_word_segments);
 
             DiffLineData {
                 left_line_no: line
@@ -1065,56 +1048,100 @@ fn update_current_diff(window: &MainWindow, state: &mut AppState, new_index: i32
     update_detail_pane(window, &model, new_index, tab);
 }
 
+/// Build a \x01-separated segment string from word diff segments.
+/// Even indices = unchanged, odd indices = changed.
+/// If the first segment is changed, an empty unchanged prefix is prepended.
+fn build_word_diff_string(segments: &[crate::models::diff_line::WordDiffSegment]) -> String {
+    if segments.is_empty() {
+        return String::new();
+    }
+    let mut parts: Vec<&str> = Vec::with_capacity(segments.len() + 1);
+    if segments[0].changed {
+        parts.push(""); // empty unchanged prefix so odd indices = changed
+    }
+    for seg in segments {
+        parts.push(&seg.text);
+    }
+    parts.join("\x01")
+}
+
+fn parse_word_diff_segments(text: &str, word_diff: &str) -> ModelRc<WordSegment> {
+    if word_diff.is_empty() {
+        return ModelRc::new(VecModel::from(vec![WordSegment {
+            text: SharedString::from(text),
+            is_changed: false,
+        }]));
+    }
+    let parts: Vec<&str> = word_diff.split('\x01').collect();
+    let segments: Vec<WordSegment> = parts
+        .iter()
+        .enumerate()
+        .map(|(i, part)| WordSegment {
+            text: SharedString::from(*part),
+            is_changed: i % 2 == 1,
+        })
+        .collect();
+    ModelRc::new(VecModel::from(segments))
+}
+
 fn update_detail_pane(
     window: &MainWindow,
     model: &ModelRc<DiffLineData>,
     diff_index: i32,
-    tab: &TabState,
+    _tab: &TabState,
 ) {
-    if diff_index < 0 || diff_index as usize >= tab.diff_positions.len() {
-        window.set_detail_left_text(SharedString::default());
-        window.set_detail_right_text(SharedString::default());
-        window.set_detail_left_highlights(SharedString::default());
-        window.set_detail_right_highlights(SharedString::default());
+    if diff_index < 0 {
+        window.set_detail_has_left(false);
+        window.set_detail_has_right(false);
+        window.set_detail_left_lines(ModelRc::new(VecModel::from(Vec::<DetailLineData>::new())));
+        window.set_detail_right_lines(ModelRc::new(VecModel::from(Vec::<DetailLineData>::new())));
         return;
     }
 
-    let vec_model = match model.as_any().downcast_ref::<VecModel<DiffLineData>>() {
-        Some(m) => m,
-        None => return,
-    };
+    let mut left_lines: Vec<DetailLineData> = Vec::new();
+    let mut right_lines: Vec<DetailLineData> = Vec::new();
 
-    // Collect all lines belonging to this diff block
-    let mut left_lines = Vec::new();
-    let mut right_lines = Vec::new();
-    let mut left_word_diffs = Vec::new();
-    let mut right_word_diffs = Vec::new();
-    for i in 0..vec_model.row_count() {
-        let row = vec_model.row_data(i).unwrap();
-        if row.diff_index == diff_index {
-            let lt = row.left_text.to_string();
-            let rt = row.right_text.to_string();
-            if !lt.is_empty() {
-                left_lines.push(lt);
-                let wd = row.left_word_diff.to_string();
-                if !wd.is_empty() {
-                    left_word_diffs.push(wd);
-                }
-            }
-            if !rt.is_empty() {
-                right_lines.push(rt);
-                let wd = row.right_word_diff.to_string();
-                if !wd.is_empty() {
-                    right_word_diffs.push(wd);
-                }
-            }
+    let count = model.row_count();
+    for i in 0..count {
+        let dl = model.row_data(i).unwrap();
+        if dl.diff_index != diff_index {
+            continue;
+        }
+        let status = dl.status; // 1=added, 2=removed, 3=modified, 4=moved
+
+        // Left side: removed(2), modified(3), moved(4)
+        if status == 2 || status == 3 || status == 4 {
+            let segments =
+                parse_word_diff_segments(&dl.left_text.to_string(), &dl.left_word_diff.to_string());
+            left_lines.push(DetailLineData {
+                segments,
+                is_current: true,
+                status,
+            });
+        }
+
+        // Right side: added(1), modified(3), moved(4)
+        if status == 1 || status == 3 || status == 4 {
+            let segments = parse_word_diff_segments(
+                &dl.right_text.to_string(),
+                &dl.right_word_diff.to_string(),
+            );
+            right_lines.push(DetailLineData {
+                segments,
+                is_current: true,
+                status,
+            });
         }
     }
 
-    window.set_detail_left_text(SharedString::from(left_lines.join("\n")));
-    window.set_detail_right_text(SharedString::from(right_lines.join("\n")));
-    window.set_detail_left_highlights(SharedString::from(left_word_diffs.join("\n")));
-    window.set_detail_right_highlights(SharedString::from(right_word_diffs.join("\n")));
+    let has_left = !left_lines.is_empty();
+    let has_right = !right_lines.is_empty();
+    window.set_detail_left_lines(ModelRc::new(VecModel::from(left_lines)));
+    window.set_detail_right_lines(ModelRc::new(VecModel::from(right_lines)));
+    window.set_detail_has_left(has_left);
+    window.set_detail_has_right(has_right);
+    window.set_detail_left_scroll_y(0.0);
+    window.set_detail_right_scroll_y(0.0);
 }
 
 fn push_undo_snapshot(state: &mut AppState, vec_model: &VecModel<DiffLineData>) {

--- a/src/excel.rs
+++ b/src/excel.rs
@@ -5,6 +5,7 @@ use std::io::Cursor;
 pub struct ExcelCellDiff {
     pub sheet: String,
     pub row: usize, // 1-based
+    #[allow(dead_code)]
     pub col: usize, // 1-based
     pub col_name: String,
     pub left_value: String,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -189,7 +189,7 @@ impl Default for AppSettings {
             font_size: default_font_size(),
             tab_width: default_tab_width(),
             show_line_numbers: true,
-            word_wrap: true,
+            word_wrap: false,
             syntax_highlighting: true,
             enable_context_menu: true,
             theme: default_theme(),

--- a/translations/ja/LC_MESSAGES/winxmerge.po
+++ b/translations/ja/LC_MESSAGES/winxmerge.po
@@ -111,6 +111,27 @@ msgstr "✓ 差分詳細ペイン"
 msgid "  Diff Detail Pane"
 msgstr "  差分詳細ペイン"
 
+msgid "✓ Diff Only"
+msgstr "✓ 差分のみ表示"
+
+msgid "  Diff Only"
+msgstr "  差分のみ表示"
+
+msgid "✓ Wrap Lines"
+msgstr "✓ 行を右端で折り返す"
+
+msgid "  Wrap Lines"
+msgstr "  行を右端で折り返す"
+
+msgid "Zoom In"
+msgstr "拡大"
+
+msgid "Zoom Out"
+msgstr "縮小"
+
+msgid "Reset Zoom"
+msgstr "ズームをリセット"
+
 msgid "Close"
 msgstr "閉じる"
 

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -1,5 +1,5 @@
-import { Button, HorizontalBox, VerticalBox, Palette, CheckBox, LineEdit, ScrollView } from "std-widgets.slint";
-import { DiffView, DiffLineData } from "widgets/diff-view.slint";
+import { Button, HorizontalBox, VerticalBox, Palette, CheckBox, LineEdit, ScrollView, ListView } from "std-widgets.slint";
+import { DiffView, DiffLineData, WordSegment } from "widgets/diff-view.slint";
 import { DiffView3Way, ThreeWayLineData } from "widgets/diff-view-3way.slint";
 import { FolderView, FolderItemData } from "widgets/folder-view.slint";
 import { TabBar, TabData } from "widgets/tab-bar.slint";
@@ -16,7 +16,13 @@ export struct PluginEntryData {
     command: string,
 }
 
-export { DiffLineData, ExcelCellData, FolderItemData, TabData, RecentEntryData, ThreeWayLineData, ThemeColors, FileEntryData }
+export struct DetailLineData {
+    segments: [WordSegment],
+    is-current: bool,
+    status: int,  // 1=added, 2=removed, 3=modified, 4=moved
+}
+
+export { DiffLineData, WordSegment, ExcelCellData, FolderItemData, TabData, RecentEntryData, ThreeWayLineData, ThemeColors, FileEntryData }
 
 // Toolbar icon button: fixed 32x32 with image icon + optional overlay text
 component ToolBtn inherits Rectangle {
@@ -141,8 +147,10 @@ export component MainWindow inherits Window {
     in-out property <string> window-title: "WinXMerge";
     title: window-title;
     icon: @image-url("../assets/icons/app-icon-256.png");
-    width: 1200px;
-    height: 800px;
+    preferred-width: 1200px;
+    preferred-height: 800px;
+    min-width: 600px;
+    min-height: 400px;
 
     // File diff properties
     in-out property <[DiffLineData]> diff-lines;
@@ -199,13 +207,21 @@ export component MainWindow inherits Window {
     // Scroll control for diff view (in pixels, negative = scroll down)
     in-out property <length> diff-scroll-y: 0px;
 
-    // Diff detail pane: shows current diff block content
-    in-out property <string> detail-left-text: "";
-    in-out property <string> detail-right-text: "";
-    in-out property <string> detail-left-highlights: ""; // word-diff string for detail pane (pipe-separated segments)
-    in-out property <string> detail-right-highlights: "";
+    // Detail pane: current diff block lines with word-diff segment highlighting
+    in property <[DetailLineData]> detail-left-lines: [];
+    in property <[DetailLineData]> detail-right-lines: [];
+    in-out property <length> detail-left-scroll-y: 0px;
+    in-out property <length> detail-right-scroll-y: 0px;
     in-out property <bool> show-detail-pane: true;
-    in-out property <length> detail-pane-height: 120px;
+    in-out property <length> detail-pane-height: 180px;
+    // Split ratio between top (Left/removed) and bottom (Right/added) in detail pane
+    in-out property <float> detail-inner-split: 0.5;
+    // Explicitly set from Rust when detail lines change (avoids model-length reactivity issues)
+    in-out property <bool> detail-has-left: false;
+    in-out property <bool> detail-has-right: false;
+    property <bool> detail-has-both: detail-has-left && detail-has-right;
+    // Available height for content panes (total minus comment row, minus inner handle if both shown)
+    property <length> detail-content-height: detail-pane-height - 32px - (detail-has-both ? 5px : 0px);
     in-out property <bool> show-location-pane: true;
     in-out property <bool> show-word-diff: true;
     in-out property <bool> opt-diff-only: false;
@@ -335,7 +351,7 @@ export component MainWindow inherits Window {
     in-out property <bool> opt-ignore-eol: false;
     in-out property <bool> opt-detect-moved-lines: true;
     in-out property <bool> opt-show-line-numbers: true;
-    in-out property <bool> opt-word-wrap: true;
+    in-out property <bool> opt-word-wrap: false;
     in-out property <bool> opt-syntax-highlighting: true;
     in-out property <int> opt-font-size: 13;
     in-out property <int> opt-tab-width: 4;
@@ -526,6 +542,24 @@ export component MainWindow inherits Window {
                 title: root.opt-diff-only ? @tr("✓ Diff Only") : @tr("  Diff Only");
                 enabled: root.view-mode == 0;
                 activated => { root.opt-diff-only = !root.opt-diff-only; }
+            }
+            MenuItem {
+                title: root.opt-word-wrap ? @tr("✓ Wrap Lines") : @tr("  Wrap Lines");
+                enabled: root.view-mode == 0;
+                activated => { root.opt-word-wrap = !root.opt-word-wrap; }
+            }
+            MenuSeparator {}
+            MenuItem {
+                title: @tr("Zoom In");
+                activated => { root.opt-font-size = Math.min(root.opt-font-size + 1, 32); }
+            }
+            MenuItem {
+                title: @tr("Zoom Out");
+                activated => { root.opt-font-size = Math.max(root.opt-font-size - 1, 8); }
+            }
+            MenuItem {
+                title: @tr("Reset Zoom");
+                activated => { root.opt-font-size = 13; }
             }
             MenuSeparator {}
             MenuItem {
@@ -1036,78 +1070,133 @@ export component MainWindow inherits Window {
             VerticalLayout {
                 spacing: 0;
 
-                // Top: Left (removed)
-                Rectangle {
-                    vertical-stretch: 1;
-                    background: root.detail-left-text != "" ? ThemeColors.removed-bg : Palette.background;
+                // Left panel: removed/modified lines of the current block
+                if root.detail-has-left : Rectangle {
+                    height: root.detail-has-both
+                        ? root.detail-content-height * root.detail-inner-split
+                        : root.detail-content-height;
                     border-color: Palette.border;
                     border-width: 1px;
+                    clip: true;
 
-                    ScrollView {
-                        HorizontalLayout {
-                            padding: 4px;
-                            spacing: 4px;
-                            alignment: start;
+                    VerticalLayout {
+                        spacing: 0;
+                        Rectangle {
+                            height: 14px;
+                            background: ThemeColors.removed-bg;
                             Text {
+                                x: 4px;
                                 text: @tr("Left");
                                 font-size: 10px;
                                 font-weight: 600;
-                                color: Palette.foreground.transparentize(0.4);
-                                vertical-alignment: top;
+                                color: ThemeColors.removed-fg;
+                                vertical-alignment: center;
                             }
-                            VerticalLayout {
-                                spacing: 0;
-                                alignment: start;
-                                Text {
-                                    text: root.detail-left-text;
-                                    font-size: 12px;
-                                    font-family: "monospace";
-                                    color: Palette.foreground;
-                                }
-                                if root.show-word-diff && root.detail-left-highlights != "" : Text {
-                                    text: root.detail-left-highlights;
-                                    font-size: 10px;
-                                    font-family: "monospace";
-                                    color: ThemeColors.removed-fg;
+                        }
+                        ListView {
+                            viewport-y: root.detail-left-scroll-y;
+                            for line in root.detail-left-lines: Rectangle {
+                                height: (root.opt-font-size + 2) * 1px;
+                                background: line.status == 3 ? ThemeColors.modified-bg-current :
+                                            line.status == 4 ? ThemeColors.moved-bg-current :
+                                            ThemeColors.removed-bg-current;
+                                HorizontalLayout {
+                                    spacing: 0;
+                                    alignment: start;
+                                    padding-left: 4px;
+                                    for seg in line.segments: Rectangle {
+                                        background: seg.is-changed ? ThemeColors.removed-fg.transparentize(0.7) : transparent;
+                                        border-radius: 2px;
+                                        Text {
+                                            text: seg.text;
+                                            font-size: root.opt-font-size * 1px;
+                                            font-family: "monospace";
+                                            color: Palette.foreground;
+                                            vertical-alignment: center;
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
                 }
 
-                // Bottom: Right (added)
-                Rectangle {
-                    vertical-stretch: 1;
-                    background: root.detail-right-text != "" ? ThemeColors.added-bg : Palette.background;
+                // Inner resize handle: only when both panels are visible
+                if root.detail-has-both : Rectangle {
+                    height: 5px;
+                    background: inner-handle-drag.has-hover ? Palette.background.darker(0.12) : transparent;
+
+                    Rectangle {
+                        y: 2px;
+                        height: 1px;
+                        background: Palette.border;
+                    }
+
+                    inner-handle-drag := TouchArea {
+                        mouse-cursor: row-resize;
+                        property <length> drag-start-y;
+                        property <float> drag-start-split;
+                        moved => {
+                            root.detail-inner-split = Math.clamp(
+                                drag-start-split + (self.mouse-y - drag-start-y) / root.detail-content-height,
+                                0.1,
+                                0.9
+                            );
+                        }
+                        pointer-event(ev) => {
+                            if ev.kind == PointerEventKind.down {
+                                drag-start-y = self.mouse-y;
+                                drag-start-split = root.detail-inner-split;
+                            }
+                        }
+                    }
+                }
+
+                // Right panel: added/modified lines of the current block
+                if root.detail-has-right : Rectangle {
+                    height: root.detail-has-both
+                        ? root.detail-content-height * (1.0 - root.detail-inner-split)
+                        : root.detail-content-height;
                     border-color: Palette.border;
                     border-width: 1px;
+                    clip: true;
 
-                    ScrollView {
-                        HorizontalLayout {
-                            padding: 4px;
-                            spacing: 4px;
-                            alignment: start;
+                    VerticalLayout {
+                        spacing: 0;
+                        Rectangle {
+                            height: 14px;
+                            background: ThemeColors.added-bg;
                             Text {
+                                x: 4px;
                                 text: @tr("Right");
                                 font-size: 10px;
                                 font-weight: 600;
-                                color: Palette.foreground.transparentize(0.4);
-                                vertical-alignment: top;
+                                color: ThemeColors.added-fg;
+                                vertical-alignment: center;
                             }
-                            VerticalLayout {
-                                spacing: 0;
-                                alignment: start;
-                                Text {
-                                    text: root.detail-right-text;
-                                    font-size: 12px;
-                                    font-family: "monospace";
-                                    color: Palette.foreground;
-                                }
-                                if root.show-word-diff && root.detail-right-highlights != "" : Text {
-                                    text: root.detail-right-highlights;
-                                    font-size: 10px;
-                                    font-family: "monospace";
-                                    color: ThemeColors.added-fg;
+                        }
+                        ListView {
+                            viewport-y: root.detail-right-scroll-y;
+                            for line in root.detail-right-lines: Rectangle {
+                                height: (root.opt-font-size + 2) * 1px;
+                                background: line.status == 3 ? ThemeColors.modified-bg-current :
+                                            line.status == 4 ? ThemeColors.moved-bg-current :
+                                            ThemeColors.added-bg-current;
+                                HorizontalLayout {
+                                    spacing: 0;
+                                    alignment: start;
+                                    padding-left: 4px;
+                                    for seg in line.segments: Rectangle {
+                                        background: seg.is-changed ? ThemeColors.added-fg.transparentize(0.7) : transparent;
+                                        border-radius: 2px;
+                                        Text {
+                                            text: seg.text;
+                                            font-size: root.opt-font-size * 1px;
+                                            font-family: "monospace";
+                                            color: Palette.foreground;
+                                            vertical-alignment: center;
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/ui/widgets/diff-view.slint
+++ b/ui/widgets/diff-view.slint
@@ -1,6 +1,11 @@
 import { VerticalBox, HorizontalBox, ListView, Palette } from "std-widgets.slint";
 import { ThemeColors } from "../theme.slint";
 
+export struct WordSegment {
+    text: string,
+    is-changed: bool,
+}
+
 export struct DiffLineData {
     left-line-no: string,
     right-line-no: string,
@@ -56,7 +61,7 @@ component DiffLineRow inherits Rectangle {
     HorizontalLayout {
         padding-left: 4px;
         padding-right: 4px;
-        spacing: 8px;
+        spacing: 4px;
 
         // Line number (clickable for diff selection)
         if show-line-no : Rectangle {
@@ -81,20 +86,7 @@ component DiffLineRow inherits Rectangle {
             }
         }
 
-        // Status marker
-        Rectangle {
-            width: 16px;
-            Text {
-                text: status == 1 ? "+" : status == 2 ? "-" : status == 3 ? "~" : status == 4 ? "↕" : " ";
-                font-size: 12px;
-                font-family: "monospace";
-                color: status == 1 ? ThemeColors.added-fg : status == 2 ? ThemeColors.removed-fg : status == 3 ? ThemeColors.modified-fg : status == 4 ? ThemeColors.moved-fg : Palette.foreground.transparentize(0.5);
-                vertical-alignment: center;
-                horizontal-alignment: center;
-            }
-        }
-
-        // Text content with word-level diff indicator
+        // Text content
         VerticalLayout {
             spacing: 0;
 
@@ -131,15 +123,6 @@ component DiffLineRow inherits Rectangle {
                 }
             }
 
-            // Word diff underline: shows changed characters with highlighting
-            if word-diff != "" : Text {
-                text: word-diff;
-                font-size: (text-font-size - 2) * 1px;
-                font-family: "monospace";
-                color: ThemeColors.modified-fg;
-                overflow: elide;
-                height: 12px;
-            }
         }
     }
 }
@@ -229,19 +212,17 @@ export component DiffView inherits Rectangle {
     // Splitter ratio (0.0 to 1.0)
     in-out property <float> split-ratio: 0.5;
 
-    // Computed widths
+    // Fixed widths only – no derived properties that depend on root.width (avoids binding loop)
     property <length> merge-col-width: 32px;
-    property <length> location-pane-width: root.diff-lines.length > 0 && root.show-location-pane ? 14px : 0px;
-    property <length> available-pane-width: root.width - 2px - merge-col-width - location-pane-width;
-    property <length> left-pane-width: Math.max(80px, Math.min(available-pane-width - 80px, available-pane-width * root.split-ratio));
 
     VerticalLayout {
         // Header
         HorizontalLayout {
             height: 28px;
 
-            Rectangle {
-                width: root.left-pane-width;
+            left-header-rect := Rectangle {
+                horizontal-stretch: root.split-ratio;
+                min-width: 80px;
                 background: Palette.background.darker(0.05);
                 border-color: Palette.border;
                 border-width: 1px;
@@ -278,14 +259,17 @@ export component DiffView inherits Rectangle {
                     moved => {
                         if self.pressed {
                             root.split-ratio = Math.max(0.1, Math.min(0.9,
-                                (root.left-pane-width + self.mouse-x - self.pressed-x) / root.available-pane-width
+                                (left-header-rect.width + self.mouse-x - self.pressed-x) /
+                                (left-header-rect.width + right-header-rect.width)
                             ));
                         }
                     }
                 }
             }
 
-            Rectangle {
+            right-header-rect := Rectangle {
+                horizontal-stretch: 1.0 - root.split-ratio;
+                min-width: 80px;
                 background: Palette.background.darker(0.05);
                 border-color: Palette.border;
                 border-width: 1px;
@@ -302,8 +286,8 @@ export component DiffView inherits Rectangle {
             }
 
             // Spacer for location pane
-            if root.diff-lines.length > 0 : Rectangle {
-                width: root.location-pane-width;
+            if root.diff-lines.length > 0 && root.show-location-pane : Rectangle {
+                width: 14px;
                 background: Palette.background.darker(0.05);
                 border-color: Palette.border;
                 border-width: 1px;
@@ -314,7 +298,8 @@ export component DiffView inherits Rectangle {
         HorizontalLayout {
             // Left pane
             Rectangle {
-                width: root.left-pane-width;
+                horizontal-stretch: root.split-ratio;
+                min-width: 80px;
 
                 if root.context-menu-enabled : ContextMenuArea {
                     Menu {
@@ -336,8 +321,7 @@ export component DiffView inherits Rectangle {
                     for line[idx] in diff-lines: DiffLineRow {
                         height: (root.diff-only-mode || root.diff-status-filter != 0) && line.status == 0 ? 0px
                               : root.diff-status-filter != 0 && line.status != 0 && line.status != root.diff-status-filter ? 0px
-                              : root.word-wrap-mode ? 72px
-                              : (line.left-word-diff != "" || line.right-word-diff != "") && root.show-word-diff ? 36px : 24px;
+                              : (root.editor-font-size + 2) * 1px;
                         line-no: line.left-line-no;
                         text: line.left-text;
                         status: line.status == 1 ? 0 : line.status;
@@ -368,8 +352,7 @@ export component DiffView inherits Rectangle {
                     for line in diff-lines: Rectangle {
                         height: (root.diff-only-mode || root.diff-status-filter != 0) && line.status == 0 ? 0px
                               : root.diff-status-filter != 0 && line.status != 0 && line.status != root.diff-status-filter ? 0px
-                              : root.word-wrap-mode ? 72px
-                              : (line.left-word-diff != "" || line.right-word-diff != "") && root.show-word-diff ? 36px : 24px;
+                              : (root.editor-font-size + 2) * 1px;
                         if line.status != 0 : HorizontalLayout {
                             padding: 1px;
                             spacing: 1px;
@@ -416,6 +399,8 @@ export component DiffView inherits Rectangle {
 
             // Right pane
             Rectangle {
+                horizontal-stretch: 1.0 - root.split-ratio;
+                min-width: 80px;
                 if root.context-menu-enabled : ContextMenuArea {
                     Menu {
                         title: @tr("Context");
@@ -436,8 +421,7 @@ export component DiffView inherits Rectangle {
                     for line[idx] in diff-lines: DiffLineRow {
                         height: (root.diff-only-mode || root.diff-status-filter != 0) && line.status == 0 ? 0px
                               : root.diff-status-filter != 0 && line.status != 0 && line.status != root.diff-status-filter ? 0px
-                              : root.word-wrap-mode ? 72px
-                              : (line.left-word-diff != "" || line.right-word-diff != "") && root.show-word-diff ? 36px : 24px;
+                              : (root.editor-font-size + 2) * 1px;
                         line-no: line.right-line-no;
                         text: line.right-text;
                         status: line.status == 2 ? 0 : line.status;


### PR DESCRIPTION
## Summary

- **Diff detail pane (WinMerge-style)**: shows only the currently selected diff block; single panel when only one side has changes; character-level word-diff background highlighting using `\x01`-separated segment format (bug fix for previous broken highlighting)
- **View menu enhancements**: Zoom In / Zoom Out / Reset Zoom (font size 8–32pt); Wrap Lines toggle (default off); row height unified to `(font-size + 2)px` regardless of wrap mode
- **Window resizing**: switched to `preferred-width/height`; fixed binding loop in `diff-view.slint` by replacing explicit `width` with `horizontal-stretch`; minimum window size 600×400
- **UX polish**: removed `+/-/~/↕` status markers from diff lines; removed word-diff secondary row from main editor; tightened row spacing; detail pane default height 180px; `detail-has-left/right` set explicitly from Rust to fix reactivity issue

## Test plan

- [ ] Open two files with additions only → Right panel shown in detail pane
- [ ] Open two files with deletions only → Left panel shown in detail pane
- [ ] Open two files with modifications → both panels shown with character highlighting
- [ ] View → Zoom In / Zoom Out / Reset Zoom changes font size
- [ ] View → Wrap Lines toggles line wrapping
- [ ] Resize window — layout scales correctly
- [ ] Drag detail pane top handle to resize height
- [ ] Drag inner handle to adjust Left/Right split
- [ ] `cargo build` produces no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)