### PR TITLE
v0.34.1: IPC single-instance — git difftool opens diffs as tabs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winxmerge"
-version = "0.34.0"
+version = "0.34.1"
 edition = "2024"
 
 [lib]
@@ -76,7 +76,7 @@ identifier = "io.github.masak1yu.winxmerge"
 icon = ["assets/icons/app-icon-32.png", "assets/icons/app-icon-64.png",
         "assets/icons/app-icon-128.png", "assets/icons/app-icon-256.png",
         "assets/icons/app-icon-512.png", "assets/icons/app-icon.icns"]
-version = "0.34.0"
+version = "0.34.1"
 copyright = "WinXMerge contributors"
 category = "Developer Tool"
 short_description = "Cross-platform file diff and merge tool"

--- a/README.md
+++ b/README.md
@@ -351,6 +351,12 @@ git difftool main..feature-branch
 git mergetool
 ```
 
+### Single-Instance Tab Mode
+
+When multiple files are changed, `git difftool` invokes WinXMerge once per file.
+WinXMerge uses IPC (Unix domain socket) to detect a running instance and opens
+subsequent diffs as new tabs in the existing window instead of spawning separate processes.
+
 ## Project Structure
 
 ```

--- a/handover.md
+++ b/handover.md
@@ -8,11 +8,21 @@ Web アプリ: `https://winxmerge.app`
 
 ## 現在の状態
 
-- **バージョン:** 0.33.0 開発中
-- **ブランチ:** `v0.33.0`
+- **バージョン:** 0.34.1
+- **ブランチ:** `feature/v0.34.1`
+- **テスト:** 29件すべてパス
+- **ビルド:** `cargo build --features desktop` 成功
 - **CI:** GitHub Actions（Ubuntu / macOS (aarch64) / Windows）+ Cloudflare Pages (WASM)
 
-## v0.33.0 の変更内容（開発中）
+## v0.34.1 の変更内容
+
+### IPC によるシングルインスタンス・タブ追加
+- Unix domain socket (`/tmp/winxmerge-<user>.sock`) による IPC
+- 2回目以降の起動は既存インスタンスにファイルパスを送信して即終了
+- 既存インスタンスが新しいタブとして diff を開く
+- `git difftool` で複数ファイル差分が1ウィンドウのタブとして表示可能に
+
+## v0.33.0 の変更内容
 
 ### インライン編集（WinMerge 仕様準拠）
 - [x] `editing_mode` 廃止 — 常に Ghost 行込み整列ビューで編集
@@ -79,6 +89,9 @@ trunk build --release  # 本番ビルド → dist/
 
 | バージョン | PR | 内容 |
 |-----------|-----|------|
+| v0.34.1 | #38 | IPC シングルインスタンス — git difftool でタブ式に複数ファイル差分を開く |
+| v0.34.0 | #37 | 3-way diff エンジン全面書き換え、コピー/F5 バグ修正、保存ドロップダウン |
+| v0.33.0 | #36 | インライン編集、新規ドキュメント、Save As ファイルブラウザ、終了時保存導線 |
 | v0.32.0 | #35 | WASM フルスクリーン、ダークテーマ、ペースト、diff 統計 |
 | v0.31.0 | #34 | WASM 表示修正（lib+bin ハイブリッド、canvas DOM 挿入） |
 | v0.30.0 | #33 | WASM ファイルアップロード、diff ナビゲーション |

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,0 +1,61 @@
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::mpsc::Sender;
+
+fn socket_path() -> std::path::PathBuf {
+    let user = std::env::var("USER").unwrap_or_else(|_| "default".to_string());
+    std::path::PathBuf::from(format!("/tmp/winxmerge-{}.sock", user))
+}
+
+/// Try to connect to a running instance and send file paths.
+/// Returns Ok(()) if paths were sent successfully (caller should exit).
+/// Returns Err if no running instance found (caller should become the primary).
+pub fn try_send(paths: &[String]) -> Result<(), ()> {
+    let sock = socket_path();
+    match UnixStream::connect(&sock) {
+        Ok(mut stream) => {
+            let payload = paths.join("\n") + "\n";
+            let _ = stream.write_all(payload.as_bytes());
+            let _ = stream.flush();
+            Ok(())
+        }
+        Err(_) => Err(()),
+    }
+}
+
+/// Start listening for incoming file paths from other instances.
+/// Sends received (left, right) pairs through the channel.
+pub fn start_listener(tx: Sender<Vec<String>>) {
+    let sock = socket_path();
+    // Remove stale socket file
+    let _ = std::fs::remove_file(&sock);
+
+    let listener = match UnixListener::bind(&sock) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("[winxmerge] IPC listen failed: {}", e);
+            return;
+        }
+    };
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            if let Ok(stream) = stream {
+                let reader = BufReader::new(stream);
+                let paths: Vec<String> = reader
+                    .lines()
+                    .map_while(Result::ok)
+                    .filter(|l| !l.is_empty())
+                    .collect();
+                if !paths.is_empty() {
+                    let _ = tx.send(paths);
+                }
+            }
+        }
+    });
+}
+
+/// Clean up the socket file (call on app exit).
+pub fn cleanup() {
+    let _ = std::fs::remove_file(socket_path());
+}

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -9,7 +9,7 @@ fn socket_path() -> std::path::PathBuf {
 
 /// Try to connect to a running instance and send file paths.
 /// Returns Ok(()) if paths were sent successfully (caller should exit).
-/// Returns Err if no running instance found (caller should become the primary).
+/// Returns Err if no running instance found.
 pub fn try_send(paths: &[String]) -> Result<(), ()> {
     let sock = socket_path();
     match UnixStream::connect(&sock) {
@@ -23,8 +23,57 @@ pub fn try_send(paths: &[String]) -> Result<(), ()> {
     }
 }
 
+/// Try to send with retries (waiting for server to start).
+pub fn try_send_with_retry(paths: &[String], retries: u32) -> Result<(), ()> {
+    for _ in 0..retries {
+        if try_send(paths).is_ok() {
+            return Ok(());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    Err(())
+}
+
+/// Copy files to a temp directory so git difftool can clean up originals.
+/// Returns new paths pointing to the copies.
+pub fn copy_to_temp(paths: &[String]) -> Vec<String> {
+    let temp_dir = std::env::temp_dir().join("winxmerge-diff");
+    let _ = std::fs::create_dir_all(&temp_dir);
+    let id = std::process::id();
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+
+    paths
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            let src = std::path::Path::new(p);
+            let name = src
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| format!("file{}", i));
+            let dest = temp_dir.join(format!("{}-{}-{}-{}", id, ts, i, name));
+            let _ = std::fs::copy(src, &dest);
+            dest.to_string_lossy().to_string()
+        })
+        .collect()
+}
+
+/// Spawn a new winxmerge server process in the background.
+pub fn spawn_server() {
+    let exe = std::env::current_exe().unwrap_or_else(|_| "winxmerge".into());
+    let _ = std::process::Command::new(exe)
+        .arg("--server")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+}
+
 /// Start listening for incoming file paths from other instances.
-/// Sends received (left, right) pairs through the channel.
+/// Sends received paths through the channel.
 pub fn start_listener(tx: Sender<Vec<String>>) {
     let sock = socket_path();
     // Remove stale socket file

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,8 @@ use slint::{Model, ModelRc, SharedString, VecModel};
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
+    let is_server_mode = args.iter().any(|a| a == "--server");
+
     // --clear-history: wipe session + recent files and exit
     if args.iter().any(|a| a == "--clear-history") {
         let mut s = settings::AppSettings::load();
@@ -187,6 +189,7 @@ fn main() {
                 "--ignore-whitespace" | "-w" => cli_ignore_whitespace = true,
                 "--ignore-case" | "-i" => cli_ignore_case = true,
                 "--ignore-blank-lines" | "-B" => cli_ignore_blank_lines = true,
+                "--server" | "--clear-history" => {}
                 _ => positional.push(args[i].clone()),
             }
             i += 1;
@@ -216,18 +219,27 @@ fn main() {
         }
     }
 
-    // IPC: if another instance is running, send file paths to it and exit
-    if positional.len() >= 2 {
-        if ipc::try_send(&positional).is_ok() {
+    // IPC client mode: if we have file args and are NOT the server,
+    // copy files, send to running instance (or spawn one), then exit immediately.
+    if !is_server_mode && positional.len() >= 2 {
+        let copied = ipc::copy_to_temp(&positional);
+        if ipc::try_send(&copied).is_ok() {
             return;
         }
+        // No running instance — spawn a server and send via IPC
+        ipc::spawn_server();
+        if ipc::try_send_with_retry(&copied, 30).is_ok() {
+            return;
+        }
+        eprintln!("[winxmerge] failed to connect to server");
+        return;
     }
 
-    // Start IPC listener for subsequent instances
+    // Server mode (--server) or no-args launch: start IPC listener
     let (ipc_tx, ipc_rx) = std::sync::mpsc::channel::<Vec<String>>();
     ipc::start_listener(ipc_tx);
 
-    // Handle positional arguments:
+    // Handle positional arguments (direct launch without IPC):
     //   winxmerge <left> <right>           — 2-way diff
     //   winxmerge <base> <left> <right>    — 3-way merge
     if positional.len() >= 3 {
@@ -256,7 +268,7 @@ fn main() {
         app::run_diff(&window, &mut s);
         app::sync_tab_list(&window, &s);
     } else {
-        // No CLI args: start with blank screen (WinMerge style — no session restore)
+        // No CLI args / --server: start with blank screen, wait for IPC
     }
 
     // New blank text document

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ mod export;
 mod highlight;
 #[cfg(not(target_arch = "wasm32"))]
 mod image_compare;
+#[cfg(not(target_arch = "wasm32"))]
+mod ipc;
 mod models;
 #[cfg(not(target_arch = "wasm32"))]
 mod settings;
@@ -213,6 +215,17 @@ fn main() {
             window.set_ignore_case(true);
         }
     }
+
+    // IPC: if another instance is running, send file paths to it and exit
+    if positional.len() >= 2 {
+        if ipc::try_send(&positional).is_ok() {
+            return;
+        }
+    }
+
+    // Start IPC listener for subsequent instances
+    let (ipc_tx, ipc_rx) = std::sync::mpsc::channel::<Vec<String>>();
+    ipc::start_listener(ipc_tx);
 
     // Handle positional arguments:
     //   winxmerge <left> <right>           — 2-way diff
@@ -1646,6 +1659,7 @@ fn main() {
     {
         let window_weak = window.as_weak();
         let state = state.clone();
+        let settings = settings.clone();
         let timer = slint::Timer::default();
         timer.start(
             slint::TimerMode::Repeated,
@@ -1653,6 +1667,36 @@ fn main() {
             move || {
                 if let Some(window) = window_weak.upgrade() {
                     apply_pending_diff_if_ready(&window, &mut state.borrow_mut());
+
+                    // IPC: receive file paths from other instances and open as new tabs
+                    while let Ok(paths) = ipc_rx.try_recv() {
+                        let mut s = state.borrow_mut();
+                        if paths.len() >= 3 {
+                            // 3-way merge
+                            add_tab(&window, &mut s);
+                            start_three_way_compare(
+                                &window, &mut s, &paths[0], &paths[1], &paths[2],
+                            );
+                        } else if paths.len() >= 2 {
+                            // 2-way diff
+                            add_tab(&window, &mut s);
+                            {
+                                let tab = s.current_tab_mut();
+                                tab.left_path = Some(std::path::PathBuf::from(&paths[0]));
+                                tab.right_path = Some(std::path::PathBuf::from(&paths[1]));
+                                tab.view_mode = 0;
+                            }
+                            window.set_view_mode(0);
+                            run_diff(&window, &mut s);
+                        }
+                        app::sync_tab_list(&window, &s);
+                        // Save to recent
+                        if paths.len() >= 2 {
+                            let mut ss = settings.borrow_mut();
+                            ss.add_recent(&paths[0], &paths[1], false);
+                            sync_recent_entries(&window, &ss);
+                        }
+                    }
                 }
             },
         );
@@ -2013,6 +2057,7 @@ fn main() {
     }
 
     window.run().unwrap();
+    ipc::cleanup();
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ mod export;
 mod highlight;
 #[cfg(not(target_arch = "wasm32"))]
 mod image_compare;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), unix))]
 mod ipc;
 mod models;
 #[cfg(not(target_arch = "wasm32"))]
@@ -219,8 +219,9 @@ fn main() {
         }
     }
 
-    // IPC client mode: if we have file args and are NOT the server,
+    // IPC client mode (Unix only): if we have file args and are NOT the server,
     // copy files, send to running instance (or spawn one), then exit immediately.
+    #[cfg(unix)]
     if !is_server_mode && positional.len() >= 2 {
         let copied = ipc::copy_to_temp(&positional);
         if ipc::try_send(&copied).is_ok() {
@@ -235,8 +236,10 @@ fn main() {
         return;
     }
 
-    // Server mode (--server) or no-args launch: start IPC listener
+    // Server mode (--server) or no-args launch: start IPC listener (Unix only)
+    #[cfg(unix)]
     let (ipc_tx, ipc_rx) = std::sync::mpsc::channel::<Vec<String>>();
+    #[cfg(unix)]
     ipc::start_listener(ipc_tx);
 
     // Handle positional arguments (direct launch without IPC):
@@ -1680,7 +1683,8 @@ fn main() {
                 if let Some(window) = window_weak.upgrade() {
                     apply_pending_diff_if_ready(&window, &mut state.borrow_mut());
 
-                    // IPC: receive file paths from other instances and open as new tabs
+                    // IPC: receive file paths from other instances and open as new tabs (Unix only)
+                    #[cfg(unix)]
                     while let Ok(paths) = ipc_rx.try_recv() {
                         let mut s = state.borrow_mut();
                         if paths.len() >= 3 {
@@ -2069,6 +2073,7 @@ fn main() {
     }
 
     window.run().unwrap();
+    #[cfg(unix)]
     ipc::cleanup();
 }
 


### PR DESCRIPTION
## Summary
- Unix domain socket IPC によるシングルインスタンス検出を追加
- 2回目以降の `winxmerge` 起動は既存インスタンスにファイルパスを送信して即終了
- 既存インスタンスが新しいタブとして diff を開く
- `git difftool` で複数ファイル差分が1ウィンドウのタブとして表示可能に

## Test plan
- [x] `cargo test --features desktop` — 全29テスト通過
- [x] `cargo build --features desktop` — 成功
- [ ] 手動テスト: `winxmerge file1 file2 & sleep 0.5 && winxmerge file3 file4` → 1ウィンドウ2タブ
- [ ] `git difftool -y HEAD~1` → 変更ファイルがタブで開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)