### PR TITLE
v0.31.0: Fix WASM blank screen (lib+bin hybrid crate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,14 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --verbose --features desktop
 
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --verbose --features desktop
 
       - name: Check formatting
         run: cargo fmt -- --check
 
       - name: Run clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --features desktop -- -D warnings
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,11 @@ jobs:
 
       - name: Build release (Windows with icon)
         if: runner.os == 'Windows'
-        run: cargo build --release --target ${{ matrix.target }} --features embed-icon
+        run: cargo build --release --target ${{ matrix.target }} --features desktop,embed-icon
 
       - name: Build release (non-Windows)
         if: runner.os != 'Windows'
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} --features desktop
 
       - name: Package (Unix)
         if: runner.os != 'Windows'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,6 +977,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-field-offset"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6558,11 +6568,12 @@ dependencies = [
 
 [[package]]
 name = "winxmerge"
-version = "0.29.0"
+version = "0.31.0"
 dependencies = [
  "arboard",
  "calamine",
  "chardetng",
+ "console_error_panic_hook",
  "dirs",
  "encoding_rs",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "winxmerge"
-version = "0.29.0"
+version = "0.31.0"
 edition = "2024"
+
+[lib]
+crate-type = ["lib", "cdylib"]
 
 [dependencies]
 slint = "1.15.1"
@@ -46,8 +49,9 @@ wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = [
     "Document", "Element", "EventTarget",
     "HtmlInputElement", "File", "FileList", "Blob",
-    "Event", "Window",
+    "Event", "Window", "console",
 ] }
+console_error_panic_hook = "0.1"
 
 [build-dependencies]
 slint-build = "1.15.1"
@@ -63,7 +67,7 @@ identifier = "io.github.masak1yu.winxmerge"
 icon = ["assets/icons/app-icon-32.png", "assets/icons/app-icon-64.png",
         "assets/icons/app-icon-128.png", "assets/icons/app-icon-256.png",
         "assets/icons/app-icon-512.png", "assets/icons/app-icon.icns"]
-version = "0.29.0"
+version = "0.31.0"
 copyright = "WinXMerge contributors"
 category = "Developer Tool"
 short_description = "Cross-platform file diff and merge tool"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,12 @@ edition = "2024"
 [lib]
 crate-type = ["lib", "cdylib"]
 
+# The binary requires the "desktop" feature so that trunk (WASM builds)
+# skips it and falls back to building the cdylib lib target instead.
+[[bin]]
+name = "winxmerge"
+required-features = ["desktop"]
+
 [dependencies]
 slint = "1.15.1"
 similar = "2.6"
@@ -60,6 +66,8 @@ winres = { version = "0.1", optional = true }
 [features]
 # Enable on Windows builds to embed the .ico into the executable
 embed-icon = ["winres"]
+# Required to build the native desktop binary (not used for WASM/trunk builds)
+desktop = []
 
 [package.metadata.bundle]
 name = "WinXMerge"

--- a/index.html
+++ b/index.html
@@ -15,10 +15,13 @@
         }
         canvas {
             display: block;
+            width: 100%;
+            height: 100%;
         }
     </style>
     <link data-trunk rel="rust" data-wasm-opt="z" />
 </head>
 <body>
+    <canvas id="canvas"></canvas>
 </body>
 </html>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,27 @@
+//! WASM entry point for the web build (Cloudflare Pages).
+//! Desktop builds use src/main.rs (binary target).
+
+#[cfg(target_arch = "wasm32")]
+mod diff;
+#[cfg(target_arch = "wasm32")]
+mod highlight;
+#[cfg(target_arch = "wasm32")]
+mod models;
+#[cfg(target_arch = "wasm32")]
+mod wasm;
+
+#[cfg(target_arch = "wasm32")]
+slint::include_modules!();
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+/// WASM entry point — called by wasm-bindgen's __wbindgen_start after init().
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
+pub fn main() {
+    #[cfg(target_arch = "wasm32")]
+    {
+        console_error_panic_hook::set_once();
+        wasm::run();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,20 +18,12 @@ mod models;
 #[cfg(not(target_arch = "wasm32"))]
 mod settings;
 
-#[cfg(target_arch = "wasm32")]
-mod wasm;
-
 slint::include_modules!();
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::cell::{Cell, RefCell};
 #[cfg(not(target_arch = "wasm32"))]
 use std::rc::Rc;
-
-#[cfg(target_arch = "wasm32")]
-fn main() {
-    wasm::wasm_entry();
-}
 
 #[cfg(not(target_arch = "wasm32"))]
 use app::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,9 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 #[cfg(target_arch = "wasm32")]
-fn main() {}
+fn main() {
+    wasm::wasm_entry();
+}
 
 #[cfg(not(target_arch = "wasm32"))]
 use app::{

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -150,7 +150,7 @@ fn open_file_picker(callback: impl Fn(String, String) + 'static) {
     input.click();
 }
 
-pub fn wasm_entry() {
+pub fn run() {
     let window = crate::WasmApp::new().unwrap();
 
     // Shared state: diff block start-line positions and current diff index

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -150,7 +150,6 @@ fn open_file_picker(callback: impl Fn(String, String) + 'static) {
     input.click();
 }
 
-#[wasm_bindgen(start)]
 pub fn wasm_entry() {
     let window = crate::WasmApp::new().unwrap();
 


### PR DESCRIPTION
## Summary

- Convert to lib+bin hybrid crate (`crate-type = ["lib", "cdylib"]`) — the official Slint WASM pattern
- Add `src/lib.rs` as WASM entry with `#[wasm_bindgen(start)]`; in a `cdylib`, wasm-bindgen correctly handles winit's JS exception-based event loop transfer
- Remove the WASM stub from `src/main.rs` (was calling `wasm::wasm_entry()`, which was never invoked properly as `__wbindgen_start` in a binary crate)
- Rename `wasm_entry` → `run` in `src/wasm.rs`; remove diagnostic `console.log` calls
- Clean up `index.html` (remove diagnostic DOM inspection script)
- Bump version to 0.31.0

## Test plan

- [ ] `cargo check` passes (native target)
- [ ] `cargo build --target wasm32-unknown-unknown --lib` passes
- [ ] `trunk build --release` succeeds in CI
- [ ] winxmerge.pages.dev shows the app (no blank screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)