### PR TITLE
v0.27.0: Excel export, print comments, folder sort, image overlay, export all comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4330,6 +4330,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_xlsxwriter"
+version = "0.80.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442eafa04d985ae671e027481e07a5b70fdb1b2cb5e46d9e074b67ca98e01a0a"
+dependencies = [
+ "zip",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6549,7 +6558,7 @@ dependencies = [
 
 [[package]]
 name = "winxmerge"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "arboard",
  "calamine",
@@ -6560,6 +6569,7 @@ dependencies = [
  "open",
  "regex",
  "rfd",
+ "rust_xlsxwriter",
  "serde",
  "serde_json",
  "similar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winxmerge"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2024"
 
 [dependencies]
@@ -34,6 +34,7 @@ tree-sitter-md = "0.5"
 zip = "2"
 calamine = "0.26"
 image = "0.25"
+rust_xlsxwriter = "0.80"
 
 [build-dependencies]
 slint-build = "1.15.1"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A cross-platform file diff comparison and merge tool inspired by WinMerge, built
 - Right-click context menu (copy to left/right, delete)
 - "< Back" button to return to folder view
 - **Status filter bar**: All / Identical / Different / Left only / Right only filter buttons above the file list
+- **Column sort**: click any column header (Name / Status / Left Size / Right Size / Left Modified / Right Modified) to sort; click again to toggle ascending/descending (▲▼ indicator)
 
 ### Tabs
 - Manage multiple comparisons with tabs
@@ -157,6 +158,7 @@ A cross-platform file diff comparison and merge tool inspired by WinMerge, built
 - Pixel-level comparison for PNG, JPEG, GIF, BMP, WebP, TIFF, ICO
 - Side-by-side left/right panels + diff overlay (changed pixels in red, identical pixels in gray)
 - Continuous zoom slider (10–400%) with Fit mode and diff panel toggle
+- **Blend slider** (0–100%): overlay changed-pixel highlights directly on the left/right panels at adjustable opacity
 
 ### Diff Detail Pane (WinMerge-style)
 - Shows only the currently selected diff block (not the whole file)
@@ -167,7 +169,8 @@ A cross-platform file diff comparison and merge tool inspired by WinMerge, built
 
 ### Diff Comments
 - Add per-block notes in the detail pane (Note field)
-- Comments persisted to session and embedded in HTML export reports
+- Comments persisted to session and embedded in HTML / Excel export reports
+- **Export All Comments**: File → Export All Comments (CSV/JSON)... — collects all comments across all tabs and saves as CSV or JSON
 
 ### App Icon
 - Custom "Diff Panels" icon (cross-platform): embedded in the Windows executable (.ico) and macOS bundle (.icns)
@@ -195,7 +198,8 @@ A cross-platform file diff comparison and merge tool inspired by WinMerge, built
 - WinMerge-style options dialog (Edit → Options...)
 - Right-click context menu (copy, merge, navigation)
 - Unsaved changes confirmation dialog
-- HTML diff report export (File → Export HTML Report...) with embedded diff comments
+- HTML diff report export (File → Export HTML Report...) with embedded diff comments (also included in Print)
+- Excel diff report export (File → Export Excel (.xlsx)...) with color-coded rows and comments column
 - Native menu bar (macOS / Windows)
 - Settings persistence (~/.config/winxmerge/settings.json)
 - Performance optimizations for large files
@@ -216,6 +220,7 @@ A cross-platform file diff comparison and merge tool inspired by WinMerge, built
 | Settings Persistence | [serde](https://crates.io/crates/serde) + [serde_json](https://crates.io/crates/serde_json) |
 | ZIP Comparison | [zip](https://crates.io/crates/zip) |
 | Excel Comparison | [calamine](https://crates.io/crates/calamine) |
+| Excel Export | [rust_xlsxwriter](https://crates.io/crates/rust_xlsxwriter) |
 | Image Comparison | [image](https://crates.io/crates/image) |
 
 ## Setup

--- a/handover.md
+++ b/handover.md
@@ -7,8 +7,8 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 
 ## 現在の状態
 
-- **バージョン:** 0.26.0
-- **ブランチ:** `feature/v0.26.0`
+- **バージョン:** 0.27.0
+- **ブランチ:** `feature/v0.27.0`
 - **テスト:** 19件すべてパス
 - **ビルド:** `cargo build` 成功（警告なし）
 - **CI:** GitHub Actions（Ubuntu / macOS (aarch64) / Windows）
@@ -43,6 +43,7 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 | v0.24.0 | - | アプリアイコン、差分コメントHTMLエクスポート、画像連続ズームスライダー、差分コメントセッション保存、フォルダステータスフィルタUI、ショートカットダイアログ、セッション保存改善、差分統計ミニグラフ |
 | v0.25.0 | - | 差分詳細ペイン改善（現在ブロックのみ表示・片方のみ対応・文字レベルハイライト）、View メニュー拡張（Zoom In/Out/Reset・行折り返し）、ウィンドウリサイズ対応、マージ列削除、GitHub Actions リリースワークフロー追加 |
 | v0.26.0 | - | UIアイコン修正（📋ペーストボタン→SVGアイコン化、フォルダ一覧ファイルアイコン→SVG化）、ファイルブラウザフォーカスバグ修正、リリース対象からmacOS Intel除外 |
+| v0.27.0 | - | Excel差分エクスポート（.xlsx、色分け+コメント列）、差分コメント印刷対応、フォルダ比較列ヘッダソート、画像比較オーバーレイ透明度スライダー、全タブコメント一括エクスポート（CSV/JSON） |
 
 ## 実装済み機能一覧
 
@@ -260,6 +261,11 @@ GitHub: `git@github.com:masak1yu/winxmerge.git`
 - **キーボードショートカット一覧ダイアログ** — `ui/dialogs/shortcuts-dialog.slint` 新規作成。Help メニュー → "Keyboard Shortcuts" で表示。File/Navigation/Merge/View セクション
 - **タブのセッション保存改善** — `SessionEntry` に `left_encoding`, `right_encoding`, `left_eol`, `right_eol`, `tab_width`, `diff_only`, `diff_status_filter` 追加。復元時に TabState へ反映
 - **差分統計ミニグラフ表示** — ステータスバーに緑/赤/黄の比例バー（`horizontal-stretch` 使用）を追加。`parse_diff_stats()` + `sync_diff_stats()` ヘルパーで `+A -R ~M` テキストと同時に3プロパティを更新
+- **Excelエクスポート** — `rust_xlsxwriter` で `.xlsx` 生成。ヘッダ固定・オートフィルタ・差分色付き（追加=緑/削除=赤/変更=黄/移動=青）・コメント列付き
+- **差分コメント印刷対応** — `export_html_for_print` に `comments` を渡すよう修正。印刷HTMLにもコメント行を含める
+- **フォルダ比較列ヘッダソート** — Name/Status/Left Size/Right Size/Left Modified/Right Modified の各列ヘッダをクリックでソート。同列再クリックで昇順↔降順切り替え（▲▼インジケーター表示）
+- **画像比較オーバーレイ透明度スライダー** — Blend スライダー（0〜100%）で変更画素（赤）を左右パネル上にオーバーレイ表示。fit/zoom 両モード対応。`overlay_rgba` は同一画素をα=0（透明）で生成
+- **全タブコメント一括エクスポート** — File → Export All Comments (CSV/JSON) で全タブの差分コメントをタブタイトル・ファイルパス・差分ブロック番号付きで出力
 
 ## アーキテクチャ
 
@@ -360,13 +366,9 @@ AppSettings (永続化)
 
 ---
 
-## 次にやるべき項目 (v0.25.0+)
+## 次にやるべき項目 (v0.28.0+)
 
 1. **ドラッグ＆ドロップ** — Slint の OS ファイル D&D サポート待ち（winit の DroppedFile が Slint 公開 API に未公開）
-2. **差分コメントの印刷対応** — `export_html_for_print` にもコメントを渡すよう改善
-3. **フォルダ比較のソート** — 列ヘッダクリックでの Name/Status/Size/Date ソート
-4. **画像比較のオーバーレイ透明度調整** — diff overlay の blend 強度スライダー
-5. **差分コメントの全体エクスポート** — 全タブのコメントを一括 CSV/JSON 出力
 
 ## ビルド・テスト手順
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -100,6 +100,7 @@ pub struct TabState {
     pub left_image: Option<slint::Image>,
     pub right_image: Option<slint::Image>,
     pub diff_image: Option<slint::Image>,
+    pub overlay_image: Option<slint::Image>,
     pub image_stats: String,
     /// Image dimensions for zoom support
     pub image_left_w: i32,
@@ -110,6 +111,9 @@ pub struct TabState {
     pub diff_comments: HashMap<usize, String>,
     /// Status filter for diff view (0=All, 1=Added, 2=Removed, 3=Modified, 4=Moved)
     pub diff_status_filter: i32,
+    /// Folder sort column: -1=none, 0=Name, 1=Status, 2=LeftSize, 3=RightSize, 4=LeftModified, 5=RightModified
+    pub folder_sort_column: i32,
+    pub folder_sort_ascending: bool,
 }
 
 impl TabState {
@@ -155,6 +159,7 @@ impl TabState {
             left_image: None,
             right_image: None,
             diff_image: None,
+            overlay_image: None,
             image_stats: String::new(),
             image_left_w: 0,
             image_left_h: 0,
@@ -162,6 +167,8 @@ impl TabState {
             image_right_h: 0,
             diff_comments: HashMap::new(),
             diff_status_filter: 0,
+            folder_sort_column: -1,
+            folder_sort_ascending: true,
         }
     }
 }
@@ -1630,6 +1637,135 @@ pub fn export_html_report(window: &MainWindow, state: &AppState) {
     }
 }
 
+pub fn export_xlsx_report(window: &MainWindow, state: &AppState) {
+    let tab = state.current_tab();
+
+    let left_text = tab.left_lines.join("\n") + "\n";
+    let right_text = tab.right_lines.join("\n") + "\n";
+    let result = compute_diff_with_options(&left_text, &right_text, &tab.diff_options);
+
+    let left_title = tab
+        .left_path
+        .as_ref()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| "Left".to_string());
+    let right_title = tab
+        .right_path
+        .as_ref()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| "Right".to_string());
+
+    match crate::export::export_xlsx(&result, &left_title, &right_title, &tab.diff_comments) {
+        Ok(bytes) => {
+            if let Some(path) = rfd::FileDialog::new()
+                .set_title("Export Excel Report")
+                .set_file_name("diff-report.xlsx")
+                .add_filter("Excel", &["xlsx"])
+                .save_file()
+            {
+                match fs::write(&path, &bytes) {
+                    Ok(_) => {
+                        window.set_status_text(SharedString::from(format!(
+                            "Exported to {}",
+                            path.to_string_lossy()
+                        )));
+                    }
+                    Err(e) => {
+                        window.set_status_text(SharedString::from(format!("Export error: {}", e)));
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            window.set_status_text(SharedString::from(format!("Excel export error: {}", e)));
+        }
+    }
+}
+
+/// Collect all non-empty comments from every tab
+fn collect_all_comments(state: &AppState) -> Vec<crate::export::CommentEntry> {
+    let mut entries = Vec::new();
+    for tab in &state.tabs {
+        if tab.diff_comments.is_empty() {
+            continue;
+        }
+        let left_file = tab
+            .left_path
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let right_file = tab
+            .right_path
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let tab_title = tab.title.clone();
+        let mut indices: Vec<usize> = tab.diff_comments.keys().copied().collect();
+        indices.sort_unstable();
+        for idx in indices {
+            let comment = &tab.diff_comments[&idx];
+            if comment.is_empty() {
+                continue;
+            }
+            entries.push(crate::export::CommentEntry {
+                tab_title: tab_title.clone(),
+                left_file: left_file.clone(),
+                right_file: right_file.clone(),
+                diff_block: idx,
+                comment: comment.clone(),
+            });
+        }
+    }
+    entries
+}
+
+pub fn export_all_comments(window: &MainWindow, state: &AppState, use_json: bool) {
+    let entries = collect_all_comments(state);
+    if entries.is_empty() {
+        window.set_status_text(SharedString::from("No comments to export"));
+        return;
+    }
+
+    let (content, ext, filter_name) = if use_json {
+        (
+            crate::export::export_all_comments_json(&entries),
+            "json",
+            "JSON",
+        )
+    } else {
+        (
+            crate::export::export_all_comments_csv(&entries),
+            "csv",
+            "CSV",
+        )
+    };
+
+    let filename = if use_json {
+        "diff-comments.json"
+    } else {
+        "diff-comments.csv"
+    };
+    if let Some(path) = rfd::FileDialog::new()
+        .set_title("Export All Comments")
+        .set_file_name(filename)
+        .add_filter(filter_name, &[ext])
+        .save_file()
+    {
+        match fs::write(&path, &content) {
+            Ok(_) => {
+                window.set_status_text(SharedString::from(format!(
+                    "Exported {} comment(s) to {}",
+                    entries.len(),
+                    path.to_string_lossy()
+                )));
+            }
+            Err(e) => {
+                window.set_status_text(SharedString::from(format!("Export error: {}", e)));
+            }
+        }
+    }
+}
+
 pub fn print_diff(window: &MainWindow, state: &AppState) {
     let tab = state.current_tab();
     let left_text = tab.left_lines.join("\n") + "\n";
@@ -1647,7 +1783,12 @@ pub fn print_diff(window: &MainWindow, state: &AppState) {
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|| "Right".to_string());
 
-    let html = crate::export::export_html_for_print(&result, &left_title, &right_title);
+    let html = crate::export::export_html_for_print(
+        &result,
+        &left_title,
+        &right_title,
+        &tab.diff_comments,
+    );
 
     // Write to a temp file and open in default browser
     let tmp = std::env::temp_dir().join("winxmerge-print.html");
@@ -3149,6 +3290,8 @@ fn run_image_compare(
                 rgba_to_slint_image(&result.right_rgba, result.right_width, result.right_height);
             let diff_img =
                 rgba_to_slint_image(&result.diff_rgba, result.diff_width, result.diff_height);
+            let overlay_img =
+                rgba_to_slint_image(&result.overlay_rgba, result.diff_width, result.diff_height);
 
             let tab = state.current_tab_mut();
             tab.view_mode = 5;
@@ -3157,6 +3300,7 @@ fn run_image_compare(
             tab.left_image = Some(left_img.clone());
             tab.right_image = Some(right_img.clone());
             tab.diff_image = Some(diff_img.clone());
+            tab.overlay_image = Some(overlay_img.clone());
             tab.image_left_w = result.left_width as i32;
             tab.image_left_h = result.left_height as i32;
             tab.image_right_w = result.right_width as i32;
@@ -3166,6 +3310,7 @@ fn run_image_compare(
             window.set_left_image(left_img);
             window.set_right_image(right_img);
             window.set_diff_image(diff_img);
+            window.set_overlay_image(overlay_img);
             window.set_image_stats(SharedString::from(stats.clone()));
             window.set_image_left_width(result.left_width as i32);
             window.set_image_left_height(result.left_height as i32);
@@ -3190,6 +3335,114 @@ fn format_size(bytes: u64) -> String {
     } else {
         format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
     }
+}
+
+// --- Feature: Folder sort ---
+
+/// Helper: convert folder_items to folder_item_data
+fn folder_items_to_data(items: &[crate::models::folder_item::FolderItem]) -> Vec<FolderItemData> {
+    use crate::models::folder_item::FileCompareStatus;
+    items
+        .iter()
+        .map(|item| {
+            let status: i32 = match item.status {
+                FileCompareStatus::Identical => 0,
+                FileCompareStatus::Different => 1,
+                FileCompareStatus::LeftOnly => 2,
+                FileCompareStatus::RightOnly => 3,
+            };
+            let depth = item
+                .relative_path
+                .chars()
+                .filter(|&c| c == '/' || c == '\\')
+                .count() as i32;
+            FolderItemData {
+                relative_path: SharedString::from(&item.relative_path),
+                is_directory: item.is_directory,
+                status,
+                left_size: item
+                    .left_size
+                    .map(|s| SharedString::from(format_size(s)))
+                    .unwrap_or_default(),
+                right_size: item
+                    .right_size
+                    .map(|s| SharedString::from(format_size(s)))
+                    .unwrap_or_default(),
+                left_modified: item
+                    .left_modified
+                    .as_ref()
+                    .map(|s| SharedString::from(s.as_str()))
+                    .unwrap_or_default(),
+                right_modified: item
+                    .right_modified
+                    .as_ref()
+                    .map(|s| SharedString::from(s.as_str()))
+                    .unwrap_or_default(),
+                depth,
+            }
+        })
+        .collect()
+}
+
+pub fn sort_folder(window: &MainWindow, state: &mut AppState, column: i32) {
+    use crate::models::folder_item::FileCompareStatus;
+
+    let tab = state.current_tab_mut();
+    if tab.view_mode != 1 || tab.folder_items.is_empty() {
+        return;
+    }
+
+    // Toggle direction if same column, else reset to ascending
+    if tab.folder_sort_column == column {
+        tab.folder_sort_ascending = !tab.folder_sort_ascending;
+    } else {
+        tab.folder_sort_column = column;
+        tab.folder_sort_ascending = true;
+    }
+
+    let ascending = tab.folder_sort_ascending;
+
+    tab.folder_items.sort_by(|a, b| {
+        let ord = match column {
+            0 => a
+                .relative_path
+                .to_lowercase()
+                .cmp(&b.relative_path.to_lowercase()),
+            1 => {
+                let status_ord = |s: &FileCompareStatus| match s {
+                    FileCompareStatus::Identical => 0,
+                    FileCompareStatus::Different => 1,
+                    FileCompareStatus::LeftOnly => 2,
+                    FileCompareStatus::RightOnly => 3,
+                };
+                status_ord(&a.status).cmp(&status_ord(&b.status))
+            }
+            2 => a.left_size.unwrap_or(0).cmp(&b.left_size.unwrap_or(0)),
+            3 => a.right_size.unwrap_or(0).cmp(&b.right_size.unwrap_or(0)),
+            4 => a
+                .left_modified
+                .as_deref()
+                .unwrap_or("")
+                .cmp(b.left_modified.as_deref().unwrap_or("")),
+            5 => a
+                .right_modified
+                .as_deref()
+                .unwrap_or("")
+                .cmp(b.right_modified.as_deref().unwrap_or("")),
+            _ => std::cmp::Ordering::Equal,
+        };
+        if ascending { ord } else { ord.reverse() }
+    });
+
+    let data = folder_items_to_data(&tab.folder_items);
+    tab.folder_item_data = data.clone();
+    let sort_col = tab.folder_sort_column;
+    let sort_asc = tab.folder_sort_ascending;
+
+    window.set_folder_items(ModelRc::new(VecModel::from(data)));
+    window.set_folder_selected_index(-1);
+    window.set_folder_sort_column(sort_col);
+    window.set_folder_sort_ascending(sort_asc);
 }
 
 // --- Feature: Diff block comments ---

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,17 +1,62 @@
 use crate::models::diff_line::{DiffResult, LineStatus};
 
+/// One comment entry across all tabs
+pub struct CommentEntry {
+    pub tab_title: String,
+    pub left_file: String,
+    pub right_file: String,
+    pub diff_block: usize,
+    pub comment: String,
+}
+
+/// Export all comment entries as CSV
+pub fn export_all_comments_csv(entries: &[CommentEntry]) -> String {
+    let mut out = String::from("Tab,Left File,Right File,Diff Block,Comment\n");
+    for e in entries {
+        let esc = |s: &str| format!("\"{}\"", s.replace('"', "\"\""));
+        out.push_str(&format!(
+            "{},{},{},{},{}\n",
+            esc(&e.tab_title),
+            esc(&e.left_file),
+            esc(&e.right_file),
+            e.diff_block,
+            esc(&e.comment)
+        ));
+    }
+    out
+}
+
+/// Export all comment entries as JSON
+pub fn export_all_comments_json(entries: &[CommentEntry]) -> String {
+    let esc = |s: &str| {
+        s.replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('\n', "\\n")
+    };
+    let mut out = String::from("[\n");
+    for (i, e) in entries.iter().enumerate() {
+        out.push_str(&format!(
+            "  {{\"tab\":\"{}\",\"left_file\":\"{}\",\"right_file\":\"{}\",\"diff_block\":{},\"comment\":\"{}\"}}{}",
+            esc(&e.tab_title),
+            esc(&e.left_file),
+            esc(&e.right_file),
+            e.diff_block,
+            esc(&e.comment),
+            if i + 1 < entries.len() { ",\n" } else { "\n" }
+        ));
+    }
+    out.push_str("]\n");
+    out
+}
+
 /// Generate HTML for printing: includes auto-print script and print-optimized CSS
 pub fn export_html_for_print(
     diff_result: &DiffResult,
     left_title: &str,
     right_title: &str,
+    comments: &std::collections::HashMap<usize, String>,
 ) -> String {
-    let mut html = export_html(
-        diff_result,
-        left_title,
-        right_title,
-        &std::collections::HashMap::new(),
-    );
+    let mut html = export_html(diff_result, left_title, right_title, comments);
     // Insert auto-print script before </body>
     let script = "<script>window.onload=function(){window.print();}</script>\n";
     if let Some(pos) = html.rfind("</body>") {
@@ -320,6 +365,141 @@ pub fn export_folder_html(
         escape_html(right_title),
         rows
     )
+}
+
+/// Export diff result as an Excel (.xlsx) file
+pub fn export_xlsx(
+    diff_result: &DiffResult,
+    left_title: &str,
+    right_title: &str,
+    comments: &std::collections::HashMap<usize, String>,
+) -> Result<Vec<u8>, String> {
+    use rust_xlsxwriter::{Color, Format, Workbook};
+
+    let mut workbook = Workbook::new();
+    let sheet = workbook.add_worksheet();
+    sheet.set_name("Diff Report").map_err(|e| e.to_string())?;
+
+    // Formats
+    let fmt_header = Format::new()
+        .set_bold()
+        .set_background_color(Color::RGB(0xF0F0F0));
+    let fmt_added = Format::new().set_background_color(Color::RGB(0xE6FFEC));
+    let fmt_removed = Format::new().set_background_color(Color::RGB(0xFFEBE9));
+    let fmt_modified = Format::new().set_background_color(Color::RGB(0xFFF8C5));
+    let fmt_moved = Format::new().set_background_color(Color::RGB(0xE0E8FF));
+    let fmt_comment = Format::new()
+        .set_background_color(Color::RGB(0xFFFBE6))
+        .set_italic();
+
+    // Header row
+    sheet
+        .write_string_with_format(0, 0, "Status", &fmt_header)
+        .map_err(|e| e.to_string())?;
+    sheet
+        .write_string_with_format(0, 1, "Left Line", &fmt_header)
+        .map_err(|e| e.to_string())?;
+    sheet
+        .write_string_with_format(0, 2, left_title, &fmt_header)
+        .map_err(|e| e.to_string())?;
+    sheet
+        .write_string_with_format(0, 3, "Right Line", &fmt_header)
+        .map_err(|e| e.to_string())?;
+    sheet
+        .write_string_with_format(0, 4, right_title, &fmt_header)
+        .map_err(|e| e.to_string())?;
+    sheet
+        .write_string_with_format(0, 5, "Comment", &fmt_header)
+        .map_err(|e| e.to_string())?;
+
+    // Column widths
+    sheet.set_column_width(0, 10).map_err(|e| e.to_string())?;
+    sheet.set_column_width(1, 8).map_err(|e| e.to_string())?;
+    sheet.set_column_width(2, 60).map_err(|e| e.to_string())?;
+    sheet.set_column_width(3, 8).map_err(|e| e.to_string())?;
+    sheet.set_column_width(4, 60).map_err(|e| e.to_string())?;
+    sheet.set_column_width(5, 40).map_err(|e| e.to_string())?;
+
+    let mut row: u32 = 1;
+    let mut diff_block_idx: usize = 0;
+
+    for line in &diff_result.lines {
+        let (status_str, fmt) = match line.status {
+            LineStatus::Equal => ("Equal", None),
+            LineStatus::Added => ("Added", Some(&fmt_added)),
+            LineStatus::Removed => ("Removed", Some(&fmt_removed)),
+            LineStatus::Modified => ("Modified", Some(&fmt_modified)),
+            LineStatus::Moved => ("Moved", Some(&fmt_moved)),
+        };
+
+        let left_no = line.left_line_no.map(|n| n as f64);
+        let right_no = line.right_line_no.map(|n| n as f64);
+
+        if let Some(fmt) = fmt {
+            sheet
+                .write_string_with_format(row, 0, status_str, fmt)
+                .map_err(|e| e.to_string())?;
+            if let Some(n) = left_no {
+                sheet
+                    .write_number_with_format(row, 1, n, fmt)
+                    .map_err(|e| e.to_string())?;
+            }
+            sheet
+                .write_string_with_format(row, 2, &line.left_text, fmt)
+                .map_err(|e| e.to_string())?;
+            if let Some(n) = right_no {
+                sheet
+                    .write_number_with_format(row, 3, n, fmt)
+                    .map_err(|e| e.to_string())?;
+            }
+            sheet
+                .write_string_with_format(row, 4, &line.right_text, fmt)
+                .map_err(|e| e.to_string())?;
+
+            // Comment column
+            let comment = comments
+                .get(&diff_block_idx)
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            if !comment.is_empty() {
+                sheet
+                    .write_string_with_format(row, 5, comment, fmt)
+                    .map_err(|e| e.to_string())?;
+            }
+            diff_block_idx += 1;
+        } else {
+            sheet
+                .write_string(row, 0, status_str)
+                .map_err(|e| e.to_string())?;
+            if let Some(n) = left_no {
+                sheet.write_number(row, 1, n).map_err(|e| e.to_string())?;
+            }
+            sheet
+                .write_string(row, 2, &line.left_text)
+                .map_err(|e| e.to_string())?;
+            if let Some(n) = right_no {
+                sheet.write_number(row, 3, n).map_err(|e| e.to_string())?;
+            }
+            sheet
+                .write_string(row, 4, &line.right_text)
+                .map_err(|e| e.to_string())?;
+        }
+
+        row += 1;
+    }
+
+    // Freeze header row
+    sheet.set_freeze_panes(1, 0).map_err(|e| e.to_string())?;
+
+    // Auto-filter on header
+    sheet
+        .autofilter(0, 0, row - 1, 5)
+        .map_err(|e| e.to_string())?;
+
+    // Drop unused format warnings
+    let _ = fmt_comment;
+
+    workbook.save_to_buffer().map_err(|e| e.to_string())
 }
 
 fn escape_html(s: &str) -> String {

--- a/src/image_compare.rs
+++ b/src/image_compare.rs
@@ -29,6 +29,8 @@ pub struct ImageCompareResult {
     pub diff_height: u32,
     /// Diff image: differing pixels → red, identical pixels → dimmed grayscale
     pub diff_rgba: Vec<u8>,
+    /// Overlay image: differing pixels → red (alpha=255), identical pixels → transparent (alpha=0)
+    pub overlay_rgba: Vec<u8>,
 }
 
 /// Decode both images and compute a pixel-level diff.
@@ -52,6 +54,7 @@ pub fn compare_images(left_data: &[u8], right_data: &[u8]) -> Result<ImageCompar
     let total = (dw as u64) * (dh as u64);
 
     let mut diff_rgba = vec![255u8; (dw * dh * 4) as usize];
+    let mut overlay_rgba = vec![0u8; (dw * dh * 4) as usize];
     let mut diff_pixels = 0u64;
 
     for y in 0..dh {
@@ -76,6 +79,11 @@ pub fn compare_images(left_data: &[u8], right_data: &[u8]) -> Result<ImageCompar
                 diff_rgba[idx + 1] = 0;
                 diff_rgba[idx + 2] = 0;
                 diff_rgba[idx + 3] = 255;
+                // Overlay: red with full alpha
+                overlay_rgba[idx] = 220;
+                overlay_rgba[idx + 1] = 30;
+                overlay_rgba[idx + 2] = 30;
+                overlay_rgba[idx + 3] = 255;
                 if in_left || in_right {
                     diff_pixels += 1;
                 }
@@ -104,5 +112,6 @@ pub fn compare_images(left_data: &[u8], right_data: &[u8]) -> Result<ImageCompar
         diff_width: dw,
         diff_height: dh,
         diff_rgba,
+        overlay_rgba,
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,16 +19,17 @@ use app::{
     compare_clipboard_as_left, compare_clipboard_as_right, copy_all_diffs_to_left,
     copy_all_diffs_to_right, copy_all_text, copy_current_line_text, copy_left_and_next,
     copy_right_and_next, copy_selection_to_left, copy_selection_to_right, copy_to_left,
-    copy_to_right, discard_and_proceed, edit_line, export_csv_report, export_folder_html_report,
-    export_html_report, export_patch, first_diff, folder_copy_to_left, folder_copy_to_right,
-    folder_delete_item, goto_line, last_diff, navigate_bookmark, navigate_conflict, navigate_diff,
-    navigate_diff_by_status, navigate_search, open_file_dialog, open_folder_dialog,
-    open_folder_item, open_in_editor, paste_clipboard_path_left, paste_clipboard_path_right,
-    preview_folder_item, print_diff, redo, reorder_tab, replace_all_text, replace_text, rescan,
-    resolve_conflict_use_left, resolve_conflict_use_right, run_diff, run_folder_compare,
-    run_plugin, save_file, search_text, select_diff, set_diff_comment, set_diff_filter,
-    set_row_selection, start_compare, start_three_way_compare, switch_tab, toggle_bookmark,
-    toggle_ignore_case, toggle_ignore_whitespace, undo,
+    copy_to_right, discard_and_proceed, edit_line, export_all_comments, export_csv_report,
+    export_folder_html_report, export_html_report, export_patch, export_xlsx_report, first_diff,
+    folder_copy_to_left, folder_copy_to_right, folder_delete_item, goto_line, last_diff,
+    navigate_bookmark, navigate_conflict, navigate_diff, navigate_diff_by_status, navigate_search,
+    open_file_dialog, open_folder_dialog, open_folder_item, open_in_editor,
+    paste_clipboard_path_left, paste_clipboard_path_right, preview_folder_item, print_diff, redo,
+    reorder_tab, replace_all_text, replace_text, rescan, resolve_conflict_use_left,
+    resolve_conflict_use_right, run_diff, run_folder_compare, run_plugin, save_file, search_text,
+    select_diff, set_diff_comment, set_diff_filter, set_row_selection, sort_folder, start_compare,
+    start_three_way_compare, switch_tab, toggle_bookmark, toggle_ignore_case,
+    toggle_ignore_whitespace, undo,
 };
 use slint::{ModelRc, SharedString, VecModel};
 
@@ -810,6 +811,16 @@ fn main() {
         });
     }
 
+    // Folder sort
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_folder_sort(move |col| {
+            let window = window_weak.unwrap();
+            sort_folder(&window, &mut state.borrow_mut(), col);
+        });
+    }
+
     // Copy text to clipboard (from context menu)
     {
         let window_weak = window.as_weak();
@@ -919,6 +930,36 @@ fn main() {
         window.on_export_html(move || {
             let window = window_weak.unwrap();
             export_html_report(&window, &state.borrow());
+        });
+    }
+
+    // Export All Comments CSV
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_export_comments_csv(move || {
+            let window = window_weak.unwrap();
+            export_all_comments(&window, &state.borrow(), false);
+        });
+    }
+
+    // Export All Comments JSON
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_export_comments_json(move || {
+            let window = window_weak.unwrap();
+            export_all_comments(&window, &state.borrow(), true);
+        });
+    }
+
+    // Export Excel
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_export_xlsx(move || {
+            let window = window_weak.unwrap();
+            export_xlsx_report(&window, &state.borrow());
         });
     }
 

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -265,6 +265,9 @@ export component MainWindow inherits Window {
     callback export-patch();
     callback export-csv();
     callback export-tsv();
+    callback export-xlsx();
+    callback export-comments-csv();
+    callback export-comments-json();
     callback export-folder-html();
     callback print-diff();
     callback copy-left-text();
@@ -410,6 +413,11 @@ export component MainWindow inherits Window {
     // Folder status filter (0=All, 1=Identical, 2=Different, 3=LeftOnly, 4=RightOnly)
     in-out property <int> folder-status-filter: 0;
 
+    // Folder sort state (-1=none, 0=Name, 1=Status, 2=LeftSize, 3=RightSize, 4=LeftModified, 5=RightModified)
+    in-out property <int> folder-sort-column: -1;
+    in-out property <bool> folder-sort-ascending: true;
+    callback folder-sort(int);
+
     // Clipboard paste path callbacks
     callback paste-left-path();
     callback paste-right-path();
@@ -424,6 +432,7 @@ export component MainWindow inherits Window {
     in property <image> left-image;
     in property <image> right-image;
     in property <image> diff-image;
+    in property <image> overlay-image;
     in property <string> image-stats: "";
     in property <int> image-left-width: 0;
     in property <int> image-left-height: 0;
@@ -490,7 +499,11 @@ export component MainWindow inherits Window {
             MenuItem { title: @tr("Export Patch (Unified Diff)..."); enabled: root.diff-count > 0; activated => { root.export-patch(); } }
             MenuItem { title: @tr("Export CSV..."); enabled: root.diff-count > 0; activated => { root.export-csv(); } }
             MenuItem { title: @tr("Export TSV..."); enabled: root.diff-count > 0; activated => { root.export-tsv(); } }
+            MenuItem { title: @tr("Export Excel (.xlsx)..."); enabled: root.diff-count > 0; activated => { root.export-xlsx(); } }
             MenuItem { title: @tr("Export Folder Report..."); enabled: root.view-mode == 1; activated => { root.export-folder-html(); } }
+            MenuSeparator {}
+            MenuItem { title: @tr("Export All Comments (CSV)..."); activated => { root.export-comments-csv(); } }
+            MenuItem { title: @tr("Export All Comments (JSON)..."); activated => { root.export-comments-json(); } }
         }
         Menu {
             title: @tr("Edit");
@@ -925,11 +938,14 @@ export component MainWindow inherits Window {
             selected-index: root.folder-selected-index;
             context-menu-enabled: root.opt-enable-context-menu;
             folder-status-filter <=> root.folder-status-filter;
+            sort-column: root.folder-sort-column;
+            sort-ascending: root.folder-sort-ascending;
             item-double-clicked(idx) => { root.folder-item-double-clicked(idx); }
             copy-to-right(idx) => { root.folder-copy-to-right(idx); }
             copy-to-left(idx) => { root.folder-copy-to-left(idx); }
             delete-item(idx) => { root.folder-delete-item(idx); }
             item-preview(idx) => { root.folder-item-preview(idx); }
+            sort-by(col) => { root.folder-sort(col); }
         }
 
         if root.view-mode == 1 && root.folder-preview-name != "" : Rectangle {
@@ -1020,6 +1036,7 @@ export component MainWindow inherits Window {
             left-image: root.left-image;
             right-image: root.right-image;
             diff-image: root.diff-image;
+            overlay-image: root.overlay-image;
             stats: root.image-stats;
             left-title: root.left-path != "" ? root.left-path : @tr("Left");
             right-title: root.right-path != "" ? root.right-path : @tr("Right");

--- a/ui/widgets/folder-view.slint
+++ b/ui/widgets/folder-view.slint
@@ -123,12 +123,16 @@ export component FolderView inherits Rectangle {
     in property <bool> context-menu-enabled: true;
     // 0=All, 1=Identical, 2=Different, 3=LeftOnly, 4=RightOnly
     in-out property <int> folder-status-filter: 0;
+    // sort-column: -1=none, 0=Name, 1=Status, 2=LeftSize, 3=RightSize, 4=LeftModified, 5=RightModified
+    in property <int> sort-column: -1;
+    in property <bool> sort-ascending: true;
 
     callback item-double-clicked(int);
     callback copy-to-right(int);
     callback copy-to-left(int);
     callback delete-item(int);
     callback item-preview(int);
+    callback sort-by(int);
 
     accessible-role: list;
     accessible-label: "Folder comparison results";
@@ -181,52 +185,118 @@ export component FolderView inherits Rectangle {
 
                 Rectangle { width: 16px; }
 
-                Text {
+                // Name header
+                Rectangle {
                     horizontal-stretch: 1;
-                    text: @tr("Name");
-                    font-size: 12px;
-                    font-weight: 600;
-                    vertical-alignment: center;
+                    background: col-name-ta.has-hover ? Palette.background.darker(0.1) : transparent;
+                    col-name-ta := TouchArea { clicked => { root.sort-by(0); } }
+                    HorizontalLayout {
+                        spacing: 4px;
+                        Text {
+                            text: @tr("Name");
+                            font-size: 12px; font-weight: 600; vertical-alignment: center;
+                        }
+                        Text {
+                            text: root.sort-column == 0 ? (root.sort-ascending ? "▲" : "▼") : "";
+                            font-size: 10px; vertical-alignment: center;
+                            color: Palette.accent-background;
+                        }
+                    }
                 }
-                Text {
+
+                // Status header
+                Rectangle {
                     width: 80px;
-                    text: @tr("Status");
-                    font-size: 12px;
-                    font-weight: 600;
-                    vertical-alignment: center;
-                    horizontal-alignment: center;
+                    background: col-status-ta.has-hover ? Palette.background.darker(0.1) : transparent;
+                    col-status-ta := TouchArea { clicked => { root.sort-by(1); } }
+                    HorizontalLayout {
+                        alignment: center; spacing: 4px;
+                        Text {
+                            text: @tr("Status");
+                            font-size: 12px; font-weight: 600; vertical-alignment: center; horizontal-alignment: center;
+                        }
+                        Text {
+                            text: root.sort-column == 1 ? (root.sort-ascending ? "▲" : "▼") : "";
+                            font-size: 10px; vertical-alignment: center;
+                            color: Palette.accent-background;
+                        }
+                    }
                 }
-                Text {
+
+                // Left Size header
+                Rectangle {
                     width: 70px;
-                    text: @tr("Left Size");
-                    font-size: 12px;
-                    font-weight: 600;
-                    horizontal-alignment: right;
-                    vertical-alignment: center;
+                    background: col-lsize-ta.has-hover ? Palette.background.darker(0.1) : transparent;
+                    col-lsize-ta := TouchArea { clicked => { root.sort-by(2); } }
+                    HorizontalLayout {
+                        alignment: end; spacing: 4px;
+                        Text {
+                            text: @tr("Left Size");
+                            font-size: 12px; font-weight: 600; vertical-alignment: center; horizontal-alignment: right;
+                        }
+                        Text {
+                            text: root.sort-column == 2 ? (root.sort-ascending ? "▲" : "▼") : "";
+                            font-size: 10px; vertical-alignment: center;
+                            color: Palette.accent-background;
+                        }
+                    }
                 }
-                Text {
+
+                // Right Size header
+                Rectangle {
                     width: 70px;
-                    text: @tr("Right Size");
-                    font-size: 12px;
-                    font-weight: 600;
-                    horizontal-alignment: right;
-                    vertical-alignment: center;
+                    background: col-rsize-ta.has-hover ? Palette.background.darker(0.1) : transparent;
+                    col-rsize-ta := TouchArea { clicked => { root.sort-by(3); } }
+                    HorizontalLayout {
+                        alignment: end; spacing: 4px;
+                        Text {
+                            text: @tr("Right Size");
+                            font-size: 12px; font-weight: 600; vertical-alignment: center; horizontal-alignment: right;
+                        }
+                        Text {
+                            text: root.sort-column == 3 ? (root.sort-ascending ? "▲" : "▼") : "";
+                            font-size: 10px; vertical-alignment: center;
+                            color: Palette.accent-background;
+                        }
+                    }
                 }
-                Text {
+
+                // Left Modified header
+                Rectangle {
                     width: 110px;
-                    text: @tr("Left Modified");
-                    font-size: 12px;
-                    font-weight: 600;
-                    horizontal-alignment: center;
-                    vertical-alignment: center;
+                    background: col-lmod-ta.has-hover ? Palette.background.darker(0.1) : transparent;
+                    col-lmod-ta := TouchArea { clicked => { root.sort-by(4); } }
+                    HorizontalLayout {
+                        alignment: center; spacing: 4px;
+                        Text {
+                            text: @tr("Left Modified");
+                            font-size: 12px; font-weight: 600; vertical-alignment: center; horizontal-alignment: center;
+                        }
+                        Text {
+                            text: root.sort-column == 4 ? (root.sort-ascending ? "▲" : "▼") : "";
+                            font-size: 10px; vertical-alignment: center;
+                            color: Palette.accent-background;
+                        }
+                    }
                 }
-                Text {
+
+                // Right Modified header
+                Rectangle {
                     width: 110px;
-                    text: @tr("Right Modified");
-                    font-size: 12px;
-                    font-weight: 600;
-                    horizontal-alignment: center;
-                    vertical-alignment: center;
+                    background: col-rmod-ta.has-hover ? Palette.background.darker(0.1) : transparent;
+                    col-rmod-ta := TouchArea { clicked => { root.sort-by(5); } }
+                    HorizontalLayout {
+                        alignment: center; spacing: 4px;
+                        Text {
+                            text: @tr("Right Modified");
+                            font-size: 12px; font-weight: 600; vertical-alignment: center; horizontal-alignment: center;
+                        }
+                        Text {
+                            text: root.sort-column == 5 ? (root.sort-ascending ? "▲" : "▼") : "";
+                            font-size: 10px; vertical-alignment: center;
+                            color: Palette.accent-background;
+                        }
+                    }
                 }
             }
         }

--- a/ui/widgets/image-view.slint
+++ b/ui/widgets/image-view.slint
@@ -15,6 +15,9 @@ export component ImageView inherits Rectangle {
     // 0 = Fit, >0 = zoom percentage (10..400)
     in-out property <float> zoom-percent: 0;
     in-out property <bool> show-diff-panel: true;
+    in property <image> overlay-image;
+    // 0 = no overlay, 100 = full overlay
+    in-out property <float> overlay-opacity: 0;
 
     VerticalLayout {
         // Stats bar
@@ -70,6 +73,27 @@ export component ImageView inherits Rectangle {
                     vertical-alignment: center;
                     color: Palette.foreground.transparentize(0.3);
                 }
+                // Blend slider (overlay opacity)
+                Text {
+                    text: @tr("Blend:");
+                    font-size: 11px;
+                    vertical-alignment: center;
+                    color: Palette.foreground.transparentize(0.3);
+                }
+                Slider {
+                    minimum: 0;
+                    maximum: 100;
+                    value <=> root.overlay-opacity;
+                    width: 80px;
+                    height: 20px;
+                }
+                Text {
+                    text: round(root.overlay-opacity) + "%";
+                    font-size: 10px;
+                    width: 32px;
+                    vertical-alignment: center;
+                    color: Palette.foreground.transparentize(0.3);
+                }
                 // Diff panel toggle
                 Rectangle {
                     width: 72px;
@@ -111,19 +135,38 @@ export component ImageView inherits Rectangle {
                         }
                     }
 
-                    if root.zoom-percent == 0 : Image {
-                        source: root.left-image;
-                        image-fit: contain;
-                        vertical-stretch: 1;
-                    }
-                    if root.zoom-percent > 0 : ScrollView {
+                    if root.zoom-percent == 0 : Rectangle {
                         vertical-stretch: 1;
                         Image {
                             source: root.left-image;
+                            image-fit: contain;
+                            width: 100%; height: 100%;
+                        }
+                        if root.overlay-opacity > 0 : Image {
+                            source: root.overlay-image;
+                            image-fit: contain;
+                            width: 100%; height: 100%;
+                            opacity: root.overlay-opacity / 100;
+                        }
+                    }
+                    if root.zoom-percent > 0 : ScrollView {
+                        vertical-stretch: 1;
+                        Rectangle {
                             width: (root.left-image-width * root.zoom-percent / 100) * 1px;
                             height: (root.left-image-height * root.zoom-percent / 100) * 1px;
-                            image-fit: fill;
-                            image-rendering: pixelated;
+                            Image {
+                                source: root.left-image;
+                                width: 100%; height: 100%;
+                                image-fit: fill;
+                                image-rendering: pixelated;
+                            }
+                            if root.overlay-opacity > 0 : Image {
+                                source: root.overlay-image;
+                                width: 100%; height: 100%;
+                                image-fit: fill;
+                                image-rendering: pixelated;
+                                opacity: root.overlay-opacity / 100;
+                            }
                         }
                     }
                 }
@@ -151,19 +194,38 @@ export component ImageView inherits Rectangle {
                         }
                     }
 
-                    if root.zoom-percent == 0 : Image {
-                        source: root.right-image;
-                        image-fit: contain;
-                        vertical-stretch: 1;
-                    }
-                    if root.zoom-percent > 0 : ScrollView {
+                    if root.zoom-percent == 0 : Rectangle {
                         vertical-stretch: 1;
                         Image {
                             source: root.right-image;
+                            image-fit: contain;
+                            width: 100%; height: 100%;
+                        }
+                        if root.overlay-opacity > 0 : Image {
+                            source: root.overlay-image;
+                            image-fit: contain;
+                            width: 100%; height: 100%;
+                            opacity: root.overlay-opacity / 100;
+                        }
+                    }
+                    if root.zoom-percent > 0 : ScrollView {
+                        vertical-stretch: 1;
+                        Rectangle {
                             width: (root.right-image-width * root.zoom-percent / 100) * 1px;
                             height: (root.right-image-height * root.zoom-percent / 100) * 1px;
-                            image-fit: fill;
-                            image-rendering: pixelated;
+                            Image {
+                                source: root.right-image;
+                                width: 100%; height: 100%;
+                                image-fit: fill;
+                                image-rendering: pixelated;
+                            }
+                            if root.overlay-opacity > 0 : Image {
+                                source: root.overlay-image;
+                                width: 100%; height: 100%;
+                                image-fit: fill;
+                                image-rendering: pixelated;
+                                opacity: root.overlay-opacity / 100;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- **Excel diff export** — `File → Export Excel (.xlsx)...` generates a color-coded spreadsheet (added=green, removed=red, modified=yellow, moved=blue) with header freeze, autofilter, and a Comments column. Uses `rust_xlsxwriter`.
- **Print includes diff comments** — `File → Print...` now embeds diff block comments in the printed HTML (same as HTML export).
- **Folder comparison column sort** — click any column header (Name / Status / Left Size / Right Size / Left Modified / Right Modified) to sort; click again to toggle ▲/▼. Sort is performed in Rust on the raw `FolderItem` data.
- **Image overlay blend slider** — a Blend slider (0–100%) in the image comparison stats bar overlays changed-pixel highlights (transparent for identical, red for changed) on top of both left and right panels at adjustable opacity. Works in both Fit and zoom modes.
- **Export All Comments (CSV / JSON)** — `File → Export All Comments (CSV)...` and `(JSON)...` collect all non-empty diff comments from every open tab and save them with tab title, left/right file path, diff block index, and comment text.

## Test plan

- [ ] Build: `cargo build` passes without errors
- [ ] Tests: `cargo test` — 19 passed
- [ ] Export HTML → comments appear in exported file
- [ ] Export Excel → open .xlsx in Excel/LibreOffice, verify color coding and comment column
- [ ] Print → open in browser, verify comments visible
- [ ] Folder compare → click each column header, verify sort order and ▲▼ indicator; click again for reverse
- [ ] Image compare → drag Blend slider, verify red overlay appears on both panels in Fit and zoom modes
- [ ] Export All Comments CSV/JSON → verify all tabs' comments present with correct metadata; verify "No comments" message when none exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)