### PR TITLE
v0.34.0: 3-way diff engine rewrite & UI fixes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cargo fmt --quiet 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# CLAUDE.md — WinXMerge
+
+## Build & Test
+```bash
+cargo build --features desktop      # デスクトップビルド
+cargo test --features desktop       # 全テスト実行（必ずfeatures指定）
+cargo fmt                           # フォーマット
+```
+
+## Architecture
+- **Slint 1.15.1** UI framework + **Rust** backend
+- `src/app.rs` — アプリロジック全体（4000行超、最大ファイル）
+- `src/main.rs` — コールバック配線
+- `src/diff/three_way.rs` — 3-way diffエンジン（merge_hunks）
+- `src/diff/engine.rs` — 2-way diffエンジン
+- `ui/main.slint` — メインUI・ツールバー・ダイアログ
+- `ui/widgets/diff-view-3way.slint` — 3-wayペイン（ThreeWayLineRow）
+- `ui/widgets/diff-view.slint` — 2-wayペイン
+- VecModelが**唯一の正（authoritative）データソース**。tab内部配列は補助。
+
+## Gotchas（既知の罠）
+1. **ghost行のbase_line_no**: コピー時にbase側ghost行（base_line_no空）にテキストを入れても、`rebuild_three_way_text`がスキップする。コピー時は必ず`base_line_no`に"+"等の非空値を設定すること。
+2. **最後の行を削除すると入力不能**: `three_way_delete_line`でreal_line_countが1のときは削除禁止。
+3. **F5(rescan)でテキスト復活**: rescanは必ずVecModelから`rebuild_three_way_text`で再構築。tab.*_linesを直接使わない。
+4. **merge_hunksのファイル側レンジ計算**: hunkの`new_start/new_end`を直接使うとequal行を見落とす。`net = Σ(new_count - old_count)`で計算すること。
+5. **Slint TextInput**: 行ごとに独立widget。クロス行ドラッグ選択は不可（Slint仕様）。
+6. **cargo test単体ではテストが見つからない**: `--features desktop`が必要。
+7. **`@tr()`の罠**: 翻訳エントリがない文字列は原文のまま表示→言語混在。ペインラベル等は`@tr()`を使わない。
+
+## Work Rules
+- **featureブランチで作業**。main直接作業禁止。
+- **新機能はplanモードで設計→合意→実装**の順。即実装しない。
+- **1機能1コミット**。小さく区切る。
+- 変更後は必ず`cargo test --features desktop`と`cargo build --features desktop`で確認。
+- UI変更はGotchasを確認してからコードに触る。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6584,7 +6584,7 @@ dependencies = [
 
 [[package]]
 name = "winxmerge"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "arboard",
  "calamine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winxmerge"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -20,10 +20,14 @@ A cross-platform file diff comparison and merge tool inspired by WinMerge, built
 
 ### 3-way Merge
 - Three-pane display (Left / Base / Right)
+- WinMerge-style Make3wayDiff overlap-grouping algorithm
 - Automatic detection of changes from base file
 - Conflict highlighting (red) with L/R buttons for conflict resolution
 - Conflict navigation (next/previous)
+- Copy & advance, copy all toolbar buttons
 - Auto-merge when both sides have identical changes
+- Inline editing with F5 rescan (VecModel as authoritative source)
+- Save dropdown: save Left / Middle / Right individually
 
 ### Folder Comparison
 - Recursive directory comparison with tree-style indentation

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,7 @@ fn main() {
         slint_build::compile("ui/wasm-app.slint").unwrap();
     } else {
         // Desktop build: compile the full main UI with translations
+        println!("cargo:rerun-if-changed=translations/");
         let config = slint_build::CompilerConfiguration::new()
             .with_bundled_translations("translations/")
             .with_default_translation_context(slint_build::DefaultTranslationContext::None);

--- a/doc/winmerge_3way_diff_analysis.md
+++ b/doc/winmerge_3way_diff_analysis.md
@@ -1,0 +1,657 @@
+# WinMerge 3-Way Diff アルゴリズム 技術解析書
+
+WinMerge のソースコード（GitHub: WinMerge/winmerge）および GNU diff3 アルゴリズムの解析に基づく、3-way diff/merge の詳細技術仕様。
+
+---
+
+## 目次
+
+1. [3-Way Diff アルゴリズム概要](#1-3-way-diff-アルゴリズム概要)
+2. [Make3wayDiff: ハンクマージアルゴリズム](#2-make3waydiff-ハンクマージアルゴリズム)
+3. [OP_TYPE 分類ロジック](#3-op_type-分類ロジック)
+4. [行アラインメントとGhost行](#4-行アラインメントとghost行)
+5. [コピー操作](#5-コピー操作)
+6. [UI表示と着色](#6-ui表示と着色)
+7. [ナビゲーション](#7-ナビゲーション)
+8. [エッジケース](#8-エッジケース)
+9. [WinXMerge 実装への適用](#9-winxmerge-実装への適用)
+
+---
+
+## 1. 3-Way Diff アルゴリズム概要
+
+### 1.1 基本原理
+
+WinMerge の 3-way diff は **GNU diff3 アルゴリズム** に基づいており、次の手順で動作する:
+
+1. **3組のペアワイズ 2-way diff を実行**
+2. **2-way diff の結果（ハンク列）をマージして 3-way diff ブロックを生成**
+3. **各ブロックの変更タイプ（OP_TYPE）を決定**
+4. **Ghost行を挿入して3ペインの行を同期**
+
+### 1.2 ペアワイズ比較の構成
+
+WinMerge は **3つのファイル（file[0]=左, file[1]=中央/Base, file[2]=右）** に対して3組の 2-way diff を実行する:
+
+| 比較ID | 比較対象 | 記法 | 意味 |
+|--------|---------|------|------|
+| `diffdata10` | file[1] vs file[0] | Base vs Left | 中央から見た左の変更 |
+| `diffdata12` | file[1] vs file[2] | Base vs Right | 中央から見た右の変更 |
+| `diffdata02` | file[0] vs file[2] | Left vs Right | 左右の直接比較（コンフリクト判定用） |
+
+**重要**: `diffdata10` と `diffdata12` は Base（file[1]）を基準にしている。これにより、Base の行番号空間でハンクのオーバーラップを検出できる。
+
+`diffdata02`（左 vs 右）は `Make3wayDiff` 内でコンフリクト判定（左と右が同一変更か異なる変更か）に使用される。直接ハンクマージには参加しない。
+
+### 1.3 実行フロー
+
+```
+RunFileDiff()
+  ├── Diff2Files(&script10, file[1], file[0])  // Base vs Left
+  ├── Diff2Files(&script12, file[1], file[2])  // Base vs Right
+  ├── Diff2Files(&script02, file[0], file[2])  // Left vs Right (比較関数用)
+  │
+  └── LoadWinMergeDiffsFromDiffUtilsScript3()
+        ├── script10 → diff10 (DiffRangeInfo vector に変換)
+        ├── script12 → diff12 (DiffRangeInfo vector に変換)
+        └── Make3wayDiff(diff3, diff10, diff12, Comp02Functor, has_trivial)
+              └── diff3 = マージ済み3-wayブロック列
+```
+
+---
+
+## 2. Make3wayDiff: ハンクマージアルゴリズム
+
+### 2.1 データ構造
+
+```cpp
+struct DIFFRANGE {
+    int begin[3];    // 各ファイルの開始行（0-indexed）
+    int end[3];      // 各ファイルの終了行（inclusive）
+    int dbegin;      // 同期済み（Ghost行追加後）開始行
+    int dend;        // 同期済み終了行
+    int blank[3];    // 各ファイルのBlank（Ghost）行数 (-1=なし)
+    OP_TYPE op;      // 操作タイプ
+};
+```
+
+入力の `diff10` と `diff12` は2要素配列（`begin[0]`, `begin[1]`, `end[0]`, `end[1]`）で、`begin[0]`/`end[0]` がBase（file[1]）側、`begin[1]`/`end[1]` が対象ファイル側の行範囲。
+
+出力の `diff3` は3要素配列（`begin[0..2]`, `end[0..2]`）で、3ファイルそれぞれの行範囲を持つ。
+
+### 2.2 マージアルゴリズムの詳細
+
+`Make3wayDiff` は、`diff10`（Base vs Left）と `diff12`（Base vs Right）のハンク列を **Base の行番号空間で走査** し、オーバーラップするハンクをグループ化して3-wayブロックを生成する。
+
+#### ステップ1: 先頭ハンクの選択
+
+```
+diff10 の次のハンク: dr10first （Base行 = dr10first.begin[0]）
+diff12 の次のハンク: dr12first （Base行 = dr12first.begin[0]）
+
+firstDiffBlockIsDiff12 = (dr12first.begin[0] <= dr10first.begin[0])
+```
+
+Base 行番号が小さい方を「最初のブロック」とする。
+
+#### ステップ2: オーバーラップ検出ループ
+
+2つのハンク列を交互にスキャンし、Base 行範囲がオーバーラップするハンクをすべてグループに取り込む:
+
+```
+while (diff10 と diff12 の両方にハンクが残っている):
+    dr10 = diff10 の現在のハンク
+    dr12 = diff12 の現在のハンク
+
+    // 完全に終了行が一致 → 両方を消費して終了
+    if dr10.end[0] == dr12.end[0]:
+        consume both, break
+
+    // 最後に処理したのが diff12 側のハンクなら
+    if lastDiffBlockIsDiff12:
+        if max(dr12.begin[0], dr12.end[0]) < dr10.begin[0]:
+            break  // オーバーラップなし、グループ完成
+    else:
+        if max(dr10.begin[0], dr10.end[0]) < dr12.begin[0]:
+            break
+
+    // より大きい end[0] を持つ方を進める
+    if dr12.end[0] > dr10.end[0]:
+        advance diff10, lastDiffBlockIsDiff12 = true
+    else:
+        advance diff12, lastDiffBlockIsDiff12 = false
+```
+
+**核心**: このループは、Base 行空間で「重なり合う」すべてのハンクを1つのグループにまとめる。重なりがなくなった時点でグループが確定する。
+
+#### ステップ3: 3-way ブロックの行範囲計算
+
+グループ内のハンクから、3ファイルそれぞれの行範囲を算出する:
+
+```
+if firstDiffBlockIsDiff12:
+    dr3.begin[1] = dr12first.begin[0]    // Base開始
+    dr3.begin[2] = dr12first.begin[1]    // Right開始
+    if diff10 がグループに参加していない:
+        dr3.begin[0] = dr3.begin[1] - linelast1 + linelast0  // Leftはオフセット計算
+    else:
+        dr3.begin[0] = dr3.begin[1] - dr10first.begin[0] + dr10first.begin[1]
+
+// end も同様に計算（lastDiffBlockIsDiff12 で分岐）
+```
+
+**行番号のオフセット計算**: `linelast0`, `linelast1`, `linelast2` は前のブロック終了時点の各ファイルの行位置（end+1）。ハンクに参加していない側の行範囲は、Baseからのオフセットで推定する。
+
+#### ステップ4: OP_TYPE の決定
+
+```
+if diff10 がグループに不参加:
+    op = OP_3RDONLY       // Base vs Right のみ差分 → 右だけ変更
+else if diff12 がグループに不参加:
+    op = OP_1STONLY       // Base vs Left のみ差分 → 左だけ変更
+else:
+    // 両方に差分がある
+    if cmpfunc(dr3) == true:  // file[0] と file[2] が同一か？
+        op = OP_2NDONLY   // 左=右 → 中央（Base）だけ変更
+    else:
+        op = OP_DIFF      // コンフリクト（3ファイルとも異なる）
+```
+
+#### ステップ5: 後処理（オーバーラップ修正）
+
+最終的に、隣接する3-wayブロックの行範囲が重複する場合の修正:
+
+```
+for each adjacent pair (dr3[i], dr3[i+1]):
+    for j in 0..3:
+        if dr3[i].end[j] >= dr3[i+1].begin[j]:
+            dr3[i].end[j] = dr3[i+1].begin[j] - 1
+```
+
+### 2.3 Comp02Functor: コンフリクト判定
+
+両側に差分がある場合、`file[0]`（Left）と `file[2]`（Right）を直接行比較する:
+
+```cpp
+struct Comp02Functor {
+    bool operator()(const DiffRangeInfo& dr3) {
+        int line0 = dr3.begin[0], line0end = dr3.end[0];
+        int line2 = dr3.begin[2], line2end = dr3.end[2];
+
+        // 行数が異なれば不一致
+        if ((line0end - line0) != (line2end - line2))
+            return false;
+
+        // 各行を比較
+        for (int i = 0; i <= line0end - line0; ++i) {
+            if (line_cmp(linbuf0[line0+i], linbuf2[line2+i]) != 0)
+                return false;
+        }
+        return true;  // 完全一致 → OP_2NDONLY
+    }
+};
+```
+
+`line_cmp` は大文字小文字、空白、EOL の各オプションに応じた比較を行う。
+
+---
+
+## 3. OP_TYPE 分類ロジック
+
+### 3.1 OP_TYPE 一覧
+
+| OP_TYPE | 値 | 意味 | 条件 |
+|---------|---|------|------|
+| `OP_NONE` | 0 | 差分なし | 3ファイルとも同一（Equal領域） |
+| `OP_1STONLY` | 1 | 左のみ変更 | diff12 に該当ハンクなし（Base=Right, Left だけ異なる） |
+| `OP_2NDONLY` | 2 | 中央のみ変更 | diff10 と diff12 の両方に該当があり、Left=Right |
+| `OP_3RDONLY` | 3 | 右のみ変更 | diff10 に該当ハンクなし（Base=Left, Right だけ異なる） |
+| `OP_DIFF` | 4 | コンフリクト | diff10 と diff12 の両方に該当があり、Left!=Right |
+| `OP_TRIVIAL` | 5 | 無視された差分 | 空白のみの差分など（オプション依存） |
+
+### 3.2 判定フロー図
+
+```
+diff10にハンクあり?  diff12にハンクあり?
+      No                  Yes          → OP_3RDONLY (右のみ変更)
+      Yes                 No           → OP_1STONLY (左のみ変更)
+      Yes                 Yes          →
+         Left == Right?
+            Yes → OP_2NDONLY (中央のみ変更 = 両側が同じ変更をした)
+            No  → OP_DIFF (コンフリクト)
+```
+
+### 3.3 OP_TYPE と変更主体の関係
+
+| OP_TYPE | Left | Base | Right | 解釈 |
+|---------|------|------|-------|------|
+| `OP_1STONLY` | 変更あり | 元 | 元と同じ | 左だけが変更した |
+| `OP_2NDONLY` | 変更あり | 元 | 左と同じ | 左右が同じ変更をした（Baseだけ異なる） |
+| `OP_3RDONLY` | 元と同じ | 元 | 変更あり | 右だけが変更した |
+| `OP_DIFF` | 変更A | 元 | 変更B (A!=B) | 左右が異なる変更をした（コンフリクト） |
+
+---
+
+## 4. 行アラインメントとGhost行
+
+### 4.1 Ghost行の目的
+
+3-way diff では、各ファイルの行数が異なる差分ブロックが発生する。3ペインの表示を同期するために、行数が少ないペインに **Ghost行**（空行）を挿入して行数を揃える。
+
+### 4.2 PrimeTextBuffers: Ghost行挿入
+
+`PrimeTextBuffers()` で各差分ブロックに対してGhost行を挿入する:
+
+```
+for each DIFFRANGE curDiff:
+    // 各ファイルの実行数
+    nline[0] = curDiff.end[0] - curDiff.begin[0] + 1  // Left
+    nline[1] = curDiff.end[1] - curDiff.begin[1] + 1  // Base
+    nline[2] = curDiff.end[2] - curDiff.begin[2] + 1  // Right
+
+    // 最大行数
+    nmaxline = max(nline[0], nline[1], nline[2])
+
+    for file in 0..3:
+        nextra = nmaxline - nline[file]
+        if nextra > 0:
+            // Ghost行を挿入
+            SetEmptyLine(position, nextra)
+            // フラグを設定
+            dflag = LF_GHOST
+            if (file==0 && op==OP_3RDONLY) || (file==2 && op==OP_1STONLY):
+                dflag |= LF_SNP
+            SetLineFlag(each ghost line, dflag)
+```
+
+### 4.3 LF_SNP フラグ（Same in Non-active Pair）
+
+`LF_SNP` は「このペインの内容はペアの他方と同一である」ことを示すフラグ:
+
+| OP_TYPE | LF_SNP 設定先 | 意味 |
+|---------|--------------|------|
+| `OP_3RDONLY` | file[0]（Left）のGhost行 | Left = Base（左と中央は同じ）|
+| `OP_1STONLY` | file[2]（Right）のGhost行 | Right = Base（右と中央は同じ）|
+
+**用途**:
+- **着色**: LF_SNP が設定されたペインは変更ハイライトをスキップ（変更がないため）
+- **Detail ペイン**: LF_SNP のペインではワードレベル差分ハイライトを省略
+
+### 4.4 同期済み行番号（dbegin / dend）
+
+Ghost行挿入後、`DIFFRANGE` の `dbegin` / `dend` が計算される。これは **3ペインで共通の表示行番号** であり、すべてのペインで同じ行位置に同じ差分ブロックが表示される。
+
+```
+curDiff.dbegin = 累積表示行位置
+curDiff.dend = dbegin + nmaxline - 1
+```
+
+### 4.5 行アラインメントの詳細ロジック
+
+#### AdjustDiffBlocks3way
+
+差分ブロック内で類似行を整列させる機能（「Align similar lines」オプション）:
+
+1. 各差分ブロックに対して、3組のペアワイズ DiffMap を計算
+2. `CreateVirtualLineToRealLineMap3way()` で仮想行マップを構築
+3. 仮想行ごとに `ComputeOpType3way()` でサブ分類
+4. 類似行同士が横に並ぶようにGhost行を再配置
+
+#### ComputeOpType3way
+
+仮想行レベルでの細粒度分類:
+
+```
+for each virtual line:
+    pane0_has_content = (not ghost in pane 0)
+    pane1_has_content = (not ghost in pane 1)
+    pane2_has_content = (not ghost in pane 2)
+
+    if only pane0: OP_1STONLY
+    if only pane1: OP_2NDONLY
+    if only pane2: OP_3RDONLY
+    if pane0 && pane1 && !pane2:
+        compare(pane0, pane1) → same: OP_3RDONLY, diff: OP_DIFF
+    // ... 他の組み合わせも同様
+    if all three:
+        compare pairwise → determine OP_TYPE
+```
+
+### 4.6 具体例
+
+**Base**:
+```
+line 1
+line 2
+line 3
+```
+
+**Left** (2行追加):
+```
+line 1
+added-L1
+added-L2
+line 2
+line 3
+```
+
+**Right** (line 2 を変更):
+```
+line 1
+MODIFIED-2
+line 3
+```
+
+**Ghost行挿入後の3ペイン表示**:
+
+| 行 | Left | Base | Right | OP_TYPE |
+|----|------|------|-------|---------|
+| 1 | `line 1` | `line 1` | `line 1` | Equal |
+| 2 | `added-L1` | _(ghost)_ | _(ghost)_ | OP_1STONLY |
+| 3 | `added-L2` | _(ghost)_ | _(ghost)_ | OP_1STONLY |
+| 4 | `line 2` | `line 2` | `MODIFIED-2` | OP_3RDONLY |
+| 5 | `line 3` | `line 3` | `line 3` | Equal |
+
+- 行2-3: Leftに2行追加。BaseとRightにGhost行2行挿入。RightのGhost行に `LF_SNP` 設定。
+- 行4: Rightが変更。LeftのGhost行はなし（行数同じ）。LeftにLF_SNP設定可能。
+
+---
+
+## 5. コピー操作
+
+### 5.1 隣接ペインコピー（Copy Left / Copy Right）
+
+3-way では、Copy Left/Right は **常に隣接ペイン間** の操作:
+
+| コマンド | アクティブペイン | コピー方向 |
+|---------|---------------|-----------|
+| Copy Right (L2R) | 0（Left） | Left → Base (0 → 1) |
+| Copy Right (L2R) | 1（Base） | Base → Right (1 → 2) |
+| Copy Left (R2L) | 1（Base） | Base → Left (1 → 0) |
+| Copy Left (R2L) | 2（Right） | Right → Base (2 → 1) |
+
+### 5.2 明示的コピー操作（コンテキストメニュー）
+
+各ペインから任意のペインへのコピーが可能:
+
+| アクティブペイン | 利用可能なコピー操作 |
+|---------------|-------------------|
+| Left (0) | Copy To Middle, Copy To Right, Copy From Middle, Copy From Right |
+| Base (1) | Copy To Left, Copy To Right, Copy From Left, Copy From Right |
+| Right (2) | Copy To Middle, Copy To Left, Copy From Middle, Copy From Left |
+
+### 5.3 コピー操作の実装
+
+```
+ListCopy(srcPane, dstPane, nDiff):
+    1. 対象の DIFFRANGE を取得
+    2. Undo グループを開始
+    3. dst ペインの begin[dst]..end[dst] の行を削除
+    4. src ペインの begin[src]..end[src] の行を挿入
+    5. Ghost行を再計算
+    6. Undo グループを終了
+    7. Rescan（再差分計算）
+```
+
+**重要: 下から上への処理**
+複数の差分を一括コピーする場合、行番号のずれを防ぐため **下から上（末尾から先頭）** の順序で処理する。
+
+### 5.4 Auto Merge
+
+3-way 専用の自動マージ機能:
+
+```
+DoAutoMerge(dstPane):
+    for each diff (bottom to top):
+        srcIndex = GetMergeableSrcIndex(nDiff, dstPane)
+        if srcIndex >= 0:
+            ListCopy(srcIndex, dstPane, nDiff)
+            autoMergedCount++
+        else:
+            unresolvedConflictCount++
+
+    show message: "N diffs auto-merged, M conflicts remain"
+    navigate to first unresolved conflict
+```
+
+#### GetMergeableSrcIndex のロジック
+
+```
+GetMergeableSrcIndex(nDiff, dstIndex):
+    switch dstIndex:
+        case 0 (Left) or 2 (Right):
+            if op == OP_2NDONLY: return 1 (Base)  // Baseだけ変更 → Baseの内容をコピー
+            else: return -1  // マージ不可
+        case 1 (Base):
+            if op == OP_1STONLY: return 0 (Left)   // 左だけ変更 → 左をBaseにコピー
+            if op == OP_2NDONLY: return 0 (Left)   // Base変更（左右同じ） → 左をコピー
+            if op == OP_3RDONLY: return 2 (Right)  // 右だけ変更 → 右をBaseにコピー
+            else: return -1  // OP_DIFF（コンフリクト）は自動マージ不可
+```
+
+**OP_DIFF（コンフリクト）は自動マージ不可** — ユーザーが手動で解決する必要がある。
+
+---
+
+## 6. UI表示と着色
+
+### 6.1 行の着色
+
+WinMerge は各行の OP_TYPE に基づいて背景色を設定する:
+
+| OP_TYPE | 変更ペインの色 | 同一ペインの色 | 意味 |
+|---------|-------------|-------------|------|
+| OP_NONE | なし | なし | 差分なし |
+| OP_1STONLY | Left: 黄色系 | Base, Right: 薄い黄色 (LF_SNP) | 左のみ変更 |
+| OP_2NDONLY | Base: シアン系 | Left, Right: 薄いシアン | 中央のみ変更 |
+| OP_3RDONLY | Right: 黄色系 | Left, Base: 薄い黄色 (LF_SNP) | 右のみ変更 |
+| OP_DIFF | 全ペイン: 赤/ピンク系 | — | コンフリクト |
+
+**LF_SNP のペインは「同一」を示す淡い色** で表示される。変更があるペインは通常の差分色で表示。
+
+### 6.2 ワードレベルハイライト
+
+差分ブロック内で、行内のどの部分が変更されたかをハイライト:
+
+- `OP_3RDONLY`: Left ペインのハイライトをスキップ（Left = Base で同一なので）
+- `OP_1STONLY`: Right ペインのハイライトをスキップ（Right = Base で同一なので）
+- `OP_DIFF`: 全ペインでハイライト
+- `OP_2NDONLY`: Left と Right のハイライトをスキップ可能（同一なので）
+
+### 6.3 Location ペイン（ミニマップ）
+
+3-way 時は3本の縦バーを描画し、バー間にコネクタ領域を表示:
+
+| 色 | 条件 | 意味 |
+|----|------|------|
+| 黄色 | 左-中央間で `OP_3RDONLY`、中央-右間で `OP_1STONLY` | このペアは同一 |
+| シアン | `OP_2NDONLY` | 中央のみ異なる |
+| 赤 | `OP_DIFF` | コンフリクト |
+
+### 6.4 Detail ペイン
+
+3-way 時は3セクション（Left / Base / Right）を表示:
+- diff 選択時、各セクションはそのブロックの範囲にスクロール
+- 範囲外の行はグレーアウト
+- ワードレベル差分ハイライトあり（LF_SNP のペインはスキップ）
+
+---
+
+## 7. ナビゲーション
+
+### 7.1 標準ナビゲーション
+
+First / Prev / Next / Last: 2-way と同一。全有効差分ブロックを順にトラバース。
+
+### 7.2 3-way 専用ナビゲーション
+
+`THREEWAYDIFFTYPE` による分類でフィルタリング:
+
+| タイプ | 意味 | 含む OP_TYPE | 除外する OP_TYPE |
+|--------|------|-------------|----------------|
+| `LEFTMIDDLE` | 左と中央が異なる | OP_1STONLY, OP_2NDONLY, OP_DIFF | OP_3RDONLY, OP_TRIVIAL |
+| `LEFTRIGHT` | 左と右が異なる | OP_1STONLY, OP_3RDONLY, OP_DIFF | OP_2NDONLY, OP_TRIVIAL |
+| `MIDDLERIGHT` | 中央と右が異なる | OP_2NDONLY, OP_3RDONLY, OP_DIFF | OP_1STONLY, OP_TRIVIAL |
+| `LEFTONLY` | 左のみ変更 | OP_1STONLY | 他すべて |
+| `MIDDLEONLY` | 中央のみ変更 | OP_2NDONLY | 他すべて |
+| `RIGHTONLY` | 右のみ変更 | OP_3RDONLY | 他すべて |
+| `CONFLICT` | コンフリクト | OP_DIFF | 他すべて |
+
+### 7.3 ナビゲーション関数
+
+```
+NextSignificant3wayDiffFromLine(nLine, nDiffType):
+    for each diff in order:
+        if diff.dbegin >= nLine:
+            if matches nDiffType filter:
+                return diff index
+    return -1
+
+PrevSignificant3wayDiffFromLine(nLine, nDiffType):
+    for each diff in reverse:
+        if diff.dend <= nLine:
+            if matches nDiffType filter:
+                return diff index
+    return -1
+```
+
+### 7.4 コンフリクトナビゲーション
+
+`OnNextConflict` / `OnPrevConflict` は内部で `THREEWAYDIFFTYPE_CONFLICT` を指定して3-wayナビゲーション関数を呼ぶ。`OP_DIFF` のみをナビゲートする。
+
+---
+
+## 8. エッジケース
+
+### 8.1 一方の側がより多い/少ない行を持つ場合
+
+- **挿入**: 一方にのみ追加行がある場合、他の2ペインにGhost行が挿入される
+- **削除**: 一方から行が削除された場合、そのペインにGhost行が挿入される
+- **行数0のハンク**: base_start == base_end のハンク（純粋な挿入）が正しく処理される必要がある
+
+### 8.2 空ファイル
+
+- 3ファイルすべてが空: 差分なし
+- 1ファイルのみ空: そのファイル全体がGhost行、他の2ファイルの全行が差分ブロック
+- 2ファイルが空: 残り1ファイルの内容に応じた OP_TYPE
+
+### 8.3 オーバーラップするハンク
+
+Make3wayDiff のオーバーラップ検出ループが処理:
+
+```
+例:
+  diff10: Base行 5-10 が変更
+  diff12: Base行 8-15 が変更
+
+→ Base行 5-15 が1つの3-wayブロックにマージされる
+→ 両側に差分があるため OP_DIFF（Left vs Right を比較して確定）
+```
+
+### 8.4 隣接するが重ならないハンク
+
+```
+例:
+  diff10: Base行 5-10
+  diff12: Base行 11-15
+
+→ 別々の3-wayブロック
+→ diff10 のブロック: OP_1STONLY
+→ diff12 のブロック: OP_3RDONLY
+```
+
+### 8.5 同一行の変更（BothChanged）
+
+左右が BaseFrom の同じ行を同じ内容に変更した場合:
+- `Comp02Functor` が true を返す
+- `OP_2NDONLY` に分類される（「Baseだけが異なる」= 左右は一致）
+- コンフリクトにはならない
+
+### 8.6 末尾の改行
+
+- 末尾改行の有無は `lines()` の分割結果に影響する
+- WinMerge は EOL 差分を独立したオプション（`m_bIgnoreEol`）で制御
+- 改行文字の違いのみの場合、OP_TRIVIAL にできる
+
+### 8.7 大文字小文字・空白の無視
+
+比較オプションによって OP_TYPE の判定結果が変わる:
+- 大文字小文字を無視: `"ABC"` と `"abc"` は同一扱い
+- 空白を無視: `"a b"` と `"a  b"` は同一扱い
+- これらのオプションは `Comp02Functor` の `line_cmp` に影響
+
+### 8.8 Ghost行内のコピー操作
+
+Ghost行を含む差分ブロックでコピーを行う場合:
+- Ghost行は削除される（実際の行に置き換わる）
+- コピー後の行数変化により、後続ブロックの dbegin/dend が再計算される
+- Rescan で全体が再同期される
+
+---
+
+## 9. WinXMerge 実装への適用
+
+### 9.1 現在の WinXMerge 実装の分析
+
+現在の `compute_three_way_diff`（`src/diff/three_way.rs`）は:
+
+- **2組のペアワイズ diff** を使用（Base vs Left, Base vs Right）— WinMerge の3組ではなく2組
+- **ハンクのオーバーラップ処理** が簡略化されている（同一 base_start のハンクのみ処理）
+- **OP_TYPE** の代わりに `ThreeWayStatus` enum を使用（Equal, LeftChanged, RightChanged, BothChanged, Conflict）
+- **Ghost行** は line_no が None で表現される
+
+### 9.2 WinMerge との主な差異
+
+| 項目 | WinMerge | WinXMerge 現状 | 改善点 |
+|------|---------|---------------|--------|
+| ペアワイズ比較 | 3組 (10, 12, 02) | 2組 (base-left, base-right) | 02 比較は Comp02 相当のインライン比較で代替可能 |
+| ハンクマージ | オーバーラップ検出ループ | 同一 base_start のみ | **要改善**: base 範囲が重なるハンクのグループ化が必要 |
+| OP_TYPE | 6種類 | 5種類 (ThreeWayStatus) | BothChanged ≒ OP_2NDONLY で概ね対応 |
+| Ghost行 | LF_GHOST + LF_SNP フラグ | line_no: None | SNP 相当のフラグ追加を検討 |
+| 行アラインメント | AdjustDiffBlocks3way | なし | 将来対応 |
+
+### 9.3 最も重要な改善: ハンクオーバーラップ処理
+
+現在の実装の最大の問題は、**異なる base_start を持つがオーバーラップするハンクの処理**:
+
+```
+現状の問題:
+  left_hunk: base 5-10 (Left が変更)
+  right_hunk: base 8-15 (Right が変更)
+
+  現在: base_start が異なるため別々のブロックとして処理される
+  正解: base 5-15 を1つのコンフリクトブロックとしてマージすべき
+```
+
+Make3wayDiff のオーバーラップ検出ループに相当するロジックの実装が必要。
+
+### 9.4 推奨実装手順
+
+1. **ハンクオーバーラップ検出の実装**: Make3wayDiff のマージループに相当するロジック
+2. **Comp02 比較の実装**: 両側変更時に Left vs Right を直接比較
+3. **LF_SNP 相当のフラグ追加**: ThreeWayLine に `snp_pane: Option<u8>` を追加
+4. **行アラインメント改善**: 差分ブロック内の類似行整列
+5. **Auto Merge 機能の実装**: GetMergeableSrcIndex ロジック
+
+---
+
+## 参考資料
+
+### WinMerge ソースファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `Src/Diff3.h` | `Make3wayDiff()` テンプレート関数 — ハンクマージの核心 |
+| `Src/DiffList.h` | `OP_TYPE`, `THREEWAYDIFFTYPE`, `DIFFRANGE` 構造体 |
+| `Src/DiffList.cpp` | `GetMergeableSrcIndex()`, 3-way ナビゲーション関数 |
+| `Src/DiffWrapper.cpp` | 3組ペアワイズ diff + Make3wayDiff 呼び出し |
+| `Src/MergeDocDiffSync.cpp` | `ComputeOpType3way()`, Ghost行同期, 行アラインメント |
+| `Src/MergeDocDiffCopy.cpp` | `DoAutoMerge()`, コピー操作 |
+| `Src/MergeDoc.cpp` | `PrimeTextBuffers()` — Ghost行挿入, LF_SNP 設定 |
+| `Src/MergeEditView.cpp` | UI操作: 着色, ナビゲーション, コンテキストメニュー |
+
+### 外部参考
+
+- GNU diffutils マニュアル: diff3 Hunks — https://www.gnu.org/software/diffutils/manual/html_node/diff3-Hunks.html
+- James Coglan: "Merging with diff3" — https://blog.jcoglan.com/2017/05/08/merging-with-diff3/
+- Wikipedia: Diff3 — https://en.wikipedia.org/wiki/Diff3

--- a/doc/winmerge_3way_spec.md
+++ b/doc/winmerge_3way_spec.md
@@ -1,0 +1,211 @@
+# WinMerge 3-Way Merge 仕様書
+
+WinMerge のオリジナルソースコード（GitHub: WinMerge/winmerge）から解析した 3-way マージの仕様。
+
+## 1. ビューアーキテクチャ
+
+### ペイン構成
+- `m_nBuffers` = 2 (2-way) or 3 (3-way) で切り替え
+- `m_ptBuf[3]`: 左/中央/右の 3 つのテキストバッファ
+- `m_pView[3][3]`: `[group][buffer]` の 2D 配列。group はメインビュー、detailビュー、追加分割
+- ペイン番号: 0=左, 1=中央(Base), 2=右
+
+### ペイン名称
+- Pane 0: **Left** (Mine / Local)
+- Pane 1: **Middle** (Base / Ancestor)
+- Pane 2: **Right** (Theirs / Remote)
+
+### ループ構造
+全てのペイン操作は `for (nBuffer = 0; nBuffer < m_nBuffers; nBuffer++)` で回す。
+2-way / 3-way でコードパスを分岐しない設計。
+
+## 2. Diff エンジン（3-way）
+
+### 3 組のペアワイズ比較
+3-way diff は **3 組の 2-way diff** を実行して統合する：
+
+| 比較ID | 比較対象 | 意味 |
+|--------|---------|------|
+| diffdata10 | file[1] vs file[0] | 中央 vs 左 |
+| diffdata12 | file[1] vs file[2] | 中央 vs 右 |
+| diffdata02 | file[0] vs file[2] | 左 vs 右 |
+
+各ペアは GNU diffutils ベースの `Diff2Files()` で処理。
+結果は `Make3wayDiff()` (Diff3.h) で統合される。
+
+### OP_TYPE 分類
+
+| OP_TYPE | 意味 | 条件 |
+|---------|------|------|
+| `OP_NONE` | 差分なし | 3 ファイルとも同一 |
+| `OP_1STONLY` | 左のみ変更 | 中央=右、左だけ異なる |
+| `OP_2NDONLY` | 中央のみ変更 | 左=右、中央だけ異なる |
+| `OP_3RDONLY` | 右のみ変更 | 左=中央、右だけ異なる |
+| `OP_DIFF` | コンフリクト | 3 ファイルとも異なる |
+| `OP_TRIVIAL` | 無視された差分 | |
+
+### Make3wayDiff のロジック
+- diff10 のみ → `OP_3RDONLY`（右だけ変更）
+- diff12 のみ → `OP_1STONLY`（左だけ変更）
+- 両方 → file[0] と file[2] を比較:
+  - 同一なら `OP_2NDONLY`（中央だけ変更）
+  - 異なれば `OP_DIFF`（コンフリクト）
+
+### Ghost 行
+Ghost 行を挿入して 3 バッファの行数を揃える。
+`LF_SNP` (Same in Non-active Pair) フラグ:
+- `OP_3RDONLY` のとき pane 0 に設定（左=中央で同じ）
+- `OP_1STONLY` のとき pane 2 に設定（右=中央で同じ）
+
+## 3. Detail ペイン（3-way）
+
+### 構造
+- Detail ペインは **別のビューグループ** (`m_bDetailView = true`)
+- メインビューと同じ数のペインを持つ（3-way なら **3 セクション**）
+- つまり左/中央/右の 3 分割で詳細表示
+
+### 動作
+- diff 選択時、各 detail ペインはそのブロックの範囲 (`m_lineBegin` ～ `m_lineEnd`) にスクロール
+- 範囲外の行はグレーアウト
+- ワードレベルの差分ハイライトあり
+  - Pane 0: `OP_3RDONLY` のハイライトをスキップ（左と中央が同じなので）
+  - Pane 2: `OP_1STONLY` のハイライトをスキップ（右と中央が同じなので）
+
+## 4. Location ペイン（ミニマップ）
+
+### 3-way 時のバー構成
+- `m_bar[3]`: 3 本の縦バーを描画
+- バー幅: `clientWidth / (nBuffers * 2)` でマージン付き配置
+
+### バー間のコネクタ領域
+隣接バー間（左-中央間、中央-右間）に色付き矩形を描画:
+
+| 色 | 条件 | 意味 |
+|----|------|------|
+| 黄色 | 左-中央間で `OP_3RDONLY`、中央-右間で `OP_1STONLY` | このペアは同一 |
+| シアン | `OP_2NDONLY` | 中央のみ異なる |
+| 赤 | `OP_DIFF` | コンフリクト（3ファイルとも異なる） |
+
+## 5. コピー/マージ操作
+
+### コピー方向（アクティブペイン依存）
+
+| コマンド | アクティブペイン | src → dst |
+|---------|---------------|-----------|
+| Copy Right (L2R) | 0 (左) | 0 → 1 (左→中央) |
+| Copy Right (L2R) | 1 (中央) | 1 → 2 (中央→右) |
+| Copy Left (R2L) | 1 (中央) | 1 → 0 (中央→左) |
+| Copy Left (R2L) | 2 (右) | 2 → 1 (右→中央) |
+
+**重要**: 3-way では Copy Left/Right は常に **隣接ペイン** への操作。
+
+### 明示的コピー操作（コンテキストメニュー）
+各ペインから利用可能な操作:
+- **左ペイン**: Copy To Middle, Copy To Right, Copy From Middle, Copy From Right
+- **中央ペイン**: Copy To Left, Copy To Right, Copy From Left, Copy From Right
+- **右ペイン**: Copy To Middle, Copy To Left, Copy From Middle, Copy From Left
+
+### Auto Merge
+- **3-way 専用** (`m_nBuffers == 3` のみ有効)
+- 下から上に全 diff を走査
+- マージ可能な判定 (`GetMergeableSrcIndex`):
+  - dst=0 or dst=2: `OP_2NDONLY` のみマージ可（source=1, 中央）
+  - dst=1 (中央): `OP_1STONLY` → src=0、`OP_3RDONLY` → src=2
+  - `OP_DIFF` (コンフリクト) は **自動マージ不可**
+- 結果: "N diffs auto-merged, M conflicts remain"
+
+## 6. ツールバー
+
+### 3-way 時の変更点
+- **L2R / R2L**: アクティブペインに応じて隣接ペインへのコピー。メニューテキストが動的に変更
+- **All Left / All Right**: 同様にテキスト変更
+- **Auto Merge**: 3-way 専用ボタン。未編集かつ未マージ時のみ有効
+- **パッチ生成**: 2-way 専用（3-way では無効）
+- **3-way ナビゲーション**: LM/LR/MR/LO/MO/RO のナビゲーションボタンが 3-way 時のみ有効
+
+### コピーボタンの非表示/無効化
+2-way にない操作（Copy To Middle 等）は 2-way 時に無効化。
+3-way ではアクティブペインに無関係な操作を削除（コンテキストメニュー）。
+
+## 7. ナビゲーション
+
+### 標準ナビゲーション (First/Prev/Next/Last)
+2-way と同一。統合 diff リストの全有効 diff をトラバース。
+
+### 3-way 専用ナビゲーション
+
+`THREEWAYDIFFTYPE` による分類:
+
+| タイプ | 意味 | 対応 OP_TYPE |
+|--------|------|-------------|
+| LEFTMIDDLE | 左と中央が異なる | `OP_1STONLY`, `OP_2NDONLY`, `OP_DIFF` を含む（`OP_3RDONLY` を除外）|
+| LEFTRIGHT | 左と右が異なる | `OP_2NDONLY` を除外 |
+| MIDDLERIGHT | 中央と右が異なる | `OP_1STONLY` を除外 |
+| LEFTONLY | 左のみ変更 | `OP_1STONLY` のみ |
+| MIDDLEONLY | 中央のみ変更 | `OP_2NDONLY` のみ |
+| RIGHTONLY | 右のみ変更 | `OP_3RDONLY` のみ |
+| CONFLICT | コンフリクト | `OP_DIFF` のみ |
+
+### コンフリクトナビゲーション
+`OnNextConflict` / `OnPrevConflict` は内部で `OnNext3wayDiff(THREEWAYDIFFTYPE_CONFLICT)` を呼ぶ。
+コンフリクト = **3 ファイルとも異なる** (`OP_DIFF`) のみ。
+
+### Copy & Advance
+3-way では、コピー後の行数変化を考慮して次の diff 位置を計算する複雑なロジック。
+
+## 8. ステータスバー
+
+### 構造
+- `CMergeStatusBar` に `MergeStatus m_status[3]` — ペインごとに 1 つ
+- `m_nPanes` = `m_nBuffers`
+
+### 表示内容（ペインごと）
+- 行番号（実行番号。Ghost 行は "Line N-N+1" 表示）
+- カラム位置（タブ展開後）
+- 文字位置と文字数
+- 選択行/文字数
+- EOL タイプ（混在 EOL モード時）
+- コードページと BOM
+
+### Diff カウント
+"Diff N of M" または "M Diffs" 形式。2-way / 3-way 共通。
+
+## WinXMerge への適用ガイド
+
+### 現状との差分
+
+| 機能 | WinMerge | WinXMerge 現状 | 対応方針 |
+|------|---------|---------------|---------|
+| Diff エンジン | 3 組ペアワイズ + Make3wayDiff | `compute_three_way_diff` | 要確認 |
+| Detail ペイン | 3 セクション（左/中央/右）| 2 セクション（左/右）| 3 セクションに拡張 |
+| Location ペイン | 3 バー + コネクタ | 1 バー | 3 バー + コネクタ描画 |
+| コピー操作 | 隣接ペイン基準 | use-left/use-right のみ | 6 方向コピー追加 |
+| ナビゲーション | 7 種類の diff タイプ | conflict のみ | 段階的に追加 |
+| ステータスバー | 3 ペイン分 | 1 行 | 3 ペイン情報追加 |
+| Auto Merge | あり | なし | 将来対応 |
+
+### 優先実装順序
+
+1. **Detail ペイン 3 セクション化** — 左/中央/右の 3 分割
+2. **Location ペイン 3 バー化** — 3 本バー + コネクタ色分け
+3. **コピー操作の方向拡張** — 隣接ペイン間コピー
+4. **ナビゲーション拡張** — diff タイプ別移動
+5. **Auto Merge** — 非コンフリクト diff の自動マージ
+6. **ステータスバー 3 ペイン化**
+
+## 参照ソースファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `Src/MergeDoc.h` | ドキュメントクラス宣言、`m_nBuffers`, `m_ptBuf[3]`, `m_pView[3][3]` |
+| `Src/MergeDoc.cpp` | Rescan, PrimeTextBuffers, ステータスバー |
+| `Src/MergeEditView.cpp` | UI 操作全般: コピー、ナビゲーション、コンテキストメニュー、着色、detail ビュー |
+| `Src/DiffList.h` | `OP_TYPE`, `THREEWAYDIFFTYPE`, `DIFFRANGE` 構造体 |
+| `Src/Diff3.h` | `Make3wayDiff()` アルゴリズム |
+| `Src/DiffWrapper.cpp` | 3 組ペアワイズ diff + Make3wayDiff 呼び出し |
+| `Src/MergeDocDiffSync.cpp` | `ComputeOpType3way()`, Ghost 行同期 |
+| `Src/MergeDocDiffCopy.cpp` | `DoAutoMerge()`, `GetMergeableSrcIndex()` |
+| `Src/LocationView.cpp` | Location ペイン描画（3-way コネクタ領域）|
+| `Src/MergeEditSplitterView.cpp` | ペイン生成（メイン + detail）|
+| `Src/MergeFrameCommon.cpp` | `MenuIDtoXY()` マッピング、`ChangeMergeMenuText()` |
+| `Src/MergeStatusBar.h` | ステータスバー（3 スロット）|

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ use crate::archive::{compare_zip_archives, is_zip_bytes, is_zip_path};
 use crate::csv::{compare_csv, is_csv_path};
 use crate::diff::engine::{DiffOptions, compute_diff_with_options};
 use crate::diff::folder::{FolderCompareOptions, compare_folders_with_options};
-use crate::diff::three_way::{ThreeWayStatus, compute_three_way_diff};
+use crate::diff::three_way::{ThreeWayResult, ThreeWayStatus, compute_three_way_diff};
 use crate::encoding::{decode_file, detect_eol, encode_text, is_binary};
 use crate::excel::{compare_excel, is_excel_path};
 use crate::highlight::{detect_file_type, highlight_lines};
@@ -60,6 +60,7 @@ pub struct TabState {
     pub current_diff: i32,
     pub left_lines: Vec<String>,
     pub right_lines: Vec<String>,
+    pub base_lines: Vec<String>,
     pub has_unsaved_changes: bool,
     // True after any inline edit; cleared on rescan/compare
     pub editing_dirty: bool,
@@ -71,6 +72,7 @@ pub struct TabState {
     pub folder_items: Vec<crate::models::folder_item::FolderItem>,
     pub left_encoding: String,
     pub right_encoding: String,
+    pub base_encoding: String,
     pub left_eol_type: String,
     pub right_eol_type: String,
     pub diff_options: DiffOptions,
@@ -131,6 +133,7 @@ impl TabState {
             current_diff: -1,
             left_lines: Vec::new(),
             right_lines: Vec::new(),
+            base_lines: Vec::new(),
             has_unsaved_changes: false,
             editing_dirty: false,
             undo_stack: Vec::new(),
@@ -140,6 +143,7 @@ impl TabState {
             folder_items: Vec::new(),
             left_encoding: "UTF-8".to_string(),
             right_encoding: "UTF-8".to_string(),
+            base_encoding: "UTF-8".to_string(),
             left_eol_type: String::new(),
             right_eol_type: String::new(),
             diff_options: DiffOptions::default(),
@@ -223,6 +227,21 @@ pub fn add_tab(window: &MainWindow, state: &mut AppState) {
 }
 
 pub fn close_tab(window: &MainWindow, state: &mut AppState, index: i32) {
+    if index < 0 || index as usize >= state.tabs.len() || state.tabs.len() <= 1 {
+        return;
+    }
+    let idx = index as usize;
+    // Check for unsaved changes — show confirm dialog if dirty
+    if state.tabs[idx].has_unsaved_changes {
+        window.set_tab_close_target_index(index);
+        window.set_show_tab_close_confirm(true);
+        return;
+    }
+    force_close_tab(window, state, index);
+}
+
+/// Close tab without checking unsaved changes (used after dialog confirm).
+pub fn force_close_tab(window: &MainWindow, state: &mut AppState, index: i32) {
     if index < 0 || index as usize >= state.tabs.len() || state.tabs.len() <= 1 {
         return;
     }
@@ -1343,15 +1362,18 @@ pub fn rebuild_right_from_data(data: &[DiffLineData]) -> String {
 pub fn collect_pending_saves(
     window: &MainWindow,
     state: &mut AppState,
-) -> Vec<(usize, bool, String, String)> {
+) -> Vec<(usize, i32, String, String)> {
     // Sync current tab's live model data into tab state first
-    let model = window.get_diff_lines();
-    if let Some(vec_model) = model.as_any().downcast_ref::<VecModel<DiffLineData>>() {
-        let tab = state.current_tab_mut();
-        tab.diff_line_data.clear();
-        for i in 0..vec_model.row_count() {
-            if let Some(row) = vec_model.row_data(i) {
-                tab.diff_line_data.push(row);
+    let current_view_mode = state.current_tab().view_mode;
+    if current_view_mode == 0 {
+        let model = window.get_diff_lines();
+        if let Some(vec_model) = model.as_any().downcast_ref::<VecModel<DiffLineData>>() {
+            let tab = state.current_tab_mut();
+            tab.diff_line_data.clear();
+            for i in 0..vec_model.row_count() {
+                if let Some(row) = vec_model.row_data(i) {
+                    tab.diff_line_data.push(row);
+                }
             }
         }
     }
@@ -1362,30 +1384,66 @@ pub fn collect_pending_saves(
         if !state.tabs[i].has_unsaved_changes {
             continue;
         }
-        let left_path = state.tabs[i].left_path.clone();
-        let left_enc = state.tabs[i].left_encoding.clone();
-        let left_text = rebuild_left_from_data(&state.tabs[i].diff_line_data);
-        if let Some(path) = left_path {
-            let bytes = encode_text(&left_text, &left_enc);
-            let _ = fs::write(path, bytes);
-        } else if !left_text.trim().is_empty() {
-            queue.push((i, true, left_text, left_enc));
-        }
-        let right_path = state.tabs[i].right_path.clone();
-        let right_enc = state.tabs[i].right_encoding.clone();
-        let right_text = rebuild_right_from_data(&state.tabs[i].diff_line_data);
-        if let Some(path) = right_path {
-            let bytes = encode_text(&right_text, &right_enc);
-            let _ = fs::write(path, bytes);
-        } else if !right_text.trim().is_empty() {
-            queue.push((i, false, right_text, right_enc));
-        }
-        // Only clear unsaved flag if both sides were actually saved (have paths)
-        if state.tabs[i].left_path.is_some() && state.tabs[i].right_path.is_some() {
-            state.tabs[i].has_unsaved_changes = false;
+
+        if state.tabs[i].view_mode == 3 {
+            // 3-way tab: save left, base, right
+            let left_text = state.tabs[i].left_lines.join("\n") + "\n";
+            let base_text = state.tabs[i].base_lines.join("\n") + "\n";
+            let right_text = state.tabs[i].right_lines.join("\n") + "\n";
+            let left_enc = state.tabs[i].left_encoding.clone();
+            let right_enc = state.tabs[i].right_encoding.clone();
+            let base_enc = "UTF-8".to_string(); // base uses UTF-8 by default
+
+            if let Some(path) = state.tabs[i].left_path.clone() {
+                let bytes = encode_text(&left_text, &left_enc);
+                let _ = fs::write(path, bytes);
+            } else if !left_text.trim().is_empty() {
+                queue.push((i, 0, left_text, left_enc));
+            }
+            if let Some(path) = state.tabs[i].base_path.clone() {
+                let bytes = encode_text(&base_text, &base_enc);
+                let _ = fs::write(path, bytes);
+            } else if !base_text.trim().is_empty() {
+                queue.push((i, 2, base_text, base_enc));
+            }
+            if let Some(path) = state.tabs[i].right_path.clone() {
+                let bytes = encode_text(&right_text, &right_enc);
+                let _ = fs::write(path, bytes);
+            } else if !right_text.trim().is_empty() {
+                queue.push((i, 1, right_text, right_enc));
+            }
+            // Clear unsaved flag if all three sides have paths
+            if state.tabs[i].left_path.is_some()
+                && state.tabs[i].base_path.is_some()
+                && state.tabs[i].right_path.is_some()
+            {
+                state.tabs[i].has_unsaved_changes = false;
+            }
+        } else {
+            // 2-way tab
+            let left_path = state.tabs[i].left_path.clone();
+            let left_enc = state.tabs[i].left_encoding.clone();
+            let left_text = rebuild_left_from_data(&state.tabs[i].diff_line_data);
+            if let Some(path) = left_path {
+                let bytes = encode_text(&left_text, &left_enc);
+                let _ = fs::write(path, bytes);
+            } else if !left_text.trim().is_empty() {
+                queue.push((i, 0, left_text, left_enc));
+            }
+            let right_path = state.tabs[i].right_path.clone();
+            let right_enc = state.tabs[i].right_encoding.clone();
+            let right_text = rebuild_right_from_data(&state.tabs[i].diff_line_data);
+            if let Some(path) = right_path {
+                let bytes = encode_text(&right_text, &right_enc);
+                let _ = fs::write(path, bytes);
+            } else if !right_text.trim().is_empty() {
+                queue.push((i, 1, right_text, right_enc));
+            }
+            if state.tabs[i].left_path.is_some() && state.tabs[i].right_path.is_some() {
+                state.tabs[i].has_unsaved_changes = false;
+            }
         }
     }
-    // Don't clear the global flag here — it stays until all saves are confirmed or discarded
     queue
 }
 
@@ -1411,6 +1469,29 @@ fn rebuild_right(vec_model: &VecModel<DiffLineData>) -> String {
         lines.push(row.right_text.to_string());
     }
     lines.join("\n") + "\n"
+}
+
+/// Rebuild text for a specific pane (0=left, 1=base, 2=right) from the 3-way VecModel.
+/// Skips ghost lines (empty line_no) since they don't represent real content.
+fn rebuild_three_way_text(vec_model: &VecModel<ThreeWayLineData>, pane: i32) -> String {
+    let mut lines = Vec::new();
+    for i in 0..vec_model.row_count() {
+        let row = vec_model.row_data(i).unwrap();
+        let (line_no, text) = match pane {
+            0 => (&row.left_line_no, &row.left_text),
+            1 => (&row.base_line_no, &row.base_text),
+            _ => (&row.right_line_no, &row.right_text),
+        };
+        // Only include lines that have a real line number (skip ghost lines)
+        if !line_no.is_empty() {
+            lines.push(text.to_string());
+        }
+    }
+    if lines.is_empty() {
+        String::new()
+    } else {
+        lines.join("\n") + "\n"
+    }
 }
 
 fn rebuild_right_after_copy_from_left(
@@ -1804,7 +1885,33 @@ pub fn three_way_edit_line(
         _ => row.right_text = SharedString::from(new_text),
     }
     vec_model.set_row_data(row_index as usize, row);
+
+    // Sync internal line arrays
+    let row_ref = vec_model.row_data(row_index as usize).unwrap();
     let tab = state.current_tab_mut();
+    match pane {
+        0 => {
+            if let Ok(n) = row_ref.left_line_no.parse::<usize>() {
+                if n > 0 && n <= tab.left_lines.len() {
+                    tab.left_lines[n - 1] = new_text.to_string();
+                }
+            }
+        }
+        1 => {
+            if let Ok(n) = row_ref.base_line_no.parse::<usize>() {
+                if n > 0 && n <= tab.base_lines.len() {
+                    tab.base_lines[n - 1] = new_text.to_string();
+                }
+            }
+        }
+        _ => {
+            if let Ok(n) = row_ref.right_line_no.parse::<usize>() {
+                if n > 0 && n <= tab.right_lines.len() {
+                    tab.right_lines[n - 1] = new_text.to_string();
+                }
+            }
+        }
+    }
     tab.has_unsaved_changes = true;
     window.set_has_unsaved_changes(true);
     if !tab.editing_dirty {
@@ -1830,6 +1937,30 @@ pub fn three_way_insert_line_after(
     if insert_at > count {
         return;
     }
+
+    // Sync internal line arrays
+    let current_row = vec_model.row_data(row_index as usize).unwrap();
+    {
+        let tab = state.current_tab_mut();
+        match pane {
+            0 => {
+                let line_no = current_row.left_line_no.parse::<usize>().unwrap_or(1);
+                let pos = line_no.min(tab.left_lines.len());
+                tab.left_lines.insert(pos, String::new());
+            }
+            1 => {
+                let line_no = current_row.base_line_no.parse::<usize>().unwrap_or(1);
+                let pos = line_no.min(tab.base_lines.len());
+                tab.base_lines.insert(pos, String::new());
+            }
+            _ => {
+                let line_no = current_row.right_line_no.parse::<usize>().unwrap_or(1);
+                let pos = line_no.min(tab.right_lines.len());
+                tab.right_lines.insert(pos, String::new());
+            }
+        }
+    }
+
     // Build new row: only the edited pane gets a placeholder line number, others empty
     let new_row = ThreeWayLineData {
         left_line_no: if pane == 0 {
@@ -1910,12 +2041,58 @@ pub fn three_way_delete_line(window: &MainWindow, state: &mut AppState, row_inde
         return;
     }
     let row = vec_model.row_data(idx).unwrap();
-    let can_delete = match pane {
+    let text_empty = match pane {
         0 => row.left_text.is_empty(),
         1 => row.base_text.is_empty(),
         _ => row.right_text.is_empty(),
     };
+    // Count how many real lines remain for this pane (non-ghost rows)
+    let real_line_count = {
+        let mut count = 0usize;
+        for i in 0..vec_model.row_count() {
+            if let Some(r) = vec_model.row_data(i) {
+                let has_line = match pane {
+                    0 => !r.left_line_no.is_empty(),
+                    1 => !r.base_line_no.is_empty(),
+                    _ => !r.right_line_no.is_empty(),
+                };
+                if has_line {
+                    count += 1;
+                }
+            }
+        }
+        count
+    };
+    // Don't delete the last real line — keep at least one row so user can type
+    let can_delete = text_empty && real_line_count > 1;
     if can_delete {
+        // Sync internal line arrays: remove the corresponding real line
+        let line_no_str = match pane {
+            0 => &row.left_line_no,
+            1 => &row.base_line_no,
+            _ => &row.right_line_no,
+        };
+        if let Ok(line_no) = line_no_str.parse::<usize>() {
+            let tab = state.current_tab_mut();
+            match pane {
+                0 => {
+                    if line_no > 0 && line_no <= tab.left_lines.len() {
+                        tab.left_lines.remove(line_no - 1);
+                    }
+                }
+                1 => {
+                    if line_no > 0 && line_no <= tab.base_lines.len() {
+                        tab.base_lines.remove(line_no - 1);
+                    }
+                }
+                _ => {
+                    if line_no > 0 && line_no <= tab.right_lines.len() {
+                        tab.right_lines.remove(line_no - 1);
+                    }
+                }
+            }
+        }
+
         vec_model.remove(idx);
         // Renumber each pane independently
         let mut left_counter = 0usize;
@@ -2440,6 +2617,67 @@ pub fn save_file(window: &MainWindow, state: &mut AppState, save_left: bool) {
     )));
 }
 
+/// Save a pane of 3-way diff.  pane: 0=left, 1=base(middle), 2=right.
+pub fn save_three_way_pane(window: &MainWindow, state: &mut AppState, pane: i32) {
+    let model = window.get_three_way_lines();
+    let vec_model = match model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() {
+        Some(m) => m,
+        None => return,
+    };
+
+    let text = rebuild_three_way_text(vec_model, pane);
+    let tab = state.current_tab();
+    let (path, encoding) = match pane {
+        0 => (tab.left_path.clone(), tab.left_encoding.clone()),
+        1 => (tab.base_path.clone(), tab.base_encoding.clone()),
+        _ => (tab.right_path.clone(), tab.right_encoding.clone()),
+    };
+
+    let path = if let Some(p) = path {
+        p
+    } else {
+        match rfd::FileDialog::new().set_title("Save As").save_file() {
+            Some(p) => {
+                match pane {
+                    0 => {
+                        state.current_tab_mut().left_path = Some(p.clone());
+                        window.set_left_path(SharedString::from(p.to_string_lossy().to_string()));
+                    }
+                    1 => {
+                        state.current_tab_mut().base_path = Some(p.clone());
+                    }
+                    _ => {
+                        state.current_tab_mut().right_path = Some(p.clone());
+                        window.set_right_path(SharedString::from(p.to_string_lossy().to_string()));
+                    }
+                }
+                sync_tab_list(window, state);
+                p
+            }
+            None => return,
+        }
+    };
+
+    let bytes = encode_text(&text, &encoding);
+    if let Err(e) = fs::write(&path, &bytes) {
+        window.set_status_text(SharedString::from(format!("Error saving: {}", e)));
+        return;
+    }
+    state.current_tab_mut().has_unsaved_changes = false;
+    window.set_has_unsaved_changes(false);
+    let side = match pane {
+        0 => "Left",
+        1 => "Middle",
+        _ => "Right",
+    };
+    window.set_status_text(SharedString::from(format!(
+        "{} file saved: {} ({})",
+        side,
+        path.to_string_lossy(),
+        encoding
+    )));
+}
+
 pub fn apply_options(window: &MainWindow, state: &mut AppState, settings: &mut AppSettings) {
     // Read options from window
     settings.ignore_whitespace = window.get_ignore_whitespace();
@@ -2820,6 +3058,10 @@ pub fn new_blank_text_3way(window: &MainWindow, state: &mut AppState) {
         tab.diff_positions.clear();
         tab.diff_stats = String::new();
         tab.has_unsaved_changes = false;
+        tab.editing_dirty = false;
+        tab.left_lines = vec![String::new()];
+        tab.right_lines = vec![String::new()];
+        tab.base_lines = vec![String::new()];
         tab.left_encoding = "UTF-8".to_string();
         tab.right_encoding = "UTF-8".to_string();
         tab.left_eol_type = "LF".to_string();
@@ -2845,6 +3087,10 @@ pub fn new_blank_text_3way(window: &MainWindow, state: &mut AppState) {
     window.set_right_path(SharedString::from(""));
     window.set_base_path(SharedString::from(""));
     window.set_has_unsaved_changes(false);
+    window.set_left_encoding_display(SharedString::from("UTF-8"));
+    window.set_right_encoding_display(SharedString::from("UTF-8"));
+    window.set_left_eol_type(SharedString::from("LF"));
+    window.set_right_eol_type(SharedString::from("LF"));
     window.set_status_text(SharedString::from("New blank 3-way document"));
     sync_tab_list(window, state);
 }
@@ -3197,52 +3443,12 @@ pub fn run_three_way_diff(window: &MainWindow, state: &mut AppState) {
     let left_bytes = fs::read(&left_path).unwrap_or_default();
     let right_bytes = fs::read(&right_path).unwrap_or_default();
 
-    let (base_text, _) = decode_file(&base_bytes);
-    let (left_text, _) = decode_file(&left_bytes);
-    let (right_text, _) = decode_file(&right_bytes);
+    let (base_text, base_enc) = decode_file(&base_bytes);
+    let (left_text, left_enc) = decode_file(&left_bytes);
+    let (right_text, right_enc) = decode_file(&right_bytes);
 
     let result = compute_three_way_diff(&base_text, &left_text, &right_text);
-
-    let line_data: Vec<ThreeWayLineData> = result
-        .lines
-        .iter()
-        .enumerate()
-        .map(|(i, line)| {
-            let status: i32 = match line.status {
-                ThreeWayStatus::Equal => 0,
-                ThreeWayStatus::LeftChanged => 1,
-                ThreeWayStatus::RightChanged => 2,
-                ThreeWayStatus::BothChanged => 3,
-                ThreeWayStatus::Conflict => 4,
-            };
-            let conflict_index = result
-                .conflict_positions
-                .iter()
-                .position(|&pos| pos == i)
-                .map(|idx| idx as i32)
-                .unwrap_or(-1);
-            ThreeWayLineData {
-                base_line_no: line
-                    .base_line_no
-                    .map(|n| SharedString::from(n.to_string()))
-                    .unwrap_or_default(),
-                left_line_no: line
-                    .left_line_no
-                    .map(|n| SharedString::from(n.to_string()))
-                    .unwrap_or_default(),
-                right_line_no: line
-                    .right_line_no
-                    .map(|n| SharedString::from(n.to_string()))
-                    .unwrap_or_default(),
-                base_text: SharedString::from(&line.base_text),
-                left_text: SharedString::from(&line.left_text),
-                right_text: SharedString::from(&line.right_text),
-                status,
-                is_current: conflict_index == 0 && !result.conflict_positions.is_empty(),
-                conflict_index,
-            }
-        })
-        .collect();
+    let line_data = build_three_way_line_data(&result);
 
     let left_name = left_path
         .file_name()
@@ -3261,21 +3467,62 @@ pub fn run_three_way_diff(window: &MainWindow, state: &mut AppState) {
         0
     };
     tab.view_mode = 3;
+    tab.left_encoding = left_enc.to_string();
+    tab.right_encoding = right_enc.to_string();
+    tab.base_encoding = base_enc.to_string();
     tab.title = format!("{} ↔ {} (3-way)", left_name, right_name);
 
     window.set_three_way_lines(ModelRc::new(VecModel::from(line_data)));
-    window.set_conflict_count(result.conflict_count as i32);
+    window.set_conflict_count(result.conflict_positions.len() as i32);
     window.set_current_conflict_index(tab.current_conflict);
     window.set_view_mode(3);
     window.set_left_path(SharedString::from(left_path.to_string_lossy().to_string()));
     window.set_right_path(SharedString::from(right_path.to_string_lossy().to_string()));
     window.set_base_path(SharedString::from(base_path.to_string_lossy().to_string()));
     window.set_status_text(SharedString::from(format!(
-        "{} conflicts found",
-        result.conflict_count
+        "{} differences found",
+        result.conflict_positions.len()
     )));
 
+    let model = window.get_three_way_lines();
+    update_three_way_detail_pane(window, &model, tab.current_conflict);
+
     sync_tab_list(window, state);
+}
+
+/// Recompute 3-way diff from in-memory text (for rescan of edited/blank 3-way docs).
+pub fn recompute_three_way_from_text(
+    window: &MainWindow,
+    state: &mut AppState,
+    base_text: &str,
+    left_text: &str,
+    right_text: &str,
+) {
+    let result = compute_three_way_diff(base_text, left_text, right_text);
+    let line_data = build_three_way_line_data(&result);
+
+    let tab = state.current_tab_mut();
+    tab.three_way_conflict_positions = result.conflict_positions.clone();
+    tab.current_conflict = if result.conflict_positions.is_empty() {
+        -1
+    } else {
+        0
+    };
+    tab.editing_dirty = false;
+    tab.left_lines = left_text.lines().map(String::from).collect();
+    tab.right_lines = right_text.lines().map(String::from).collect();
+    tab.base_lines = base_text.lines().map(String::from).collect();
+
+    window.set_three_way_lines(ModelRc::new(VecModel::from(line_data)));
+    // BUG-2: Reset stale focus state after model replacement
+    window.set_three_way_edit_focus_left_row(-1);
+    window.set_three_way_edit_focus_base_row(-1);
+    window.set_three_way_edit_focus_right_row(-1);
+    window.set_conflict_count(result.conflict_positions.len() as i32);
+    window.set_current_conflict_index(tab.current_conflict);
+
+    let model = window.get_three_way_lines();
+    update_three_way_detail_pane(window, &model, tab.current_conflict);
 }
 
 pub fn navigate_conflict(window: &MainWindow, state: &mut AppState, forward: bool) {
@@ -3319,8 +3566,142 @@ pub fn navigate_conflict(window: &MainWindow, state: &mut AppState, forward: boo
         new_index + 1,
         total
     )));
+
+    update_three_way_detail_pane(window, &model, new_index);
 }
 
+/// Build ThreeWayLineData from ThreeWayResult with block-level conflict_index.
+/// All lines in the same contiguous diff block share the same conflict_index.
+fn build_three_way_line_data(result: &ThreeWayResult) -> Vec<ThreeWayLineData> {
+    // Assign block-level conflict_index: consecutive non-Equal lines share the same index
+    let mut block_indices: Vec<i32> = vec![-1; result.lines.len()];
+    let mut current_block = -1i32;
+    let mut was_in_diff = false;
+    for (i, line) in result.lines.iter().enumerate() {
+        if line.status != ThreeWayStatus::Equal {
+            if !was_in_diff {
+                current_block += 1;
+                was_in_diff = true;
+            }
+            block_indices[i] = current_block;
+        } else {
+            was_in_diff = false;
+        }
+    }
+
+    result
+        .lines
+        .iter()
+        .enumerate()
+        .map(|(i, line)| {
+            let status: i32 = match line.status {
+                ThreeWayStatus::Equal => 0,
+                ThreeWayStatus::LeftChanged => 1,
+                ThreeWayStatus::RightChanged => 2,
+                ThreeWayStatus::BothChanged => 3,
+                ThreeWayStatus::Conflict => 4,
+            };
+            let conflict_index = block_indices[i];
+            ThreeWayLineData {
+                base_line_no: line
+                    .base_line_no
+                    .map(|n: u32| SharedString::from(n.to_string()))
+                    .unwrap_or_default(),
+                left_line_no: line
+                    .left_line_no
+                    .map(|n: u32| SharedString::from(n.to_string()))
+                    .unwrap_or_default(),
+                right_line_no: line
+                    .right_line_no
+                    .map(|n: u32| SharedString::from(n.to_string()))
+                    .unwrap_or_default(),
+                base_text: SharedString::from(&line.base_text),
+                left_text: SharedString::from(&line.left_text),
+                right_text: SharedString::from(&line.right_text),
+                status,
+                is_current: conflict_index == 0 && !result.conflict_positions.is_empty(),
+                conflict_index,
+            }
+        })
+        .collect()
+}
+
+fn update_three_way_detail_pane(
+    window: &MainWindow,
+    model: &ModelRc<ThreeWayLineData>,
+    conflict_index: i32,
+) {
+    if conflict_index < 0 {
+        window.set_detail_has_left(false);
+        window.set_detail_has_base(false);
+        window.set_detail_has_right(false);
+        window.set_detail_left_lines(ModelRc::new(VecModel::from(Vec::<DetailLineData>::new())));
+        window.set_detail_base_lines(ModelRc::new(VecModel::from(Vec::<DetailLineData>::new())));
+        window.set_detail_right_lines(ModelRc::new(VecModel::from(Vec::<DetailLineData>::new())));
+        return;
+    }
+
+    let mut left_lines: Vec<DetailLineData> = Vec::new();
+    let mut base_lines: Vec<DetailLineData> = Vec::new();
+    let mut right_lines: Vec<DetailLineData> = Vec::new();
+
+    let count = model.row_count();
+    for i in 0..count {
+        let row = model.row_data(i).unwrap();
+        if row.conflict_index != conflict_index {
+            continue;
+        }
+        let status = row.status;
+
+        // Left side (always include for 3-way)
+        let seg = ModelRc::new(VecModel::from(vec![WordSegment {
+            text: row.left_text.clone(),
+            is_changed: status == 1 || status == 3 || status == 4,
+        }]));
+        left_lines.push(DetailLineData {
+            segments: seg,
+            is_current: true,
+            status,
+        });
+
+        // Base (middle) side (always include for 3-way)
+        let seg = ModelRc::new(VecModel::from(vec![WordSegment {
+            text: row.base_text.clone(),
+            is_changed: status == 3 || status == 4,
+        }]));
+        base_lines.push(DetailLineData {
+            segments: seg,
+            is_current: true,
+            status,
+        });
+
+        // Right side (always include for 3-way)
+        let seg = ModelRc::new(VecModel::from(vec![WordSegment {
+            text: row.right_text.clone(),
+            is_changed: status == 2 || status == 3 || status == 4,
+        }]));
+        right_lines.push(DetailLineData {
+            segments: seg,
+            is_current: true,
+            status,
+        });
+    }
+
+    let has_left = !left_lines.is_empty();
+    let has_base = !base_lines.is_empty();
+    let has_right = !right_lines.is_empty();
+    window.set_detail_left_lines(ModelRc::new(VecModel::from(left_lines)));
+    window.set_detail_base_lines(ModelRc::new(VecModel::from(base_lines)));
+    window.set_detail_right_lines(ModelRc::new(VecModel::from(right_lines)));
+    window.set_detail_has_left(has_left);
+    window.set_detail_has_base(has_base);
+    window.set_detail_has_right(has_right);
+    window.set_detail_left_scroll_y(0.0);
+    window.set_detail_base_scroll_y(0.0);
+    window.set_detail_right_scroll_y(0.0);
+}
+
+/// Copy left text to base (middle) pane for the given diff index.
 pub fn resolve_conflict_use_left(window: &MainWindow, state: &mut AppState, conflict_index: i32) {
     let tab = state.current_tab();
     if conflict_index < 0 || conflict_index as usize >= tab.three_way_conflict_positions.len() {
@@ -3330,32 +3711,62 @@ pub fn resolve_conflict_use_left(window: &MainWindow, state: &mut AppState, conf
     let pos = tab.three_way_conflict_positions[conflict_index as usize];
     let model = window.get_three_way_lines();
     if let Some(vec_model) = model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() {
-        if let Some(mut row) = vec_model.row_data(pos) {
-            row.right_text = row.left_text.clone();
-            row.status = 3; // BothChanged (resolved)
-            row.conflict_index = -1;
-            vec_model.set_row_data(pos, row);
+        // Find all rows in this block (same conflict_index)
+        let block_ci = vec_model
+            .row_data(pos)
+            .map(|r| r.conflict_index)
+            .unwrap_or(-1);
+        if block_ci < 0 {
+            return;
+        }
+        for i in 0..vec_model.row_count() {
+            if let Some(mut row) = vec_model.row_data(i) {
+                if row.conflict_index == block_ci {
+                    if !row.left_line_no.is_empty() {
+                        // Left has a real line — copy it to base
+                        row.base_text = row.left_text.clone();
+                        if row.base_line_no.is_empty() {
+                            row.base_line_no = SharedString::from("+");
+                        }
+                    }
+                    // Don't touch base_text if left is a ghost row
+                    row.status = if row.left_text == row.right_text {
+                        0
+                    } else {
+                        2
+                    };
+                    vec_model.set_row_data(i, row);
+                }
+            }
+        }
+        // Rebuild tab.base_lines from VecModel (authoritative after copy)
+        let tab = state.current_tab_mut();
+        tab.base_lines = Vec::new();
+        for i in 0..vec_model.row_count() {
+            if let Some(row) = vec_model.row_data(i) {
+                if !row.base_line_no.is_empty() {
+                    tab.base_lines.push(row.base_text.to_string());
+                }
+            }
         }
     }
 
-    // Remove from conflict positions
     let tab = state.current_tab_mut();
-    tab.three_way_conflict_positions.retain(|&p| p != pos);
-    window.set_conflict_count(tab.three_way_conflict_positions.len() as i32);
+    tab.has_unsaved_changes = true;
+    tab.editing_dirty = true;
+    window.set_has_unsaved_changes(true);
+    window.set_status_text(SharedString::from("Left → Middle copied"));
 
-    if tab.three_way_conflict_positions.is_empty() {
-        tab.current_conflict = -1;
-        window.set_status_text(SharedString::from("All conflicts resolved"));
-    } else {
-        let new_idx = (conflict_index as usize).min(tab.three_way_conflict_positions.len() - 1);
-        tab.current_conflict = new_idx as i32;
-        window.set_status_text(SharedString::from(format!(
-            "{} conflicts remaining",
-            tab.three_way_conflict_positions.len()
-        )));
-    }
+    // BUG-3: Clear stale focus state after copy
+    window.set_three_way_edit_focus_left_row(-1);
+    window.set_three_way_edit_focus_base_row(-1);
+    window.set_three_way_edit_focus_right_row(-1);
+
+    let model = window.get_three_way_lines();
+    update_three_way_detail_pane(window, &model, conflict_index);
 }
 
+/// Copy right text to base (middle) pane for the given diff index.
 pub fn resolve_conflict_use_right(window: &MainWindow, state: &mut AppState, conflict_index: i32) {
     let tab = state.current_tab();
     if conflict_index < 0 || conflict_index as usize >= tab.three_way_conflict_positions.len() {
@@ -3365,29 +3776,105 @@ pub fn resolve_conflict_use_right(window: &MainWindow, state: &mut AppState, con
     let pos = tab.three_way_conflict_positions[conflict_index as usize];
     let model = window.get_three_way_lines();
     if let Some(vec_model) = model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() {
-        if let Some(mut row) = vec_model.row_data(pos) {
-            row.left_text = row.right_text.clone();
-            row.status = 3; // BothChanged (resolved)
-            row.conflict_index = -1;
-            vec_model.set_row_data(pos, row);
+        let block_ci = vec_model
+            .row_data(pos)
+            .map(|r| r.conflict_index)
+            .unwrap_or(-1);
+        if block_ci < 0 {
+            return;
+        }
+        for i in 0..vec_model.row_count() {
+            if let Some(mut row) = vec_model.row_data(i) {
+                if row.conflict_index == block_ci {
+                    if !row.right_line_no.is_empty() {
+                        // Right has a real line — copy it to base
+                        row.base_text = row.right_text.clone();
+                        if row.base_line_no.is_empty() {
+                            row.base_line_no = SharedString::from("+");
+                        }
+                    }
+                    // Don't touch base_text if right is a ghost row
+                    row.status = if row.left_text == row.right_text {
+                        0
+                    } else {
+                        1
+                    };
+                    vec_model.set_row_data(i, row);
+                }
+            }
+        }
+        // Rebuild tab.base_lines from VecModel (authoritative after copy)
+        let tab = state.current_tab_mut();
+        tab.base_lines = Vec::new();
+        for i in 0..vec_model.row_count() {
+            if let Some(row) = vec_model.row_data(i) {
+                if !row.base_line_no.is_empty() {
+                    tab.base_lines.push(row.base_text.to_string());
+                }
+            }
         }
     }
 
     let tab = state.current_tab_mut();
-    tab.three_way_conflict_positions.retain(|&p| p != pos);
-    window.set_conflict_count(tab.three_way_conflict_positions.len() as i32);
+    tab.has_unsaved_changes = true;
+    tab.editing_dirty = true;
+    window.set_has_unsaved_changes(true);
+    window.set_status_text(SharedString::from("Right → Middle copied"));
 
-    if tab.three_way_conflict_positions.is_empty() {
-        tab.current_conflict = -1;
-        window.set_status_text(SharedString::from("All conflicts resolved"));
-    } else {
-        let new_idx = (conflict_index as usize).min(tab.three_way_conflict_positions.len() - 1);
-        tab.current_conflict = new_idx as i32;
-        window.set_status_text(SharedString::from(format!(
-            "{} conflicts remaining",
-            tab.three_way_conflict_positions.len()
-        )));
+    // BUG-3: Clear stale focus state after copy
+    window.set_three_way_edit_focus_left_row(-1);
+    window.set_three_way_edit_focus_base_row(-1);
+    window.set_three_way_edit_focus_right_row(-1);
+
+    let model = window.get_three_way_lines();
+    update_three_way_detail_pane(window, &model, conflict_index);
+}
+
+/// Copy left to middle and advance to next diff block.
+pub fn resolve_use_left_and_next(window: &MainWindow, state: &mut AppState) {
+    let conflict_index = state.current_tab().current_conflict;
+    resolve_conflict_use_left(window, state, conflict_index);
+    navigate_conflict(window, state, true);
+}
+
+/// Copy right to middle and advance to next diff block.
+pub fn resolve_use_right_and_next(window: &MainWindow, state: &mut AppState) {
+    let conflict_index = state.current_tab().current_conflict;
+    resolve_conflict_use_right(window, state, conflict_index);
+    navigate_conflict(window, state, true);
+}
+
+/// Copy all left diffs to middle (resolve all with left).
+pub fn resolve_all_use_left(window: &MainWindow, state: &mut AppState) {
+    let tab = state.current_tab();
+    let count = tab.three_way_conflict_positions.len();
+    if count == 0 {
+        return;
     }
+    // Resolve from last to first to avoid index shifts
+    for i in (0..count as i32).rev() {
+        resolve_conflict_use_left(window, state, i);
+    }
+    window.set_status_text(SharedString::from(format!(
+        "All {} blocks: Left → Middle",
+        count
+    )));
+}
+
+/// Copy all right diffs to middle (resolve all with right).
+pub fn resolve_all_use_right(window: &MainWindow, state: &mut AppState) {
+    let tab = state.current_tab();
+    let count = tab.three_way_conflict_positions.len();
+    if count == 0 {
+        return;
+    }
+    for i in (0..count as i32).rev() {
+        resolve_conflict_use_right(window, state, i);
+    }
+    window.set_status_text(SharedString::from(format!(
+        "All {} blocks: Right → Middle",
+        count
+    )));
 }
 
 // --- Folder file operations ---
@@ -3645,6 +4132,24 @@ pub fn rescan(window: &MainWindow, state: &mut AppState) {
             recompute_diff_from_text(window, state, &left_text, &right_text);
             window.set_status_text(SharedString::from("Compared"));
         }
+    } else if tab.view_mode == 3
+        && tab.base_path.is_some()
+        && tab.left_path.is_some()
+        && tab.right_path.is_some()
+        && !tab.editing_dirty
+    {
+        run_three_way_diff(window, state);
+        window.set_status_text(SharedString::from("Files rescanned"));
+    } else if tab.view_mode == 3 {
+        // 3-way editing in progress or blank: rebuild from VecModel (authoritative source)
+        let model = window.get_three_way_lines();
+        if let Some(vec_model) = model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() {
+            let left_text = rebuild_three_way_text(vec_model, 0);
+            let base_text = rebuild_three_way_text(vec_model, 1);
+            let right_text = rebuild_three_way_text(vec_model, 2);
+            recompute_three_way_from_text(window, state, &base_text, &left_text, &right_text);
+        }
+        window.set_status_text(SharedString::from("Compared"));
     } else if tab.view_mode == 1 {
         run_folder_compare(window, state);
         window.set_status_text(SharedString::from("Folders rescanned"));

--- a/src/diff/three_way.rs
+++ b/src/diff/three_way.rs
@@ -1,12 +1,13 @@
-use similar::{ChangeTag, TextDiff};
+use similar::TextDiff;
 
+/// OP_TYPE equivalent from WinMerge
 #[derive(Debug, Clone, PartialEq)]
 pub enum ThreeWayStatus {
-    Equal,        // Same in all three
-    LeftChanged,  // Only left changed from base
-    RightChanged, // Only right changed from base
-    BothChanged,  // Both changed same way (auto-merge)
-    Conflict,     // Both changed differently
+    Equal,        // OP_NONE:     All three are the same
+    LeftChanged,  // OP_1STONLY:  Only left changed (Base=Right)
+    RightChanged, // OP_3RDONLY:  Only right changed (Base=Left)
+    BothChanged,  // OP_2NDONLY:  Left=Right but differ from Base
+    Conflict,     // OP_DIFF:     Left!=Right!=Base
 }
 
 #[derive(Debug, Clone)]
@@ -23,12 +24,58 @@ pub struct ThreeWayLine {
 #[derive(Debug, Clone)]
 pub struct ThreeWayResult {
     pub lines: Vec<ThreeWayLine>,
+    #[allow(dead_code)]
     pub conflict_count: u32,
+    /// Index into `lines` where each diff block starts.
     pub conflict_positions: Vec<usize>,
 }
 
-/// Compute a 3-way diff given base, left, and right texts.
-/// Uses base↔left and base↔right diffs to detect conflicts.
+/// A hunk from a 2-way diff: a range of "old" lines replaced by "new" lines.
+#[derive(Debug, Clone)]
+struct Hunk {
+    old_start: usize, // inclusive (base side)
+    old_end: usize,   // exclusive
+    new_start: usize, // inclusive (file side)
+    new_end: usize,   // exclusive
+}
+
+/// A merged 3-way diff block, analogous to WinMerge's DIFFRANGE.
+#[derive(Debug)]
+struct DiffBlock {
+    left_start: usize,
+    left_end: usize, // exclusive
+    base_start: usize,
+    base_end: usize, // exclusive
+    right_start: usize,
+    right_end: usize, // exclusive
+    status: ThreeWayStatus,
+}
+
+/// Extract hunks from a TextDiff (old=base, new=file).
+fn extract_hunks(diff: &TextDiff<'_, '_, '_, str>) -> Vec<Hunk> {
+    let mut hunks = Vec::new();
+    for op in diff.ops() {
+        let old = op.old_range();
+        let new = op.new_range();
+        match op.tag() {
+            similar::DiffTag::Equal => {}
+            _ => {
+                hunks.push(Hunk {
+                    old_start: old.start,
+                    old_end: old.end,
+                    new_start: new.start,
+                    new_end: new.end,
+                });
+            }
+        }
+    }
+    hunks
+}
+
+/// Core 3-way diff: implements Make3wayDiff algorithm from WinMerge.
+///
+/// Runs base↔left and base↔right 2-way diffs, then merges the hunk lists
+/// by walking them in base line-number space, grouping overlapping hunks.
 pub fn compute_three_way_diff(
     base_text: &str,
     left_text: &str,
@@ -38,145 +85,303 @@ pub fn compute_three_way_diff(
     let left_lines: Vec<&str> = left_text.lines().collect();
     let right_lines: Vec<&str> = right_text.lines().collect();
 
-    // Compute base→left and base→right changes
+    // Step 1: Two pairwise 2-way diffs (base is "old" in both)
     let left_diff = TextDiff::from_lines(base_text, left_text);
     let right_diff = TextDiff::from_lines(base_text, right_text);
 
-    let left_changes = collect_line_changes(&left_diff);
-    let right_changes = collect_line_changes(&right_diff);
+    let left_hunks = extract_hunks(&left_diff);
+    let right_hunks = extract_hunks(&right_diff);
 
+    // Step 2: Merge hunks using Make3wayDiff-style overlap detection
+    let blocks = merge_hunks(
+        &left_hunks,
+        &right_hunks,
+        &base_lines,
+        &left_lines,
+        &right_lines,
+    );
+
+    // Step 3: Build output lines with ghost-line alignment
+    build_result_lines(&blocks, &base_lines, &left_lines, &right_lines)
+}
+
+/// Merge two hunk lists (base↔left, base↔right) into 3-way diff blocks.
+/// Implements WinMerge's Make3wayDiff overlap-grouping algorithm.
+fn merge_hunks(
+    left_hunks: &[Hunk],
+    right_hunks: &[Hunk],
+    _base_lines: &[&str],
+    left_lines: &[&str],
+    right_lines: &[&str],
+) -> Vec<DiffBlock> {
+    let mut blocks = Vec::new();
+    let mut li = 0usize; // cursor into left_hunks
+    let mut ri = 0usize; // cursor into right_hunks
+
+    // Track cumulative positions for computing file-side ranges
+    // when one side has no hunk in a group
+    let mut base_pos = 0usize;
+    let mut left_pos = 0usize;
+    let mut right_pos = 0usize;
+
+    loop {
+        let lh = left_hunks.get(li);
+        let rh = right_hunks.get(ri);
+
+        if lh.is_none() && rh.is_none() {
+            break;
+        }
+
+        let l_base_start = lh.map(|h| h.old_start).unwrap_or(usize::MAX);
+        let r_base_start = rh.map(|h| h.old_start).unwrap_or(usize::MAX);
+
+        if l_base_start == usize::MAX && r_base_start == usize::MAX {
+            break;
+        }
+
+        // Determine which hunk(s) start first in base space
+        let first_base_start = l_base_start.min(r_base_start);
+
+        // Advance positions up to this block's base start
+        let skip = first_base_start - base_pos;
+        base_pos = first_base_start;
+        left_pos += skip;
+        right_pos += skip;
+
+        // Collect overlapping hunks into one group
+        let mut group_base_end = base_pos;
+        let mut group_has_left = false;
+        let mut group_has_right = false;
+        #[allow(unused_mut)]
+        let mut group_left_start;
+        #[allow(unused_mut)]
+        let mut group_left_end;
+        #[allow(unused_mut)]
+        let mut group_right_start;
+        #[allow(unused_mut)]
+        let mut group_right_end;
+        let group_li_start = li;
+        let group_ri_start = ri;
+
+        // Seed the group with the first hunk
+        if l_base_start <= r_base_start {
+            if let Some(h) = lh {
+                group_base_end = h.old_end;
+                group_has_left = true;
+                li += 1;
+            }
+        } else {
+            if let Some(h) = rh {
+                group_base_end = h.old_end;
+                group_has_right = true;
+                ri += 1;
+            }
+        }
+
+        // Expand group with overlapping hunks from both sides
+        loop {
+            let mut expanded = false;
+
+            if let Some(h) = left_hunks.get(li) {
+                if h.old_start <= group_base_end {
+                    group_has_left = true;
+                    group_base_end = group_base_end.max(h.old_end);
+                    li += 1;
+                    expanded = true;
+                }
+            }
+
+            if let Some(h) = right_hunks.get(ri) {
+                if h.old_start <= group_base_end {
+                    group_has_right = true;
+                    group_base_end = group_base_end.max(h.old_end);
+                    ri += 1;
+                    expanded = true;
+                }
+            }
+
+            if !expanded {
+                break;
+            }
+        }
+
+        // Compute file-side ranges properly.
+        // For a side with no hunk, it mirrors base exactly.
+        // For a side with hunks, compute the total file-side span:
+        //   start = file position at block's base_start
+        //   end   = start + (equal lines before first hunk) + (hunk new lines) + (equal between hunks) + (equal after last hunk)
+        // Simplified: file_end = file_start + base_count + net_insertions
+        //   where net_insertions = sum(new_count - old_count) for each hunk in this group on this side.
+        let base_count = group_base_end - base_pos;
+        if !group_has_left {
+            group_left_start = left_pos;
+            group_left_end = left_pos + base_count;
+        } else {
+            // Recompute from left_pos: total file lines = base_count + net change from hunks
+            group_left_start = left_pos;
+            let mut net: isize = 0;
+            // Walk left hunks that were consumed in this group (from the saved start to current li)
+            for h in &left_hunks[group_li_start..li] {
+                let old_count = (h.old_end - h.old_start) as isize;
+                let new_count = (h.new_end - h.new_start) as isize;
+                net += new_count - old_count;
+            }
+            group_left_end = ((left_pos + base_count) as isize + net).max(0) as usize;
+            group_left_end = group_left_end.min(left_lines.len());
+        }
+        if !group_has_right {
+            group_right_start = right_pos;
+            group_right_end = right_pos + base_count;
+        } else {
+            group_right_start = right_pos;
+            let mut net: isize = 0;
+            for h in &right_hunks[group_ri_start..ri] {
+                let old_count = (h.old_end - h.old_start) as isize;
+                let new_count = (h.new_end - h.new_start) as isize;
+                net += new_count - old_count;
+            }
+            group_right_end = ((right_pos + base_count) as isize + net).max(0) as usize;
+            group_right_end = group_right_end.min(right_lines.len());
+        }
+
+        // Determine status (OP_TYPE)
+        let status = if group_has_left && group_has_right {
+            // Both sides changed — check if Left == Right (Comp02Functor)
+            let left_new: Vec<&str> = left_lines[group_left_start..group_left_end].to_vec();
+            let right_new: Vec<&str> = right_lines[group_right_start..group_right_end].to_vec();
+            if left_new == right_new {
+                ThreeWayStatus::BothChanged // OP_2NDONLY
+            } else {
+                ThreeWayStatus::Conflict // OP_DIFF
+            }
+        } else if group_has_left {
+            ThreeWayStatus::LeftChanged // OP_1STONLY
+        } else {
+            ThreeWayStatus::RightChanged // OP_3RDONLY
+        };
+
+        blocks.push(DiffBlock {
+            left_start: group_left_start,
+            left_end: group_left_end,
+            base_start: base_pos,
+            base_end: group_base_end,
+            right_start: group_right_start,
+            right_end: group_right_end,
+            status,
+        });
+
+        // Advance positions past this block
+        base_pos = group_base_end;
+        left_pos = group_left_end;
+        right_pos = group_right_end;
+    }
+
+    blocks
+}
+
+/// Build the output ThreeWayResult from diff blocks, inserting ghost lines
+/// so all 3 panes have equal line counts within each block.
+fn build_result_lines(
+    blocks: &[DiffBlock],
+    base_lines: &[&str],
+    left_lines: &[&str],
+    right_lines: &[&str],
+) -> ThreeWayResult {
     let mut result_lines = Vec::new();
     let mut conflict_positions = Vec::new();
     let mut conflict_count = 0u32;
 
-    let mut base_idx = 0u32;
-    let mut left_idx = 0u32;
-    let mut right_idx = 0u32;
+    let mut base_pos = 0usize;
+    let mut left_pos = 0usize;
+    let mut right_pos = 0usize;
 
-    let max_base = base_lines.len() as u32;
-
-    // Walk through base lines and detect changes
-    let mut li = 0; // index into left_changes
-    let mut ri = 0; // index into right_changes
-
-    while base_idx < max_base || li < left_changes.len() as u32 || ri < right_changes.len() as u32 {
-        let left_change = left_changes.get(li as usize);
-        let right_change = right_changes.get(ri as usize);
-
-        // Check if current base line has changes
-        let left_at_base = left_change
-            .map(|c| c.base_line == base_idx)
-            .unwrap_or(false);
-        let right_at_base = right_change
-            .map(|c| c.base_line == base_idx)
-            .unwrap_or(false);
-
-        if left_at_base && right_at_base {
-            let lc = left_change.unwrap();
-            let rc = right_change.unwrap();
-
-            if lc.new_text == rc.new_text {
-                // Both changed the same way - auto-merge
-                left_idx += 1;
-                right_idx += 1;
-                base_idx += 1;
-                result_lines.push(ThreeWayLine {
-                    base_text: base_lines
-                        .get(lc.base_line as usize)
-                        .unwrap_or(&"")
-                        .to_string(),
-                    left_text: lc.new_text.clone(),
-                    right_text: rc.new_text.clone(),
-                    status: ThreeWayStatus::BothChanged,
-                    base_line_no: Some(base_idx),
-                    left_line_no: Some(left_idx),
-                    right_line_no: Some(right_idx),
-                });
-            } else {
-                // Conflict
-                conflict_positions.push(result_lines.len());
-                conflict_count += 1;
-                left_idx += 1;
-                right_idx += 1;
-                base_idx += 1;
-                result_lines.push(ThreeWayLine {
-                    base_text: base_lines
-                        .get(lc.base_line as usize)
-                        .unwrap_or(&"")
-                        .to_string(),
-                    left_text: lc.new_text.clone(),
-                    right_text: rc.new_text.clone(),
-                    status: ThreeWayStatus::Conflict,
-                    base_line_no: Some(base_idx),
-                    left_line_no: Some(left_idx),
-                    right_line_no: Some(right_idx),
-                });
-            }
-            li += 1;
-            ri += 1;
-        } else if left_at_base {
-            let lc = left_change.unwrap();
-            left_idx += 1;
-            right_idx += 1;
-            base_idx += 1;
+    for block in blocks {
+        // Equal lines before this block
+        while base_pos < block.base_start {
             result_lines.push(ThreeWayLine {
-                base_text: base_lines
-                    .get(lc.base_line as usize)
-                    .unwrap_or(&"")
-                    .to_string(),
-                left_text: lc.new_text.clone(),
-                right_text: right_lines
-                    .get(right_idx as usize - 1)
-                    .unwrap_or(&"")
-                    .to_string(),
-                status: ThreeWayStatus::LeftChanged,
-                base_line_no: Some(base_idx),
-                left_line_no: Some(left_idx),
-                right_line_no: Some(right_idx),
-            });
-            li += 1;
-        } else if right_at_base {
-            let rc = right_change.unwrap();
-            left_idx += 1;
-            right_idx += 1;
-            base_idx += 1;
-            result_lines.push(ThreeWayLine {
-                base_text: base_lines
-                    .get(rc.base_line as usize)
-                    .unwrap_or(&"")
-                    .to_string(),
-                left_text: left_lines
-                    .get(left_idx as usize - 1)
-                    .unwrap_or(&"")
-                    .to_string(),
-                right_text: rc.new_text.clone(),
-                status: ThreeWayStatus::RightChanged,
-                base_line_no: Some(base_idx),
-                left_line_no: Some(left_idx),
-                right_line_no: Some(right_idx),
-            });
-            ri += 1;
-        } else if base_idx < max_base {
-            // No changes at this base line
-            left_idx += 1;
-            right_idx += 1;
-            base_idx += 1;
-            let text = base_lines
-                .get(base_idx as usize - 1)
-                .unwrap_or(&"")
-                .to_string();
-            result_lines.push(ThreeWayLine {
-                base_text: text.clone(),
-                left_text: text.clone(),
-                right_text: text,
+                left_text: left_lines.get(left_pos).unwrap_or(&"").to_string(),
+                base_text: base_lines.get(base_pos).unwrap_or(&"").to_string(),
+                right_text: right_lines.get(right_pos).unwrap_or(&"").to_string(),
                 status: ThreeWayStatus::Equal,
-                base_line_no: Some(base_idx),
-                left_line_no: Some(left_idx),
-                right_line_no: Some(right_idx),
+                left_line_no: Some(left_pos as u32 + 1),
+                base_line_no: Some(base_pos as u32 + 1),
+                right_line_no: Some(right_pos as u32 + 1),
             });
-        } else {
-            break;
+            base_pos += 1;
+            left_pos += 1;
+            right_pos += 1;
         }
+
+        // Diff block: insert lines with ghost-line alignment
+        let left_count = block.left_end - block.left_start;
+        let base_count = block.base_end - block.base_start;
+        let right_count = block.right_end - block.right_start;
+        let max_lines = left_count.max(base_count).max(right_count);
+
+        conflict_positions.push(result_lines.len());
+        if block.status == ThreeWayStatus::Conflict {
+            conflict_count += 1;
+        }
+
+        for j in 0..max_lines {
+            let (lt, l_no) = if j < left_count {
+                let idx = block.left_start + j;
+                (
+                    left_lines.get(idx).unwrap_or(&"").to_string(),
+                    Some(idx as u32 + 1),
+                )
+            } else {
+                (String::new(), None) // Ghost line
+            };
+            let (bt, b_no) = if j < base_count {
+                let idx = block.base_start + j;
+                (
+                    base_lines.get(idx).unwrap_or(&"").to_string(),
+                    Some(idx as u32 + 1),
+                )
+            } else {
+                (String::new(), None)
+            };
+            let (rt, r_no) = if j < right_count {
+                let idx = block.right_start + j;
+                (
+                    right_lines.get(idx).unwrap_or(&"").to_string(),
+                    Some(idx as u32 + 1),
+                )
+            } else {
+                (String::new(), None)
+            };
+
+            result_lines.push(ThreeWayLine {
+                left_text: lt,
+                base_text: bt,
+                right_text: rt,
+                status: block.status.clone(),
+                left_line_no: l_no,
+                base_line_no: b_no,
+                right_line_no: r_no,
+            });
+        }
+
+        base_pos = block.base_end;
+        left_pos = block.left_end;
+        right_pos = block.right_end;
+    }
+
+    // Trailing equal lines
+    while base_pos < base_lines.len() {
+        result_lines.push(ThreeWayLine {
+            left_text: left_lines.get(left_pos).unwrap_or(&"").to_string(),
+            base_text: base_lines.get(base_pos).unwrap_or(&"").to_string(),
+            right_text: right_lines.get(right_pos).unwrap_or(&"").to_string(),
+            status: ThreeWayStatus::Equal,
+            left_line_no: Some(left_pos as u32 + 1),
+            base_line_no: Some(base_pos as u32 + 1),
+            right_line_no: Some(right_pos as u32 + 1),
+        });
+        base_pos += 1;
+        left_pos += 1;
+        right_pos += 1;
     }
 
     ThreeWayResult {
@@ -186,56 +391,26 @@ pub fn compute_three_way_diff(
     }
 }
 
-#[derive(Debug)]
-struct LineChange {
-    base_line: u32, // 0-indexed base line that was modified
-    new_text: String,
-}
-
-fn collect_line_changes<'a>(diff: &TextDiff<'a, 'a, 'a, str>) -> Vec<LineChange> {
-    let mut changes = Vec::new();
-    let all_changes: Vec<_> = diff.iter_all_changes().collect();
-    let mut base_line: u32 = 0;
-    let mut i = 0;
-
-    while i < all_changes.len() {
-        let change = &all_changes[i];
-        match change.tag() {
-            ChangeTag::Equal => {
-                base_line += 1;
-                i += 1;
-            }
-            ChangeTag::Delete => {
-                // Modified: delete followed by insert
-                if i + 1 < all_changes.len() && all_changes[i + 1].tag() == ChangeTag::Insert {
-                    let new_text = all_changes[i + 1]
-                        .value()
-                        .trim_end_matches('\n')
-                        .to_string();
-                    changes.push(LineChange {
-                        base_line,
-                        new_text,
-                    });
-                    base_line += 1;
-                    i += 2;
-                } else {
-                    // Pure deletion
-                    changes.push(LineChange {
-                        base_line,
-                        new_text: String::new(),
-                    });
-                    base_line += 1;
-                    i += 1;
-                }
-            }
-            ChangeTag::Insert => {
-                // Pure insertion (no base line consumed)
-                i += 1;
-            }
+/// Rebuild text for one pane from ThreeWayResult lines, skipping ghost lines.
+/// pane: 0=left, 1=base, 2=right.
+#[cfg(test)]
+fn rebuild_pane_text(lines: &[ThreeWayLine], pane: i32) -> String {
+    let mut out = Vec::new();
+    for line in lines {
+        let (line_no, text) = match pane {
+            0 => (&line.left_line_no, &line.left_text),
+            1 => (&line.base_line_no, &line.base_text),
+            _ => (&line.right_line_no, &line.right_text),
+        };
+        if line_no.is_some() {
+            out.push(text.as_str());
         }
     }
-
-    changes
+    if out.is_empty() {
+        String::new()
+    } else {
+        out.join("\n") + "\n"
+    }
 }
 
 #[cfg(test)]
@@ -245,17 +420,20 @@ mod tests {
     #[test]
     fn test_no_conflicts() {
         let base = "aaa\nbbb\nccc\n";
-        let left = "AAA\nbbb\nccc\n"; // changed line 1
-        let right = "aaa\nbbb\nCCC\n"; // changed line 3
+        let left = "AAA\nbbb\nccc\n";
+        let right = "aaa\nbbb\nCCC\n";
         let result = compute_three_way_diff(base, left, right);
         assert_eq!(result.conflict_count, 0);
+        assert_eq!(result.lines[0].status, ThreeWayStatus::LeftChanged);
+        assert_eq!(result.lines[1].status, ThreeWayStatus::Equal);
+        assert_eq!(result.lines[2].status, ThreeWayStatus::RightChanged);
     }
 
     #[test]
     fn test_conflict() {
         let base = "aaa\nbbb\nccc\n";
-        let left = "XXX\nbbb\nccc\n"; // changed line 1
-        let right = "YYY\nbbb\nccc\n"; // changed line 1 differently
+        let left = "XXX\nbbb\nccc\n";
+        let right = "YYY\nbbb\nccc\n";
         let result = compute_three_way_diff(base, left, right);
         assert_eq!(result.conflict_count, 1);
         assert_eq!(result.lines[0].status, ThreeWayStatus::Conflict);
@@ -269,5 +447,599 @@ mod tests {
         let result = compute_three_way_diff(base, left, right);
         assert_eq!(result.conflict_count, 0);
         assert_eq!(result.lines[0].status, ThreeWayStatus::BothChanged);
+    }
+
+    #[test]
+    fn test_left_insertion() {
+        let base = "aaa\n";
+        let left = "aaa\nbbb\n";
+        let right = "aaa\n";
+        let result = compute_three_way_diff(base, left, right);
+        assert_eq!(result.lines[0].status, ThreeWayStatus::Equal);
+        assert_eq!(result.lines[1].status, ThreeWayStatus::LeftChanged);
+        assert_eq!(result.lines[1].left_text, "bbb");
+        // Ghost lines: base and right should have no line number
+        assert!(result.lines[1].base_line_no.is_none());
+        assert!(result.lines[1].right_line_no.is_none());
+    }
+
+    #[test]
+    fn test_overlapping_hunks() {
+        // Left changes lines 1-2, Right changes lines 2-3
+        // These overlap at line 2, so should merge into one conflict block
+        let base = "aaa\nbbb\nccc\nddd\n";
+        let left = "AAA\nBBB\nccc\nddd\n";
+        let right = "aaa\nXXX\nYYY\nddd\n";
+        let result = compute_three_way_diff(base, left, right);
+        // Lines 0-2 should be one conflict block (overlapping at base line 1)
+        let non_equal: Vec<_> = result
+            .lines
+            .iter()
+            .filter(|l| l.status != ThreeWayStatus::Equal)
+            .collect();
+        assert!(!non_equal.is_empty());
+        // Should be conflict since both sides changed overlapping region differently
+        assert!(
+            non_equal
+                .iter()
+                .any(|l| l.status == ThreeWayStatus::Conflict)
+        );
+    }
+
+    #[test]
+    fn test_different_line_counts() {
+        // Left adds 2 lines, Right adds 1 line at same position
+        let base = "aaa\nccc\n";
+        let left = "aaa\nbbb1\nbbb2\nccc\n";
+        let right = "aaa\nxxx\nccc\n";
+        let result = compute_three_way_diff(base, left, right);
+        // Both inserted after "aaa" — should be conflict
+        // The diff block should have ghost lines to align
+        let block_lines: Vec<_> = result
+            .lines
+            .iter()
+            .filter(|l| l.status != ThreeWayStatus::Equal)
+            .collect();
+        assert!(!block_lines.is_empty());
+        // Left has 2 lines, right has 1 → max is 2 → right gets 1 ghost line
+        let max_block = block_lines.len();
+        assert!(max_block >= 2);
+    }
+
+    #[test]
+    fn test_empty_base() {
+        let base = "\n";
+        let left = "aaaa\naa\n";
+        let right = "bbb\n";
+        let result = compute_three_way_diff(base, left, right);
+        // Both sides changed the single base line differently → conflict
+        assert!(result.conflict_count > 0);
+    }
+
+    #[test]
+    fn test_repro_seed0_step13() {
+        let base = "\nbbb\nLLL\n\n\n";
+        let left = "\n\n\n";
+        let right = "aaa\nworld\nfoo\nRRR\ntest\n";
+        let result = compute_three_way_diff(base, left, right);
+        let rebuilt_left = rebuild_pane_text(&result.lines, 0);
+        assert_eq!(rebuilt_left, left);
+    }
+
+    #[test]
+    fn test_repro_seed0_step7() {
+        // Reproduced from stress test: seed=0 step=7
+        // All 3 sides completely different → one big conflict
+        let base = "aaa\nbbb\n\nworld\nddd\n";
+        let left = "XXX\nbbb\nLLL\n\n";
+        let right = "aaa\nworld\nfoo\nRRR\ntest\n";
+        let result = compute_three_way_diff(base, left, right);
+        let rebuilt_right = rebuild_pane_text(&result.lines, 2);
+        let expected_right = "aaa\nworld\nfoo\nRRR\ntest\n";
+        assert_eq!(
+            rebuilt_right, expected_right,
+            "right text mismatch:\nlines: {:#?}",
+            result.lines
+        );
+    }
+
+    /// Stress test: simulate random user interactions (edit, backspace, F5, copy)
+    /// on 3-way diff data and verify no panics or data corruption occur.
+    #[test]
+    fn test_random_operations_stress() {
+        // Simple deterministic PRNG (no rand crate needed)
+        struct Rng(u64);
+        impl Rng {
+            fn next(&mut self) -> u64 {
+                self.0 = self
+                    .0
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                self.0 >> 33
+            }
+            fn range(&mut self, max: usize) -> usize {
+                if max == 0 {
+                    0
+                } else {
+                    self.next() as usize % max
+                }
+            }
+        }
+
+        let seeds: Vec<u64> = (0..100u64).collect();
+
+        for seed in seeds {
+            let mut rng = Rng(seed * 12345 + 67890);
+
+            // Initial texts
+            let mut left_lines: Vec<String> =
+                vec!["aaa".into(), "bbb".into(), "ccc".into(), "ddd".into()];
+            let mut base_lines: Vec<String> =
+                vec!["aaa".into(), "bbb".into(), "ccc".into(), "ddd".into()];
+            let mut right_lines: Vec<String> =
+                vec!["aaa".into(), "bbb".into(), "ccc".into(), "ddd".into()];
+
+            // Make some initial changes so there are diffs
+            if seed % 3 == 0 {
+                left_lines[0] = "XXX".into();
+            }
+            if seed % 3 == 1 {
+                right_lines[1] = "YYY".into();
+            }
+            if seed % 2 == 0 {
+                left_lines[2] = "LLL".into();
+                right_lines[2] = "RRR".into();
+            }
+
+            let words = ["foo", "bar", "baz", "qux", "hello", "world", "test", ""];
+
+            for step in 0..100 {
+                let op = rng.range(5);
+                match op {
+                    // 0: Edit a random line on a random pane
+                    0 => {
+                        let pane = rng.range(3);
+                        let lines = match pane {
+                            0 => &mut left_lines,
+                            1 => &mut base_lines,
+                            _ => &mut right_lines,
+                        };
+                        if !lines.is_empty() {
+                            let idx = rng.range(lines.len());
+                            let word = words[rng.range(words.len())];
+                            lines[idx] = word.to_string();
+                        }
+                    }
+                    // 1: Backspace (delete a line if empty, or clear it)
+                    1 => {
+                        let pane = rng.range(3);
+                        let lines = match pane {
+                            0 => &mut left_lines,
+                            1 => &mut base_lines,
+                            _ => &mut right_lines,
+                        };
+                        if !lines.is_empty() {
+                            let idx = rng.range(lines.len());
+                            if lines[idx].is_empty() && lines.len() > 1 {
+                                lines.remove(idx);
+                            } else {
+                                lines[idx] = String::new();
+                            }
+                        }
+                    }
+                    // 2: Insert a line
+                    2 => {
+                        let pane = rng.range(3);
+                        let lines = match pane {
+                            0 => &mut left_lines,
+                            1 => &mut base_lines,
+                            _ => &mut right_lines,
+                        };
+                        if lines.len() < 20 {
+                            // cap to avoid blowup
+                            let idx = rng.range(lines.len() + 1);
+                            let word = words[rng.range(words.len())];
+                            lines.insert(idx, word.to_string());
+                        }
+                    }
+                    // 3: F5 (recompute diff from current texts)
+                    3 => {
+                        let left_text = if left_lines.is_empty() {
+                            String::new()
+                        } else {
+                            left_lines.join("\n") + "\n"
+                        };
+                        let base_text = if base_lines.is_empty() {
+                            String::new()
+                        } else {
+                            base_lines.join("\n") + "\n"
+                        };
+                        let right_text = if right_lines.is_empty() {
+                            String::new()
+                        } else {
+                            right_lines.join("\n") + "\n"
+                        };
+
+                        let result = compute_three_way_diff(&base_text, &left_text, &right_text);
+
+                        // Invariant checks
+                        assert!(
+                            !result.lines.is_empty()
+                                || (left_lines.is_empty()
+                                    && base_lines.is_empty()
+                                    && right_lines.is_empty()),
+                            "seed={} step={}: empty result with non-empty input",
+                            seed,
+                            step
+                        );
+
+                        // Rebuild text from result and verify it matches input
+                        let rebuilt_left = rebuild_pane_text(&result.lines, 0);
+                        let rebuilt_base = rebuild_pane_text(&result.lines, 1);
+                        let rebuilt_right = rebuild_pane_text(&result.lines, 2);
+
+                        assert_eq!(
+                            rebuilt_left,
+                            left_text,
+                            "seed={} step={}: left text mismatch after F5\nbase={:?}\nleft={:?}\nright={:?}\nrebuilt_left={:?}\nlines={:#?}",
+                            seed,
+                            step,
+                            base_text,
+                            left_text,
+                            right_text,
+                            rebuilt_left,
+                            result.lines
+                        );
+                        assert_eq!(
+                            rebuilt_base,
+                            base_text,
+                            "seed={} step={}: base text mismatch after F5\nbase={:?}\nleft={:?}\nright={:?}\nrebuilt_base={:?}\nlines={:#?}",
+                            seed,
+                            step,
+                            base_text,
+                            left_text,
+                            right_text,
+                            rebuilt_base,
+                            result.lines
+                        );
+                        assert_eq!(
+                            rebuilt_right,
+                            right_text,
+                            "seed={} step={}: right text mismatch after F5\nbase={:?}\nleft={:?}\nright={:?}\nrebuilt_right={:?}\nlines={:#?}",
+                            seed,
+                            step,
+                            base_text,
+                            left_text,
+                            right_text,
+                            rebuilt_right,
+                            result.lines
+                        );
+
+                        // All conflict positions must be valid indices
+                        for &pos in &result.conflict_positions {
+                            assert!(
+                                pos < result.lines.len(),
+                                "seed={} step={}: conflict_position {} out of bounds (len={})",
+                                seed,
+                                step,
+                                pos,
+                                result.lines.len()
+                            );
+                        }
+
+                        // Every line in result must have at least one real line number
+                        // (pure ghost rows shouldn't exist — at least one pane has content)
+                        for (i, line) in result.lines.iter().enumerate() {
+                            let has_any = line.left_line_no.is_some()
+                                || line.base_line_no.is_some()
+                                || line.right_line_no.is_some();
+                            assert!(
+                                has_any,
+                                "seed={} step={}: line {} has no line numbers at all",
+                                seed, step, i
+                            );
+                        }
+                    }
+                    // 4: Copy (simulate resolve: copy left→base or right→base for a diff block)
+                    4 => {
+                        let left_text = if left_lines.is_empty() {
+                            String::new()
+                        } else {
+                            left_lines.join("\n") + "\n"
+                        };
+                        let base_text = if base_lines.is_empty() {
+                            String::new()
+                        } else {
+                            base_lines.join("\n") + "\n"
+                        };
+                        let right_text = if right_lines.is_empty() {
+                            String::new()
+                        } else {
+                            right_lines.join("\n") + "\n"
+                        };
+
+                        let result = compute_three_way_diff(&base_text, &left_text, &right_text);
+
+                        if !result.conflict_positions.is_empty() {
+                            let ci = rng.range(result.conflict_positions.len());
+                            let pos = result.conflict_positions[ci];
+                            let use_left = rng.range(2) == 0;
+
+                            // Find all lines in this block (same status run starting at pos)
+                            let block_status = result.lines[pos].status.clone();
+                            let mut block_end = pos + 1;
+                            while block_end < result.lines.len()
+                                && result.lines[block_end].status == block_status
+                            {
+                                block_end += 1;
+                            }
+
+                            // Apply copy: update base_lines from the chosen side
+                            for line in &result.lines[pos..block_end] {
+                                if let Some(base_no) = line.base_line_no {
+                                    let idx = (base_no - 1) as usize;
+                                    if idx < base_lines.len() {
+                                        base_lines[idx] = if use_left {
+                                            line.left_text.clone()
+                                        } else {
+                                            line.right_text.clone()
+                                        };
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            // Final sanity check: compute one last diff and verify rebuild
+            let left_text = if left_lines.is_empty() {
+                String::new()
+            } else {
+                left_lines.join("\n") + "\n"
+            };
+            let base_text = if base_lines.is_empty() {
+                String::new()
+            } else {
+                base_lines.join("\n") + "\n"
+            };
+            let right_text = if right_lines.is_empty() {
+                String::new()
+            } else {
+                right_lines.join("\n") + "\n"
+            };
+
+            let result = compute_three_way_diff(&base_text, &left_text, &right_text);
+            let rebuilt_left = rebuild_pane_text(&result.lines, 0);
+            let rebuilt_base = rebuild_pane_text(&result.lines, 1);
+            let rebuilt_right = rebuild_pane_text(&result.lines, 2);
+
+            assert_eq!(
+                rebuilt_left, left_text,
+                "seed={}: final left mismatch",
+                seed
+            );
+            assert_eq!(
+                rebuilt_base, base_text,
+                "seed={}: final base mismatch",
+                seed
+            );
+            assert_eq!(
+                rebuilt_right, right_text,
+                "seed={}: final right mismatch",
+                seed
+            );
+        }
+    }
+
+    /// Targeted stress test: copy a conflict block then immediately F5.
+    /// The middle (base) pane text must NEVER lose lines after this sequence.
+    /// This directly addresses the reported bug where pressing F5 after copy
+    /// caused the middle pane text to disappear.
+    #[test]
+    fn test_copy_then_f5_base_preserved() {
+        struct Rng(u64);
+        impl Rng {
+            fn next(&mut self) -> u64 {
+                self.0 = self
+                    .0
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                self.0 >> 33
+            }
+            fn range(&mut self, max: usize) -> usize {
+                if max == 0 {
+                    0
+                } else {
+                    self.next() as usize % max
+                }
+            }
+        }
+
+        let words = ["foo", "bar", "baz", "qux", "hello", "world", "test", ""];
+
+        for seed in 0..200u64 {
+            let mut rng = Rng(seed * 99991 + 7);
+
+            // Generate random initial texts (1-8 lines each)
+            let gen_lines = |rng: &mut Rng| -> Vec<String> {
+                let n = rng.range(8) + 1;
+                (0..n)
+                    .map(|_| words[rng.range(words.len())].to_string())
+                    .collect()
+            };
+
+            let mut base_lines = gen_lines(&mut rng);
+            let mut left_lines = gen_lines(&mut rng);
+            let mut right_lines = gen_lines(&mut rng);
+
+            // Do 50 cycles of: copy a conflict, then F5, verifying base every time
+            for step in 0..50 {
+                let left_text = left_lines.join("\n") + "\n";
+                let base_text = base_lines.join("\n") + "\n";
+                let right_text = right_lines.join("\n") + "\n";
+
+                let result = compute_three_way_diff(&base_text, &left_text, &right_text);
+
+                // Verify all 3 panes before copy
+                let rebuilt_base = rebuild_pane_text(&result.lines, 1);
+                assert_eq!(
+                    rebuilt_base, base_text,
+                    "seed={} step={}: base text lost BEFORE copy",
+                    seed, step
+                );
+
+                // Copy a random conflict block (left→base or right→base)
+                if !result.conflict_positions.is_empty() {
+                    let ci = rng.range(result.conflict_positions.len());
+                    let pos = result.conflict_positions[ci];
+                    let block_status = result.lines[pos].status.clone();
+                    let mut block_end = pos + 1;
+                    while block_end < result.lines.len()
+                        && result.lines[block_end].status == block_status
+                    {
+                        block_end += 1;
+                    }
+
+                    let use_left = rng.range(2) == 0;
+                    for line in &result.lines[pos..block_end] {
+                        if let Some(base_no) = line.base_line_no {
+                            let idx = (base_no - 1) as usize;
+                            if idx < base_lines.len() {
+                                base_lines[idx] = if use_left {
+                                    line.left_text.clone()
+                                } else {
+                                    line.right_text.clone()
+                                };
+                            }
+                        }
+                    }
+                }
+
+                // Immediately F5 after copy — the critical sequence
+                let base_text_after = base_lines.join("\n") + "\n";
+                let result2 = compute_three_way_diff(&base_text_after, &left_text, &right_text);
+
+                let rebuilt_base2 = rebuild_pane_text(&result2.lines, 1);
+                let rebuilt_left2 = rebuild_pane_text(&result2.lines, 0);
+                let rebuilt_right2 = rebuild_pane_text(&result2.lines, 2);
+
+                assert_eq!(
+                    rebuilt_base2, base_text_after,
+                    "seed={} step={}: BASE text lost after copy+F5!\nbase={:?}\nleft={:?}\nright={:?}",
+                    seed, step, base_text_after, left_text, right_text
+                );
+                assert_eq!(
+                    rebuilt_left2, left_text,
+                    "seed={} step={}: left text lost after copy+F5",
+                    seed, step
+                );
+                assert_eq!(
+                    rebuilt_right2, right_text,
+                    "seed={} step={}: right text lost after copy+F5",
+                    seed, step
+                );
+
+                // Randomly edit one pane to create new diffs for next iteration
+                let pane = rng.range(3);
+                let lines = match pane {
+                    0 => &mut left_lines,
+                    1 => &mut base_lines,
+                    _ => &mut right_lines,
+                };
+                if !lines.is_empty() {
+                    let idx = rng.range(lines.len());
+                    lines[idx] = words[rng.range(words.len())].to_string();
+                }
+            }
+        }
+    }
+
+    /// Exact repro: user scenario where middle pane loses "aaaa" after F5.
+    /// Steps:
+    ///   1. Left="aaa\naaaa\n", Right="aaa\n", Base="" (new blank doc)
+    ///   2. Copy all left→base → Base="aaa\naaaa\n"
+    ///   3. Edit right: add "ccc" below "aaa" → Right="aaa\nccc\n"
+    ///   4. F5 (rescan) with Base="aaa\naaaa\n", Left="aaa\naaaa\n", Right="aaa\nccc\n"
+    ///   5. Base must still contain "aaa\naaaa\n"
+    #[test]
+    fn test_repro_copy_all_then_edit_right_then_f5() {
+        // Step 1: initial state — new blank document, user types in left and right
+        let base_initial = "\n";
+        let left = "aaa\naaaa\n";
+        let right_initial = "aaa\n";
+
+        // Step 1 check: initial diff
+        let r1 = compute_three_way_diff(base_initial, left, right_initial);
+        let rb1 = rebuild_pane_text(&r1.lines, 1);
+        assert_eq!(rb1, base_initial, "step1: base mismatch");
+
+        // Step 2: copy all left→base
+        let base_after_copy = "aaa\naaaa\n";
+
+        // Step 3: edit right — add "ccc" under "aaa"
+        let right_after_edit = "aaa\nccc\n";
+
+        // Step 4: F5 rescan — THIS IS WHERE THE BUG WAS REPORTED
+        let r2 = compute_three_way_diff(base_after_copy, left, right_after_edit);
+
+        let rebuilt_base = rebuild_pane_text(&r2.lines, 1);
+        let rebuilt_left = rebuild_pane_text(&r2.lines, 0);
+        let rebuilt_right = rebuild_pane_text(&r2.lines, 2);
+
+        assert_eq!(
+            rebuilt_base, base_after_copy,
+            "CRITICAL: base text lost after F5!\nexpected: {:?}\ngot: {:?}\nlines: {:#?}",
+            base_after_copy, rebuilt_base, r2.lines
+        );
+        assert_eq!(rebuilt_left, left, "left text mismatch after F5");
+        assert_eq!(
+            rebuilt_right, right_after_edit,
+            "right text mismatch after F5"
+        );
+
+        // Also verify line-by-line that "aaaa" exists in base
+        let base_has_aaaa = r2
+            .lines
+            .iter()
+            .any(|l| l.base_line_no.is_some() && l.base_text == "aaaa");
+        assert!(base_has_aaaa, "base must contain 'aaaa' line after F5");
+    }
+
+    /// Edge cases: single-line, empty, and all-identical texts
+    #[test]
+    fn test_edge_cases_text_preservation() {
+        let cases: Vec<(&str, &str, &str)> = vec![
+            // All empty
+            ("\n", "\n", "\n"),
+            // Single line, all same
+            ("x\n", "x\n", "x\n"),
+            // Single line, all different
+            ("a\n", "b\n", "c\n"),
+            // One side empty
+            ("\n", "a\nb\n", "a\nb\n"),
+            ("a\nb\n", "\n", "a\nb\n"),
+            ("a\nb\n", "a\nb\n", "\n"),
+            // Large text differences
+            ("a\nb\nc\nd\ne\nf\n", "x\n", "a\nb\nc\nd\ne\nf\n"),
+            ("x\n", "a\nb\nc\nd\ne\nf\n", "y\n"),
+            // Repeated lines
+            ("a\na\na\n", "a\na\n", "a\na\na\na\n"),
+            // All completely different, varying lengths
+            ("a\nb\n", "x\ny\nz\n", "1\n2\n3\n4\n"),
+        ];
+
+        for (i, (base, left, right)) in cases.iter().enumerate() {
+            let result = compute_three_way_diff(base, left, right);
+
+            let rebuilt_left = rebuild_pane_text(&result.lines, 0);
+            let rebuilt_base = rebuild_pane_text(&result.lines, 1);
+            let rebuilt_right = rebuild_pane_text(&result.lines, 2);
+
+            assert_eq!(rebuilt_left, *left, "case {}: left mismatch", i);
+            assert_eq!(rebuilt_base, *base, "case {}: base mismatch", i);
+            assert_eq!(rebuilt_right, *right, "case {}: right mismatch", i);
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,16 +38,17 @@ use app::{
     copy_to_left, copy_to_right, delete_line, discard_and_proceed, edit_line, export_all_comments,
     export_csv_report, export_folder_html_report, export_html_report, export_patch,
     export_xlsx_report, first_diff, folder_copy_to_left, folder_copy_to_right, folder_delete_item,
-    goto_line, insert_line_after, last_diff, navigate_bookmark, navigate_conflict, navigate_diff,
-    navigate_diff_by_status, navigate_search, new_blank_table, new_blank_table_3way,
+    force_close_tab, goto_line, insert_line_after, last_diff, navigate_bookmark, navigate_conflict,
+    navigate_diff, navigate_diff_by_status, navigate_search, new_blank_table, new_blank_table_3way,
     new_blank_text, new_blank_text_3way, open_file_dialog, open_folder_dialog, open_folder_item,
     open_in_editor, paste_clipboard_path_left, paste_clipboard_path_right, preview_folder_item,
-    print_diff, redo, reorder_tab, replace_all_text, replace_text, rescan,
-    resolve_conflict_use_left, resolve_conflict_use_right, run_diff, run_folder_compare,
-    run_plugin, save_file, search_text, select_diff, set_diff_comment, set_diff_filter,
-    set_row_selection, sort_folder, start_compare, start_three_way_compare, switch_tab,
-    three_way_delete_line, three_way_edit_line, three_way_insert_line_after, toggle_bookmark,
-    toggle_ignore_case, toggle_ignore_whitespace, undo,
+    print_diff, redo, reorder_tab, replace_all_text, replace_text, rescan, resolve_all_use_left,
+    resolve_all_use_right, resolve_conflict_use_left, resolve_conflict_use_right,
+    resolve_use_left_and_next, resolve_use_right_and_next, run_diff, run_folder_compare,
+    run_plugin, save_file, save_three_way_pane, search_text, select_diff, set_diff_comment,
+    set_diff_filter, set_row_selection, sort_folder, start_compare, start_three_way_compare,
+    switch_tab, three_way_delete_line, three_way_edit_line, three_way_insert_line_after,
+    toggle_bookmark, toggle_ignore_case, toggle_ignore_whitespace, undo,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use slint::{Model, ModelRc, SharedString, VecModel};
@@ -343,6 +344,44 @@ fn main() {
         window.on_close_tab(move |idx| {
             let window = window_weak.unwrap();
             close_tab(&window, &mut state.borrow_mut(), idx);
+        });
+    }
+
+    // Tab close: save then close
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_tab_close_save(move || {
+            let window = window_weak.unwrap();
+            let idx = window.get_tab_close_target_index();
+            window.set_show_tab_close_confirm(false);
+            let mut s = state.borrow_mut();
+            // Switch to target tab so save_file operates on it
+            let prev_active = s.active_tab;
+            s.active_tab = idx as usize;
+            save_file(&window, &mut s, true);
+            save_file(&window, &mut s, false);
+            if let Some(tab) = s.tabs.get_mut(idx as usize) {
+                tab.has_unsaved_changes = false;
+            }
+            s.active_tab = prev_active;
+            force_close_tab(&window, &mut s, idx);
+        });
+    }
+
+    // Tab close: discard and close
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_tab_close_discard(move || {
+            let window = window_weak.unwrap();
+            let idx = window.get_tab_close_target_index();
+            window.set_show_tab_close_confirm(false);
+            let mut s = state.borrow_mut();
+            if let Some(tab) = s.tabs.get_mut(idx as usize) {
+                tab.has_unsaved_changes = false;
+            }
+            force_close_tab(&window, &mut s, idx);
         });
     }
 
@@ -669,7 +708,12 @@ fn main() {
         let state = state.clone();
         window.on_save_left(move || {
             let window = window_weak.unwrap();
-            save_file(&window, &mut state.borrow_mut(), true);
+            let mut s = state.borrow_mut();
+            if s.current_tab().view_mode == 3 {
+                save_three_way_pane(&window, &mut s, 0);
+            } else {
+                save_file(&window, &mut s, true);
+            }
         });
     }
 
@@ -678,7 +722,21 @@ fn main() {
         let state = state.clone();
         window.on_save_right(move || {
             let window = window_weak.unwrap();
-            save_file(&window, &mut state.borrow_mut(), false);
+            let mut s = state.borrow_mut();
+            if s.current_tab().view_mode == 3 {
+                save_three_way_pane(&window, &mut s, 2);
+            } else {
+                save_file(&window, &mut s, false);
+            }
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_save_base(move || {
+            let window = window_weak.unwrap();
+            save_three_way_pane(&window, &mut state.borrow_mut(), 1);
         });
     }
 
@@ -1079,6 +1137,69 @@ fn main() {
         });
     }
 
+    {
+        let window_weak = window.as_weak();
+        window.on_three_way_move_focus_up(move |row, pane| {
+            let window = window_weak.unwrap();
+            let model = window.get_three_way_lines();
+            if let Some(vec_model) = model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() {
+                let mut target = row - 1;
+                while target >= 0 {
+                    if let Some(r) = vec_model.row_data(target as usize) {
+                        let has_line_no = match pane {
+                            0 => !r.left_line_no.is_empty(),
+                            1 => !r.base_line_no.is_empty(),
+                            _ => !r.right_line_no.is_empty(),
+                        };
+                        if has_line_no {
+                            break;
+                        }
+                    }
+                    target -= 1;
+                }
+                if target >= 0 {
+                    match pane {
+                        0 => window.set_three_way_edit_focus_left_row(target),
+                        1 => window.set_three_way_edit_focus_base_row(target),
+                        _ => window.set_three_way_edit_focus_right_row(target),
+                    }
+                }
+            }
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        window.on_three_way_move_focus_down(move |row, pane| {
+            let window = window_weak.unwrap();
+            let model = window.get_three_way_lines();
+            if let Some(vec_model) = model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() {
+                let count = vec_model.row_count() as i32;
+                let mut target = row + 1;
+                while target < count {
+                    if let Some(r) = vec_model.row_data(target as usize) {
+                        let has_line_no = match pane {
+                            0 => !r.left_line_no.is_empty(),
+                            1 => !r.base_line_no.is_empty(),
+                            _ => !r.right_line_no.is_empty(),
+                        };
+                        if has_line_no {
+                            break;
+                        }
+                    }
+                    target += 1;
+                }
+                if target < count {
+                    match pane {
+                        0 => window.set_three_way_edit_focus_left_row(target),
+                        1 => window.set_three_way_edit_focus_base_row(target),
+                        _ => window.set_three_way_edit_focus_right_row(target),
+                    }
+                }
+            }
+        });
+    }
+
     // Apply options
     {
         let window_weak = window.as_weak();
@@ -1182,6 +1303,15 @@ fn main() {
         window.on_row_shift_clicked(move |idx| {
             let window = window_weak.unwrap();
             set_row_selection(&window, &mut state.borrow_mut(), idx, true);
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_row_clicked(move |idx| {
+            let window = window_weak.unwrap();
+            set_row_selection(&window, &mut state.borrow_mut(), idx, false);
         });
     }
 
@@ -1399,6 +1529,42 @@ fn main() {
         window.on_use_right(move |idx| {
             let window = window_weak.unwrap();
             resolve_conflict_use_right(&window, &mut state.borrow_mut(), idx);
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_use_left_and_next(move || {
+            let window = window_weak.unwrap();
+            resolve_use_left_and_next(&window, &mut state.borrow_mut());
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_use_right_and_next(move || {
+            let window = window_weak.unwrap();
+            resolve_use_right_and_next(&window, &mut state.borrow_mut());
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_use_all_left(move || {
+            let window = window_weak.unwrap();
+            resolve_all_use_left(&window, &mut state.borrow_mut());
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_use_all_right(move || {
+            let window = window_weak.unwrap();
+            resolve_all_use_right(&window, &mut state.borrow_mut());
         });
     }
 
@@ -1661,8 +1827,8 @@ fn main() {
         });
     }
 
-    // Pending save-as queue: each item is (tab_index, is_left, text, encoding)
-    let pending_saves: Rc<RefCell<Vec<(usize, bool, String, String)>>> =
+    // Pending save-as queue: each item is (tab_index, pane: 0=left 1=right 2=base, text, encoding)
+    let pending_saves: Rc<RefCell<Vec<(usize, i32, String, String)>>> =
         Rc::new(RefCell::new(Vec::new()));
 
     // Helper: populate save-as dialog directory listing
@@ -1716,11 +1882,11 @@ fn main() {
                 do_save(&window);
                 let _ = slint::quit_event_loop();
             } else {
-                let (_, is_left, _, _) = pending_saves.borrow()[0].clone();
-                let title = if is_left {
-                    "Save Left File As"
-                } else {
-                    "Save Right File As"
+                let (_, pane, _, _) = pending_saves.borrow()[0].clone();
+                let title = match pane {
+                    0 => "Save Left File As",
+                    2 => "Save Middle File As",
+                    _ => "Save Right File As",
                 };
                 window.set_save_as_title(SharedString::from(title));
                 window.set_save_as_filename(SharedString::from(""));
@@ -1758,25 +1924,30 @@ fn main() {
             let window = window_weak.unwrap();
             let path = std::path::PathBuf::from(path_str.as_str());
             if !path_str.is_empty() {
-                if let Some((tab_idx, is_left, text, enc)) = {
+                if let Some((tab_idx, pane, text, enc)) = {
                     let b = pending_saves.borrow();
                     b.first().cloned()
                 } {
                     let bytes = encode_text(&text, &enc);
                     if fs::write(&path, bytes).is_ok() {
                         let mut s = state.borrow_mut();
-                        if is_left {
-                            s.tabs[tab_idx].left_path = Some(path);
-                        } else {
-                            s.tabs[tab_idx].right_path = Some(path);
+                        match pane {
+                            0 => s.tabs[tab_idx].left_path = Some(path),
+                            2 => s.tabs[tab_idx].base_path = Some(path),
+                            _ => s.tabs[tab_idx].right_path = Some(path),
                         }
-                        // Check if this tab is now fully saved (both sides have paths)
-                        if s.tabs[tab_idx].left_path.is_some()
-                            && s.tabs[tab_idx].right_path.is_some()
-                        {
+                        // Check if this tab is now fully saved (all sides have paths)
+                        let all_saved = if s.tabs[tab_idx].view_mode == 3 {
+                            s.tabs[tab_idx].left_path.is_some()
+                                && s.tabs[tab_idx].base_path.is_some()
+                                && s.tabs[tab_idx].right_path.is_some()
+                        } else {
+                            s.tabs[tab_idx].left_path.is_some()
+                                && s.tabs[tab_idx].right_path.is_some()
+                        };
+                        if all_saved {
                             s.tabs[tab_idx].has_unsaved_changes = false;
                         }
-                        // Check if there are still unsaved tabs remaining
                         let still_unsaved = s.tabs.iter().any(|t| t.has_unsaved_changes);
                         window.set_has_unsaved_changes(still_unsaved);
                     }

--- a/translations/ja/LC_MESSAGES/winxmerge.po
+++ b/translations/ja/LC_MESSAGES/winxmerge.po
@@ -49,6 +49,9 @@ msgstr "右フォルダを開く..."
 msgid "Save Left"
 msgstr "左を保存"
 
+msgid "Save Middle"
+msgstr "中を保存"
+
 msgid "Save Right"
 msgstr "右を保存"
 

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -222,8 +222,10 @@ export component MainWindow inherits Window {
 
     // Detail pane: current diff block lines with word-diff segment highlighting
     in property <[DetailLineData]> detail-left-lines: [];
+    in property <[DetailLineData]> detail-base-lines: [];
     in property <[DetailLineData]> detail-right-lines: [];
     in-out property <length> detail-left-scroll-y: 0px;
+    in-out property <length> detail-base-scroll-y: 0px;
     in-out property <length> detail-right-scroll-y: 0px;
     in-out property <bool> show-detail-pane: true;
     in-out property <length> detail-pane-height: 180px;
@@ -231,6 +233,7 @@ export component MainWindow inherits Window {
     in-out property <float> detail-inner-split: 0.5;
     // Explicitly set from Rust when detail lines change (avoids model-length reactivity issues)
     in-out property <bool> detail-has-left: false;
+    in-out property <bool> detail-has-base: false;
     in-out property <bool> detail-has-right: false;
     property <bool> detail-has-both: detail-has-left && detail-has-right;
     // Available height for content panes (total minus comment row, minus inner handle if both shown)
@@ -258,6 +261,7 @@ export component MainWindow inherits Window {
     callback select-diff(int);
     callback save-left();
     callback save-right();
+    callback save-base();
     callback folder-item-double-clicked(int);
     callback back-to-folder-view();
     callback toggle-ignore-whitespace();
@@ -299,6 +303,8 @@ export component MainWindow inherits Window {
     callback three-way-edit-line(/* row */ int, /* text */ string, /* pane */ int);
     callback three-way-insert-line-after(/* row */ int, /* pane */ int);
     callback three-way-delete-line(/* row */ int, /* pane */ int);
+    callback three-way-move-focus-up(/* row */ int, /* pane */ int);
+    callback three-way-move-focus-down(/* row */ int, /* pane */ int);
     callback open-recent(int);
     callback goto-line(int);
     callback toggle-bookmark(int);
@@ -330,7 +336,8 @@ export component MainWindow inherits Window {
     callback copy-all-diffs-right();
     callback copy-all-diffs-left();
 
-    // Multi-line selection copy
+    // Multi-line selection
+    callback row-clicked(int);
     callback row-shift-clicked(int);
     callback copy-selection-right();
     callback copy-selection-left();
@@ -352,7 +359,17 @@ export component MainWindow inherits Window {
     callback prev-conflict();
     callback use-left(int);
     callback use-right(int);
+    callback use-left-and-next();
+    callback use-right-and-next();
+    callback use-all-left();
+    callback use-all-right();
     callback apply-options();
+
+    // Tab close with save check
+    in-out property <bool> show-tab-close-confirm: false;
+    in-out property <int> tab-close-target-index: -1;
+    callback tab-close-save();
+    callback tab-close-discard();
 
     // File browser dialog (WSL2-safe Browse fallback)
     in-out property <bool> file-browser-visible: false;
@@ -556,6 +573,7 @@ export component MainWindow inherits Window {
             MenuItem { title: @tr("Open Right Folder..."); activated => { root.request-action(4); } }
             MenuSeparator {}
             MenuItem { title: @tr("Save Left"); enabled: root.has-unsaved-changes; activated => { root.save-left(); } }
+            MenuItem { title: @tr("Save Middle"); enabled: root.has-unsaved-changes && root.view-mode == 3; activated => { root.save-base(); } }
             MenuItem { title: @tr("Save Right"); enabled: root.has-unsaved-changes; activated => { root.save-right(); } }
             MenuSeparator {}
             MenuItem { title: @tr("Open Left in Editor"); enabled: root.left-path != ""; activated => { root.open-left-in-editor(); } }
@@ -722,8 +740,7 @@ export component MainWindow inherits Window {
                 tb-back.is-hovered ? @tr("< Back") :
                 tb-open-l.is-hovered ? @tr("Open Left File...") :
                 tb-open-r.is-hovered ? @tr("Open Right File...") :
-                tb-save-l.is-hovered ? @tr("Save Left") :
-                tb-save-r.is-hovered ? @tr("Save Right") :
+                tb-save.is-hovered ? @tr("Save...") :
                 tb-undo.is-hovered ? @tr("Undo") :
                 tb-redo.is-hovered ? @tr("Redo") :
                 tb-rescan.is-hovered ? @tr("Rescan (F5)") :
@@ -811,13 +828,71 @@ export component MainWindow inherits Window {
 
                 ToolSep {}
 
-                tb-save-l := ToolBtn { icon: @image-url("icons/save.svg"); overlay: "L"; visible: root.view-mode == 0; btn-enabled: root.has-unsaved-changes; clicked => { root.save-left(); } }
-                tb-save-r := ToolBtn { icon: @image-url("icons/save.svg"); overlay: "R"; visible: root.view-mode == 0; btn-enabled: root.has-unsaved-changes; clicked => { root.save-right(); } }
+                tb-save := ToolBtn { icon: @image-url("icons/save.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.has-unsaved-changes; clicked => { save-popup.show(); } }
+                // Dropdown ▼ for save target selection
+                Rectangle {
+                    width: 14px;
+                    height: 32px;
+                    visible: root.view-mode == 0 || root.view-mode == 3;
+                    border-radius: 3px;
+                    background: save-dd-ta.has-hover ? Palette.background.darker(0.12) : transparent;
+                    opacity: root.has-unsaved-changes ? 1.0 : 0.35;
+                    Text {
+                        text: "▾";
+                        font-size: 10px;
+                        color: Palette.foreground;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    save-dd-ta := TouchArea {
+                        enabled: root.has-unsaved-changes;
+                        clicked => { save-popup.show(); }
+                    }
+                    save-popup := PopupWindow {
+                        x: -32px;
+                        y: 32px;
+                        width: 130px;
+                        height: root.view-mode == 3 ? 90px : 60px;
+                        Rectangle {
+                            background: Palette.background;
+                            border-color: Palette.border;
+                            border-width: 1px;
+                            border-radius: 4px;
+                            drop-shadow-blur: 8px;
+                            drop-shadow-color: #00000030;
+                            VerticalLayout {
+                                padding: 4px;
+                                spacing: 2px;
+                                Rectangle {
+                                    height: 26px;
+                                    border-radius: 3px;
+                                    background: save-l-ta.has-hover ? Palette.background.darker(0.1) : transparent;
+                                    Text { text: @tr("Save Left"); font-size: 12px; color: Palette.foreground; x: 10px; vertical-alignment: center; }
+                                    save-l-ta := TouchArea { clicked => { root.save-left(); } }
+                                }
+                                if root.view-mode == 3 : Rectangle {
+                                    height: 26px;
+                                    border-radius: 3px;
+                                    background: save-m-ta.has-hover ? Palette.background.darker(0.1) : transparent;
+                                    Text { text: @tr("Save Middle"); font-size: 12px; color: Palette.foreground; x: 10px; vertical-alignment: center; }
+                                    save-m-ta := TouchArea { clicked => { root.save-base(); } }
+                                }
+                                Rectangle {
+                                    height: 26px;
+                                    border-radius: 3px;
+                                    background: save-r-ta.has-hover ? Palette.background.darker(0.1) : transparent;
+                                    Text { text: @tr("Save Right"); font-size: 12px; color: Palette.foreground; x: 10px; vertical-alignment: center; }
+                                    save-r-ta := TouchArea { clicked => { root.save-right(); } }
+                                }
+                            }
+                        }
+                    }
+                }
 
-                sep-save := ToolSep { visible: root.view-mode == 0; }
+                sep-save := ToolSep { visible: root.view-mode == 0 || root.view-mode == 3; }
 
-                tb-undo := ToolBtn { icon: @image-url("icons/undo.svg"); visible: root.view-mode == 0; clicked => { root.undo(); } }
-                tb-redo := ToolBtn { icon: @image-url("icons/redo.svg"); visible: root.view-mode == 0; clicked => { root.redo(); } }
+                tb-undo := ToolBtn { icon: @image-url("icons/undo.svg"); visible: root.view-mode == 0 || root.view-mode == 3; clicked => { root.undo(); } }
+                tb-redo := ToolBtn { icon: @image-url("icons/redo.svg"); visible: root.view-mode == 0 || root.view-mode == 3; clicked => { root.redo(); } }
 
                 ToolSep {}
 
@@ -826,19 +901,19 @@ export component MainWindow inherits Window {
 
                 ToolSep {}
 
-                tb-first := ToolBtn { icon: @image-url("icons/first.svg"); visible: root.view-mode == 0; btn-enabled: root.diff-count > 0; clicked => { root.first-diff(); } }
-                tb-prev := ToolBtn { icon: @image-url("icons/prev.svg"); visible: root.view-mode == 0; btn-enabled: root.diff-count > 0; clicked => { root.prev-diff(); } }
-                tb-next := ToolBtn { icon: @image-url("icons/next.svg"); visible: root.view-mode == 0; btn-enabled: root.diff-count > 0; clicked => { root.next-diff(); } }
-                tb-last := ToolBtn { icon: @image-url("icons/last.svg"); visible: root.view-mode == 0; btn-enabled: root.diff-count > 0; clicked => { root.last-diff(); } }
+                tb-first := ToolBtn { icon: @image-url("icons/first.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { root.first-diff(); } }
+                tb-prev := ToolBtn { icon: @image-url("icons/prev.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 3 { root.prev-conflict(); } else { root.prev-diff(); } } }
+                tb-next := ToolBtn { icon: @image-url("icons/next.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 3 { root.next-conflict(); } else { root.next-diff(); } } }
+                tb-last := ToolBtn { icon: @image-url("icons/last.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { root.last-diff(); } }
 
-                sep-nav := ToolSep { visible: root.view-mode == 0; }
+                sep-nav := ToolSep { visible: root.view-mode == 0 || root.view-mode == 3; }
 
-                tb-copy-r := ToolBtn { icon: @image-url("icons/copy-right.svg"); visible: root.view-mode == 0; btn-enabled: root.current-diff-index >= 0; clicked => { root.copy-to-right(root.current-diff-index); } }
-                tb-copy-l := ToolBtn { icon: @image-url("icons/copy-left.svg"); visible: root.view-mode == 0; btn-enabled: root.current-diff-index >= 0; clicked => { root.copy-to-left(root.current-diff-index); } }
-                tb-copy-r-next := ToolBtn { icon: @image-url("icons/copy-right-next.svg"); visible: root.view-mode == 0; btn-enabled: root.current-diff-index >= 0; clicked => { root.copy-right-and-next(); } }
-                tb-copy-l-next := ToolBtn { icon: @image-url("icons/copy-left-next.svg"); visible: root.view-mode == 0; btn-enabled: root.current-diff-index >= 0; clicked => { root.copy-left-and-next(); } }
-                tb-all-r := ToolBtn { icon: @image-url("icons/copy-all-right.svg"); visible: root.view-mode == 0; btn-enabled: root.diff-count > 0; clicked => { root.copy-all-diffs-right(); } }
-                tb-all-l := ToolBtn { icon: @image-url("icons/copy-all-left.svg"); visible: root.view-mode == 0; btn-enabled: root.diff-count > 0; clicked => { root.copy-all-diffs-left(); } }
+                tb-copy-r := ToolBtn { icon: @image-url("icons/copy-right.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 3 { root.use-left(root.current-conflict-index); } else { root.copy-to-right(root.current-diff-index); } } }
+                tb-copy-l := ToolBtn { icon: @image-url("icons/copy-left.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 3 { root.use-right(root.current-conflict-index); } else { root.copy-to-left(root.current-diff-index); } } }
+                tb-copy-r-next := ToolBtn { icon: @image-url("icons/copy-right-next.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 3 { root.use-left-and-next(); } else { root.copy-right-and-next(); } } }
+                tb-copy-l-next := ToolBtn { icon: @image-url("icons/copy-left-next.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 3 { root.use-right-and-next(); } else { root.copy-left-and-next(); } } }
+                tb-all-r := ToolBtn { icon: @image-url("icons/copy-all-right.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 3 { root.use-all-left(); } else { root.copy-all-diffs-right(); } } }
+                tb-all-l := ToolBtn { icon: @image-url("icons/copy-all-left.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 3 { root.use-all-right(); } else { root.copy-all-diffs-left(); } } }
 
                 ToolSep {}
 
@@ -1004,8 +1079,8 @@ export component MainWindow inherits Window {
             scroll-y <=> root.diff-scroll-y;
             edit-focus-row <=> root.diff-edit-focus-row;
             edit-focus-right-row <=> root.diff-edit-focus-right-row;
-            left-title: root.left-path != "" ? root.left-path : @tr("Left file");
-            right-title: root.right-path != "" ? root.right-path : @tr("Right file");
+            left-title: root.left-path != "" ? root.left-path : "Left";
+            right-title: root.right-path != "" ? root.right-path : "Right";
             context-menu-enabled: root.opt-enable-context-menu;
             show-line-numbers: root.opt-show-line-numbers;
             show-location-pane: root.show-location-pane;
@@ -1030,6 +1105,7 @@ export component MainWindow inherits Window {
             delete-line(idx, is-left) => { root.delete-line(idx, is-left); }
             move-focus-up(idx, is-left) => { root.move-focus-up(idx, is-left); }
             move-focus-down(idx, is-left) => { root.move-focus-down(idx, is-left); }
+            drag-select-start(idx) => { root.row-clicked(idx); }
             row-shift-clicked(idx) => { root.row-shift-clicked(idx); }
             copy-selection-to-right => { root.copy-selection-right(); }
             copy-selection-to-left => { root.copy-selection-left(); }
@@ -1114,10 +1190,11 @@ export component MainWindow inherits Window {
         if root.view-mode == 3 : DiffView3Way {
             lines: root.three-way-lines;
             current-conflict-index: root.current-conflict-index;
-            left-title: root.left-path != "" ? root.left-path : @tr("Left (Mine)");
-            base-title: root.base-path != "" ? root.base-path : @tr("Base");
-            right-title: root.right-path != "" ? root.right-path : @tr("Right (Theirs)");
+            left-title: root.left-path != "" ? root.left-path : "Left";
+            base-title: root.base-path != "" ? root.base-path : "Middle";
+            right-title: root.right-path != "" ? root.right-path : "Right";
             show-line-numbers: root.opt-show-line-numbers;
+            show-location-pane: root.show-location-pane;
             editor-font-size: root.opt-font-size;
             inline-edit-enabled: root.opt-inline-edit;
             edit-focus-left-row <=> root.three-way-edit-focus-left-row;
@@ -1130,6 +1207,8 @@ export component MainWindow inherits Window {
             edit-text-changed(row, text, pane) => { root.three-way-edit-line(row, text, pane); }
             insert-line-after(row, pane) => { root.three-way-insert-line-after(row, pane); }
             delete-line(row, pane) => { root.three-way-delete-line(row, pane); }
+            move-focus-up(row, pane) => { root.three-way-move-focus-up(row, pane); }
+            move-focus-down(row, pane) => { root.three-way-move-focus-down(row, pane); }
         }
 
         // Excel compare view
@@ -1153,8 +1232,8 @@ export component MainWindow inherits Window {
             diff-image: root.diff-image;
             overlay-image: root.overlay-image;
             stats: root.image-stats;
-            left-title: root.left-path != "" ? root.left-path : @tr("Left");
-            right-title: root.right-path != "" ? root.right-path : @tr("Right");
+            left-title: root.left-path != "" ? root.left-path : "Left";
+            right-title: root.right-path != "" ? root.right-path : "Right";
             left-image-width: root.image-left-width;
             left-image-height: root.image-left-height;
             right-image-width: root.image-right-width;
@@ -1218,7 +1297,7 @@ export component MainWindow inherits Window {
                             background: ThemeColors.removed-bg;
                             Text {
                                 x: 4px;
-                                text: "left";
+                                text: "Left";
                                 font-size: 10px;
                                 font-weight: 600;
                                 color: ThemeColors.removed-fg;
@@ -1300,7 +1379,7 @@ export component MainWindow inherits Window {
                             background: ThemeColors.added-bg;
                             Text {
                                 x: 4px;
-                                text: "right";
+                                text: "Right";
                                 font-size: 10px;
                                 font-weight: 600;
                                 color: ThemeColors.added-fg;
@@ -1358,6 +1437,183 @@ export component MainWindow inherits Window {
                             placeholder-text: @tr("Add a note for this diff block...");
                             font-size: 11px;
                             edited(t) => { root.diff-comment-changed(t); }
+                        }
+                    }
+                }
+            }
+        }
+
+        // 3-way detail pane resize handle
+        if root.show-detail-pane && root.view-mode == 3 && root.current-conflict-index >= 0 : Rectangle {
+            height: 5px;
+            background: transparent;
+            Rectangle {
+                y: 2px;
+                height: 1px;
+                background: Palette.border;
+            }
+            TouchArea {
+                property <length> drag-start-y;
+                property <length> drag-start-height;
+                moved => {
+                    root.detail-pane-height = Math.clamp(
+                        drag-start-height - (self.mouse-y - drag-start-y),
+                        60px,
+                        400px
+                    );
+                }
+                pointer-event(ev) => {
+                    if ev.kind == PointerEventKind.down {
+                        drag-start-y = self.mouse-y;
+                        drag-start-height = root.detail-pane-height;
+                    }
+                }
+            }
+        }
+
+        // 3-way detail pane (top=left, middle=base, bottom=right — vertical stack)
+        if root.show-detail-pane && root.view-mode == 3 && root.current-conflict-index >= 0 : Rectangle {
+            height: root.detail-pane-height;
+            background: Palette.background;
+            border-color: Palette.border;
+            border-width: 1px;
+
+            property <int> three-way-detail-panel-count:
+                (root.detail-has-left ? 1 : 0) + (root.detail-has-base ? 1 : 0) + (root.detail-has-right ? 1 : 0);
+            property <length> three-way-detail-panel-height:
+                three-way-detail-panel-count > 0
+                    ? (root.detail-pane-height - 2px) / three-way-detail-panel-count
+                    : 0px;
+
+            VerticalLayout {
+                spacing: 0;
+
+                // Left (top) panel
+                if root.detail-has-left : Rectangle {
+                    height: three-way-detail-panel-height;
+                    border-color: Palette.border;
+                    border-width: 1px;
+                    clip: true;
+                    VerticalLayout {
+                        spacing: 0;
+                        Rectangle {
+                            height: 14px;
+                            background: ThemeColors.added-bg;
+                            Text {
+                                x: 4px;
+                                text: "Left";
+                                font-size: 10px;
+                                font-weight: 600;
+                                color: ThemeColors.added-fg;
+                                vertical-alignment: center;
+                            }
+                        }
+                        ListView {
+                            viewport-y: root.detail-left-scroll-y;
+                            for line in root.detail-left-lines: Rectangle {
+                                height: (root.opt-font-size + 2) * 1px;
+                                background: line.status == 4 ? ThemeColors.removed-bg-current :
+                                            line.status == 3 ? ThemeColors.modified-bg-current :
+                                            ThemeColors.added-bg-current;
+                                HorizontalLayout {
+                                    spacing: 0;
+                                    alignment: start;
+                                    padding-left: 4px;
+                                    for seg in line.segments: Text {
+                                        text: seg.text;
+                                        font-size: root.opt-font-size * 1px;
+                                        font-family: "monospace";
+                                        color: Palette.foreground;
+                                        vertical-alignment: center;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Base (middle) panel
+                if root.detail-has-base : Rectangle {
+                    height: three-way-detail-panel-height;
+                    border-color: Palette.border;
+                    border-width: 1px;
+                    clip: true;
+                    VerticalLayout {
+                        spacing: 0;
+                        Rectangle {
+                            height: 14px;
+                            background: Palette.background.darker(0.08);
+                            Text {
+                                x: 4px;
+                                text: "Middle";
+                                font-size: 10px;
+                                font-weight: 600;
+                                color: Palette.foreground.transparentize(0.3);
+                                vertical-alignment: center;
+                            }
+                        }
+                        ListView {
+                            viewport-y: root.detail-base-scroll-y;
+                            for line in root.detail-base-lines: Rectangle {
+                                height: (root.opt-font-size + 2) * 1px;
+                                background: Palette.background.darker(0.04);
+                                HorizontalLayout {
+                                    spacing: 0;
+                                    alignment: start;
+                                    padding-left: 4px;
+                                    for seg in line.segments: Text {
+                                        text: seg.text;
+                                        font-size: root.opt-font-size * 1px;
+                                        font-family: "monospace";
+                                        color: Palette.foreground;
+                                        vertical-alignment: center;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Right (bottom) panel
+                if root.detail-has-right : Rectangle {
+                    height: three-way-detail-panel-height;
+                    border-color: Palette.border;
+                    border-width: 1px;
+                    clip: true;
+                    VerticalLayout {
+                        spacing: 0;
+                        Rectangle {
+                            height: 14px;
+                            background: ThemeColors.added-bg;
+                            Text {
+                                x: 4px;
+                                text: "Right";
+                                font-size: 10px;
+                                font-weight: 600;
+                                color: ThemeColors.added-fg;
+                                vertical-alignment: center;
+                            }
+                        }
+                        ListView {
+                            viewport-y: root.detail-right-scroll-y;
+                            for line in root.detail-right-lines: Rectangle {
+                                height: (root.opt-font-size + 2) * 1px;
+                                background: line.status == 4 ? ThemeColors.removed-bg-current :
+                                            line.status == 3 ? ThemeColors.modified-bg-current :
+                                            ThemeColors.added-bg-current;
+                                HorizontalLayout {
+                                    spacing: 0;
+                                    alignment: start;
+                                    padding-left: 4px;
+                                    for seg in line.segments: Text {
+                                        text: seg.text;
+                                        font-size: root.opt-font-size * 1px;
+                                        font-family: "monospace";
+                                        color: Palette.foreground;
+                                        vertical-alignment: center;
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -1861,6 +2117,63 @@ export component MainWindow inherits Window {
                     Button {
                         text: @tr("Cancel");
                         clicked => { root.show-quit-confirm = false; }
+                    }
+                }
+            }
+        }
+    }
+
+    // Tab close confirm dialog
+    if root.show-tab-close-confirm : Rectangle {
+        width: 100%;
+        height: 100%;
+        background: #00000060;
+
+        Rectangle {
+            width: Math.min(400px, parent.width - 48px);
+            height: dlg-tab-close.preferred-height + 32px;
+            x: (parent.width - self.width) / 2;
+            y: (parent.height - self.height) / 2;
+            background: Palette.background;
+            border-radius: 8px;
+            border-color: Palette.border;
+            border-width: 1px;
+            drop-shadow-blur: 16px;
+            drop-shadow-color: #00000040;
+
+            dlg-tab-close := VerticalLayout {
+                padding: 20px;
+                spacing: 14px;
+
+                Text {
+                    text: @tr("Unsaved Changes");
+                    font-size: 14px;
+                    font-weight: 700;
+                    color: Palette.foreground;
+                }
+                Rectangle { height: 1px; background: Palette.border; }
+                Text {
+                    text: @tr("This tab has unsaved changes. What would you like to do?");
+                    font-size: 13px;
+                    color: Palette.foreground;
+                    wrap: word-wrap;
+                    width: parent.width - 40px;
+                }
+                Rectangle { height: 1px; background: Palette.border; }
+                HorizontalLayout {
+                    alignment: end;
+                    spacing: 8px;
+                    Button {
+                        text: @tr("Save(S)");
+                        clicked => { root.tab-close-save(); }
+                    }
+                    Button {
+                        text: @tr("Don't Save(D)");
+                        clicked => { root.tab-close-discard(); }
+                    }
+                    Button {
+                        text: @tr("Cancel");
+                        clicked => { root.show-tab-close-confirm = false; }
                     }
                 }
             }

--- a/ui/widgets/diff-view-3way.slint
+++ b/ui/widgets/diff-view-3way.slint
@@ -23,15 +23,23 @@ component ThreeWayLineRow inherits Rectangle {
     in property <int> text-font-size: 13;
     in property <bool> editable: false;
     in property <bool> force-focus: false;
+    in property <bool> focus-at-end: false;
 
     callback text-edited(string);
     callback return-pressed();
     callback backspace-at-start();
     callback focus-applied();
+    callback move-up();
+    callback move-down();
+    callback clicked();
 
     // For rows that exist when focus property changes
     changed force-focus => {
         if self.force-focus {
+            if root.focus-at-end {
+                ti.text = ti.text + " ";
+                ti.text = root.text;
+            }
             ti.focus();
             root.focus-applied();
         }
@@ -47,23 +55,23 @@ component ThreeWayLineRow inherits Rectangle {
     property <color> text-color: Palette.foreground;
 
     background: is-current ? current-bg :
-                status == 1 ? ThemeColors.left-changed-bg :
-                status == 2 ? ThemeColors.right-changed-bg :
-                status == 3 ? ThemeColors.both-changed-bg :
-                status == 4 ? ThemeColors.conflict-bg :
+                status == 1 ? ThemeColors.added-bg :
+                status == 2 ? ThemeColors.added-bg :
+                status == 3 ? ThemeColors.modified-bg :
+                status == 4 ? ThemeColors.removed-bg :
                 Palette.background;
 
     property <color> current-bg:
-                status == 4 ? ThemeColors.conflict-bg-current :
-                status == 1 ? ThemeColors.left-changed-bg-current :
-                status == 2 ? ThemeColors.right-changed-bg-current :
-                status == 3 ? ThemeColors.both-changed-bg-current :
+                status == 4 ? ThemeColors.removed-bg-current :
+                status == 1 ? ThemeColors.added-bg-current :
+                status == 2 ? ThemeColors.added-bg-current :
+                status == 3 ? ThemeColors.modified-bg-current :
                 Palette.background.darker(0.05);
 
     HorizontalLayout {
         padding-left: 4px;
         padding-right: 4px;
-        spacing: 8px;
+        spacing: 4px;
 
         if show-line-no : Rectangle {
             width: 36px;
@@ -77,27 +85,18 @@ component ThreeWayLineRow inherits Rectangle {
             }
         }
 
-        // Status marker
-        Rectangle {
-            width: 14px;
-            Text {
-                text: status == 1 ? "L" : status == 2 ? "R" : status == 3 ? "=" : status == 4 ? "!" : " ";
-                font-size: 10px;
-                font-family: "monospace";
-                font-weight: 700;
-                color: status == 1 ? ThemeColors.moved-fg : status == 2 ? ThemeColors.added-fg : status == 3 ? ThemeColors.modified-fg : status == 4 ? ThemeColors.removed-fg : Palette.foreground.transparentize(0.5);
-                vertical-alignment: center;
-                horizontal-alignment: center;
+        if !root.editable : Rectangle {
+            TouchArea {
+                clicked => { root.clicked(); }
             }
-        }
-
-        if !root.editable : Text {
-            text: root.text;
-            font-size: root.text-font-size * 1px;
-            font-family: "monospace";
-            vertical-alignment: center;
-            overflow: elide;
-            color: root.text-color;
+            Text {
+                text: root.text;
+                font-size: root.text-font-size * 1px;
+                font-family: "monospace";
+                vertical-alignment: center;
+                overflow: elide;
+                color: root.text-color;
+            }
         }
         // TextInput always instantiated so `ti` id is in scope for focus()
         ti := TextInput {
@@ -116,28 +115,123 @@ component ThreeWayLineRow inherits Rectangle {
                 } else if event.text == "\u{0008}" && self.cursor-position-byte-offset == 0 {
                     root.backspace-at-start();
                     accept
+                } else if event.text == Key.UpArrow {
+                    root.move-up();
+                    accept
+                } else if event.text == Key.DownArrow {
+                    root.move-down();
+                    accept
                 } else {
                     reject
                 }
             }
         }
+        // Click overlay: intercept clicks when TextInput doesn't have focus
+        // so that clicking anywhere in the pane places cursor at end of text.
+        if root.editable && !ti.has-focus : TouchArea {
+            clicked => { root.clicked(); }
+        }
+    }
+}
+
+// WinMerge-style 3-bar location pane with connector regions
+// Bar layout: [left-bar][connector-LM][middle-bar][connector-MR][right-bar]
+// Status: 0=Equal, 1=LeftChanged, 2=RightChanged, 3=BothChanged, 4=Conflict
+component ThreeWayLocationPane inherits Rectangle {
+    in property <[ThreeWayLineData]> lines;
+    in property <int> current-conflict-index: -1;
+
+    width: 36px;
+    background: Palette.background.darker(0.02);
+    border-color: Palette.border;
+    border-width: 1px;
+
+    // Layout: 6px bar, 4px connector, 6px bar, 4px connector, 6px bar = 26px + margins
+    property <length> bar-width: 8px;
+    property <length> gap-width: 4px;
+    property <length> start-x: 2px;
+
+    // Left bar
+    for line[idx] in lines: Rectangle {
+        y: lines.length > 0 ? (idx * (parent.height - 2px) / lines.length) : 0;
+        height: lines.length > 0 ? Math.max(2px, (parent.height - 2px) / lines.length) : 0;
+        x: root.start-x;
+        width: root.bar-width;
+        background: line.status == 0 ? transparent :
+                    (line.conflict-index == root.current-conflict-index && root.current-conflict-index >= 0) ? ThemeColors.location-current :
+                    line.status == 1 ? ThemeColors.added-fg :
+                    line.status == 3 ? ThemeColors.modified-fg :
+                    line.status == 4 ? ThemeColors.removed-fg : transparent;
+    }
+
+    // Left-Middle connector
+    for line[idx] in lines: Rectangle {
+        y: lines.length > 0 ? (idx * (parent.height - 2px) / lines.length) : 0;
+        height: lines.length > 0 ? Math.max(2px, (parent.height - 2px) / lines.length) : 0;
+        x: root.start-x + root.bar-width;
+        width: root.gap-width;
+        // Yellow if right-only (left==middle), Cyan if middle-only, Red if conflict
+        background: line.status == 2 ? #ffff7f :
+                    line.status == 3 ? #7fffff :
+                    line.status == 4 ? #ff4444 : transparent;
+    }
+
+    // Middle bar
+    for line[idx] in lines: Rectangle {
+        y: lines.length > 0 ? (idx * (parent.height - 2px) / lines.length) : 0;
+        height: lines.length > 0 ? Math.max(2px, (parent.height - 2px) / lines.length) : 0;
+        x: root.start-x + root.bar-width + root.gap-width;
+        width: root.bar-width;
+        background: line.status == 0 ? transparent :
+                    (line.conflict-index == root.current-conflict-index && root.current-conflict-index >= 0) ? ThemeColors.location-current :
+                    line.status == 3 ? ThemeColors.modified-fg :
+                    line.status == 4 ? ThemeColors.removed-fg : transparent;
+    }
+
+    // Middle-Right connector
+    for line[idx] in lines: Rectangle {
+        y: lines.length > 0 ? (idx * (parent.height - 2px) / lines.length) : 0;
+        height: lines.length > 0 ? Math.max(2px, (parent.height - 2px) / lines.length) : 0;
+        x: root.start-x + root.bar-width * 2 + root.gap-width;
+        width: root.gap-width;
+        // Yellow if left-only (middle==right), Cyan if middle-only, Red if conflict
+        background: line.status == 1 ? #ffff7f :
+                    line.status == 3 ? #7fffff :
+                    line.status == 4 ? #ff4444 : transparent;
+    }
+
+    // Right bar
+    for line[idx] in lines: Rectangle {
+        y: lines.length > 0 ? (idx * (parent.height - 2px) / lines.length) : 0;
+        height: lines.length > 0 ? Math.max(2px, (parent.height - 2px) / lines.length) : 0;
+        x: root.start-x + root.bar-width * 2 + root.gap-width * 2;
+        width: root.bar-width;
+        background: line.status == 0 ? transparent :
+                    (line.conflict-index == root.current-conflict-index && root.current-conflict-index >= 0) ? ThemeColors.location-current :
+                    line.status == 2 ? ThemeColors.added-fg :
+                    line.status == 3 ? ThemeColors.modified-fg :
+                    line.status == 4 ? ThemeColors.removed-fg : transparent;
     }
 }
 
 export component DiffView3Way inherits Rectangle {
     in property <string> base-title: "Base";
-    in property <string> left-title: "Left (Mine)";
-    in property <string> right-title: "Right (Theirs)";
+    in property <string> left-title: "Left";
+    in property <string> right-title: "Right";
     in property <[ThreeWayLineData]> lines;
     in property <int> current-conflict-index: -1;
     in property <bool> show-line-numbers: true;
     in property <int> editor-font-size: 13;
     in property <bool> inline-edit-enabled: false;
+    in property <bool> show-location-pane: true;
 
     // Row index to focus for each pane (-1 = none)
     in-out property <int> edit-focus-left-row: -1;
     in-out property <int> edit-focus-base-row: -1;
     in-out property <int> edit-focus-right-row: -1;
+    in-out property <bool> focus-left-at-end: false;
+    in-out property <bool> focus-base-at-end: false;
+    in-out property <bool> focus-right-at-end: false;
 
     callback next-conflict();
     callback prev-conflict();
@@ -148,6 +242,8 @@ export component DiffView3Way inherits Rectangle {
     callback edit-text-changed(/* row */ int, /* text */ string, /* pane */ int);
     callback insert-line-after(/* row */ int, /* pane */ int);
     callback delete-line(/* row */ int, /* pane */ int);
+    callback move-focus-up(/* row */ int, /* pane */ int);
+    callback move-focus-down(/* row */ int, /* pane */ int);
 
     border-color: Palette.border;
     border-width: 1px;
@@ -158,6 +254,8 @@ export component DiffView3Way inherits Rectangle {
             height: 28px;
 
             Rectangle {
+                horizontal-stretch: 1;
+                min-width: 80px;
                 background: Palette.background.darker(0.05);
                 border-color: Palette.border;
                 border-width: 1px;
@@ -174,6 +272,8 @@ export component DiffView3Way inherits Rectangle {
             }
 
             Rectangle {
+                horizontal-stretch: 1;
+                min-width: 80px;
                 background: Palette.background.darker(0.05);
                 border-color: Palette.border;
                 border-width: 1px;
@@ -189,22 +289,9 @@ export component DiffView3Way inherits Rectangle {
                 }
             }
 
-            // Resolve buttons column header
             Rectangle {
-                width: 60px;
-                background: Palette.background.darker(0.05);
-                border-color: Palette.border;
-                border-width: 1px;
-                Text {
-                    text: @tr("Resolve");
-                    font-size: 11px;
-                    font-weight: 600;
-                    horizontal-alignment: center;
-                    vertical-alignment: center;
-                }
-            }
-
-            Rectangle {
+                horizontal-stretch: 1;
+                min-width: 80px;
                 background: Palette.background.darker(0.05);
                 border-color: Palette.border;
                 border-width: 1px;
@@ -219,123 +306,111 @@ export component DiffView3Way inherits Rectangle {
                     }
                 }
             }
+
+            // Spacer matching LocationPane width
+            if root.lines.length > 0 && root.show-location-pane : Rectangle {
+                width: 36px;
+                background: Palette.background.darker(0.05);
+                border-color: Palette.border;
+                border-width: 1px;
+            }
         }
 
-        // Content
+        // Content: three equal panes
         HorizontalLayout {
             // Left pane
-            left-list := ListView {
-                for line[idx] in lines: ThreeWayLineRow {
-                    height: 24px;
-                    line-no: line.left-line-no;
-                    text: line.left-text;
-                    status: line.status;
-                    is-current: line.is-current;
-                    show-line-no: root.show-line-numbers;
-                    text-font-size: root.editor-font-size;
-                    editable: root.inline-edit-enabled && line.left-line-no != "";
-                    force-focus: root.inline-edit-enabled && idx == root.edit-focus-left-row;
-                    text-edited(t) => { root.edit-text-changed(idx, t, 0); }
-                    return-pressed => { root.insert-line-after(idx, 0); }
-                    backspace-at-start => { root.delete-line(idx, 0); }
-                    focus-applied => { root.edit-focus-left-row = -1; }
+            Rectangle {
+                horizontal-stretch: 1;
+                min-width: 80px;
+                border-color: Palette.border;
+                border-width: 1px;
+                left-list := ListView {
+                    for line[idx] in lines: ThreeWayLineRow {
+                        height: (root.editor-font-size + 2) * 1px;
+                        line-no: line.left-line-no;
+                        text: line.left-text;
+                        status: line.status;
+                        is-current: line.is-current;
+                        show-line-no: root.show-line-numbers;
+                        text-font-size: root.editor-font-size;
+                        editable: root.inline-edit-enabled && line.left-line-no != "";
+                        force-focus: root.inline-edit-enabled && idx == root.edit-focus-left-row;
+                        focus-at-end: root.focus-left-at-end;
+                        text-edited(t) => { root.edit-text-changed(idx, t, 0); }
+                        return-pressed => { root.insert-line-after(idx, 0); }
+                        backspace-at-start => { root.focus-left-at-end = true; root.delete-line(idx, 0); }
+                        focus-applied => { root.edit-focus-left-row = -1; root.focus-left-at-end = false; }
+                        move-up => { root.move-focus-up(idx, 0); }
+                        move-down => { root.move-focus-down(idx, 0); }
+                        clicked => { root.focus-left-at-end = true; root.edit-focus-left-row = idx; }
+                    }
                 }
             }
 
             // Base pane
-            ListView {
-                viewport-y: left-list.viewport-y;
-                for line[idx] in lines: ThreeWayLineRow {
-                    height: 24px;
-                    line-no: line.base-line-no;
-                    text: line.base-text;
-                    status: 0; // Base always neutral
-                    is-current: line.is-current;
-                    show-line-no: root.show-line-numbers;
-                    text-font-size: root.editor-font-size;
-                    editable: root.inline-edit-enabled && line.base-line-no != "";
-                    force-focus: root.inline-edit-enabled && idx == root.edit-focus-base-row;
-                    text-edited(t) => { root.edit-text-changed(idx, t, 1); }
-                    return-pressed => { root.insert-line-after(idx, 1); }
-                    backspace-at-start => { root.delete-line(idx, 1); }
-                    focus-applied => { root.edit-focus-base-row = -1; }
-                }
-            }
-
-            // Resolve buttons
             Rectangle {
-                width: 60px;
-                background: Palette.background.darker(0.01);
+                horizontal-stretch: 1;
+                min-width: 80px;
                 border-color: Palette.border;
                 border-width: 1px;
-
                 ListView {
                     viewport-y: left-list.viewport-y;
-                    for line in lines: Rectangle {
-                        height: 24px;
-                        if line.status == 4 : HorizontalLayout {
-                            padding: 1px;
-                            spacing: 2px;
-                            alignment: center;
-
-                            Rectangle {
-                                width: 24px;
-                                height: 20px;
-                                background: use-l-touch.has-hover ? ThemeColors.resolve-left-hover : transparent;
-                                border-radius: 2px;
-                                Text {
-                                    text: "L";
-                                    font-size: 10px;
-                                    font-weight: 700;
-                                    color: ThemeColors.moved-fg;
-                                    horizontal-alignment: center;
-                                    vertical-alignment: center;
-                                }
-                                use-l-touch := TouchArea {
-                                    clicked => { root.use-left(line.conflict-index); }
-                                }
-                            }
-
-                            Rectangle {
-                                width: 24px;
-                                height: 20px;
-                                background: use-r-touch.has-hover ? ThemeColors.resolve-right-hover : transparent;
-                                border-radius: 2px;
-                                Text {
-                                    text: "R";
-                                    font-size: 10px;
-                                    font-weight: 700;
-                                    color: ThemeColors.added-fg;
-                                    horizontal-alignment: center;
-                                    vertical-alignment: center;
-                                }
-                                use-r-touch := TouchArea {
-                                    clicked => { root.use-right(line.conflict-index); }
-                                }
-                            }
-                        }
+                    for line[idx] in lines: ThreeWayLineRow {
+                        height: (root.editor-font-size + 2) * 1px;
+                        line-no: line.base-line-no;
+                        text: line.base-text;
+                        status: line.status;
+                        is-current: line.is-current;
+                        show-line-no: root.show-line-numbers;
+                        text-font-size: root.editor-font-size;
+                        editable: root.inline-edit-enabled && line.base-line-no != "";
+                        force-focus: root.inline-edit-enabled && idx == root.edit-focus-base-row;
+                        focus-at-end: root.focus-base-at-end;
+                        text-edited(t) => { root.edit-text-changed(idx, t, 1); }
+                        return-pressed => { root.insert-line-after(idx, 1); }
+                        backspace-at-start => { root.focus-base-at-end = true; root.delete-line(idx, 1); }
+                        focus-applied => { root.edit-focus-base-row = -1; root.focus-base-at-end = false; }
+                        move-up => { root.move-focus-up(idx, 1); }
+                        move-down => { root.move-focus-down(idx, 1); }
+                        clicked => { root.focus-base-at-end = true; root.edit-focus-base-row = idx; }
                     }
                 }
             }
 
             // Right pane
-            ListView {
-                viewport-y: left-list.viewport-y;
-                for line[idx] in lines: ThreeWayLineRow {
-                    height: 24px;
-                    line-no: line.right-line-no;
-                    text: line.right-text;
-                    status: line.status;
-                    is-current: line.is-current;
-                    show-line-no: root.show-line-numbers;
-                    text-font-size: root.editor-font-size;
-                    editable: root.inline-edit-enabled && line.right-line-no != "";
-                    force-focus: root.inline-edit-enabled && idx == root.edit-focus-right-row;
-                    text-edited(t) => { root.edit-text-changed(idx, t, 2); }
-                    return-pressed => { root.insert-line-after(idx, 2); }
-                    backspace-at-start => { root.delete-line(idx, 2); }
-                    focus-applied => { root.edit-focus-right-row = -1; }
+            Rectangle {
+                horizontal-stretch: 1;
+                min-width: 80px;
+                border-color: Palette.border;
+                border-width: 1px;
+                ListView {
+                    viewport-y: left-list.viewport-y;
+                    for line[idx] in lines: ThreeWayLineRow {
+                        height: (root.editor-font-size + 2) * 1px;
+                        line-no: line.right-line-no;
+                        text: line.right-text;
+                        status: line.status;
+                        is-current: line.is-current;
+                        show-line-no: root.show-line-numbers;
+                        text-font-size: root.editor-font-size;
+                        editable: root.inline-edit-enabled && line.right-line-no != "";
+                        force-focus: root.inline-edit-enabled && idx == root.edit-focus-right-row;
+                        focus-at-end: root.focus-right-at-end;
+                        text-edited(t) => { root.edit-text-changed(idx, t, 2); }
+                        return-pressed => { root.insert-line-after(idx, 2); }
+                        backspace-at-start => { root.focus-right-at-end = true; root.delete-line(idx, 2); }
+                        focus-applied => { root.edit-focus-right-row = -1; root.focus-right-at-end = false; }
+                        move-up => { root.move-focus-up(idx, 2); }
+                        move-down => { root.move-focus-down(idx, 2); }
+                        clicked => { root.focus-right-at-end = true; root.edit-focus-right-row = idx; }
+                    }
                 }
+            }
+
+            // Location pane (minimap)
+            if root.lines.length > 0 && root.show-location-pane : ThreeWayLocationPane {
+                lines: root.lines;
+                current-conflict-index: root.current-conflict-index;
             }
         }
     }

--- a/ui/widgets/diff-view.slint
+++ b/ui/widgets/diff-view.slint
@@ -35,6 +35,7 @@ component DiffLineRow inherits Rectangle {
     in property <bool> is-current;
     in property <int> highlight-type: -1;
     in property <int> diff-idx: -1;
+    in property <int> row-index: 0;
     in property <bool> show-line-no: true;
     in property <int> text-font-size: 13;
     in property <bool> editable: false;
@@ -45,6 +46,8 @@ component DiffLineRow inherits Rectangle {
     in property <bool> is-selected: false;
 
     callback line-clicked(int);
+    callback row-clicked(/* row-index */ int);
+    callback row-shift-clicked(/* row-index */ int);
     callback text-edited(string);
     callback return-pressed();
     callback focus-applied();
@@ -108,9 +111,16 @@ component DiffLineRow inherits Rectangle {
             }
 
             line-no-touch := TouchArea {
-                clicked => {
-                    if diff-idx >= 0 {
-                        root.line-clicked(diff-idx);
+                pointer-event(ev) => {
+                    if ev.button == PointerEventButton.left && ev.kind == PointerEventKind.up {
+                        if ev.modifiers.shift {
+                            root.row-shift-clicked(root.row-index);
+                        } else {
+                            root.row-clicked(root.row-index);
+                            if diff-idx >= 0 {
+                                root.line-clicked(diff-idx);
+                            }
+                        }
                     }
                 }
             }
@@ -261,8 +271,15 @@ export component DiffView inherits Rectangle {
     callback copy-left-text();
     callback copy-right-text();
     callback row-shift-clicked(/* row-index */ int);
+    callback drag-select-start(/* row-index */ int);
+    callback drag-select-move(/* row-index */ int);
+    callback drag-select-end();
     callback copy-selection-to-right();
     callback copy-selection-to-left();
+
+    // Internal: track whether drag is in progress
+    in-out property <bool> drag-active: false;
+    property <length> line-height: (root.editor-font-size + 2) * 1px;
 
     border-color: Palette.border;
     border-width: 1px;
@@ -350,6 +367,7 @@ export component DiffView inherits Rectangle {
                         line-no: line.left-line-no;
                         text: line.left-text;
                         status: line.status == 1 ? 0 : line.status;
+                        row-index: idx;
                         is-current: line.diff-index >= 0 && line.diff-index == root.current-diff-index;
                         is-search-match: line.is-search-match;
                         is-selected: line.is-selected;
@@ -363,6 +381,8 @@ export component DiffView inherits Rectangle {
                         force-focus: root.inline-edit-enabled && idx == root.edit-focus-row;
                         focus-at-end: root.focus-left-at-end;
                         line-clicked(didx) => { root.select-diff(didx); }
+                        row-clicked(ridx) => { root.drag-select-start(ridx); }
+                        row-shift-clicked(ridx) => { root.row-shift-clicked(ridx); }
                         text-edited(new-text) => { root.edit-left-line(idx, new-text); }
                         return-pressed => { root.insert-line-after(idx, true); }
                         focus-applied => { root.edit-focus-row = -1; root.focus-left-at-end = false; }
@@ -401,6 +421,7 @@ export component DiffView inherits Rectangle {
                         line-no: line.right-line-no;
                         text: line.right-text;
                         status: line.status == 2 ? 0 : line.status;
+                        row-index: idx;
                         is-current: line.diff-index >= 0 && line.diff-index == root.current-diff-index;
                         is-search-match: line.is-search-match;
                         is-selected: line.is-selected;
@@ -414,6 +435,8 @@ export component DiffView inherits Rectangle {
                         force-focus: root.inline-edit-enabled && idx == root.edit-focus-right-row;
                         focus-at-end: root.focus-right-at-end;
                         line-clicked(didx) => { root.select-diff(didx); }
+                        row-clicked(ridx) => { root.drag-select-start(ridx); }
+                        row-shift-clicked(ridx) => { root.row-shift-clicked(ridx); }
                         text-edited(new-text) => { root.edit-right-line(idx, new-text); }
                         return-pressed => { root.insert-line-after(idx, false); }
                         focus-applied => { root.edit-focus-right-row = -1; root.focus-right-at-end = false; }


### PR DESCRIPTION
## Summary
- 3-way diffエンジンをWinMerge Make3wayDiffアルゴリズムに基づき全面書き換え
- コピー→F5でテキストが消えるバグを修正（ghost行のbase_line_no問題、フォーカス状態リセット）
- 全テキスト削除で入力不能になるバグを修正
- 保存ボタンをドロップダウン式に統合（Left/Middle/Right選択）
- コピー&次へ、全コピーツールバーボタンを3-wayに追加
- ペインクリックでカーソルがテキスト末尾に移動
- タブ閉じ時の保存確認ダイアログ追加
- ストレステスト追加（20,000+操作で3ペインのテキスト整合性検証）
- CLAUDE.md・cargo fmtフック等の開発環境整備

## Test plan
- [x] `cargo test --features desktop` — 全29テスト通過
- [x] `cargo build --features desktop` — 警告ゼロ
- [x] 手動テスト: 左aaa/aaaa、右aaa → 全コピー → 右にccc追加 → F5 → 真ん中のaaaaが残ること確認済み
- [ ] 3-way新規ドキュメントで各種操作確認
- [ ] 2-way既存機能のリグレッション確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)