### PR TITLE
v0.34.3: fix dialog fallback, tab bar visibility, null filename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -2122,6 +2122,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -2624,12 +2630,12 @@ checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2907,14 +2913,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -4255,9 +4261,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -6580,7 +6586,7 @@ dependencies = [
 
 [[package]]
 name = "winxmerge"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "arboard",
  "calamine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winxmerge"
-version = "0.34.2"
+version = "0.34.3"
 edition = "2024"
 
 [lib]
@@ -76,7 +76,7 @@ identifier = "io.github.masak1yu.winxmerge"
 icon = ["assets/icons/app-icon-32.png", "assets/icons/app-icon-64.png",
         "assets/icons/app-icon-128.png", "assets/icons/app-icon-256.png",
         "assets/icons/app-icon-512.png", "assets/icons/app-icon.icns"]
-version = "0.34.2"
+version = "0.34.3"
 copyright = "WinXMerge contributors"
 category = "Developer Tool"
 short_description = "Cross-platform file diff and merge tool"

--- a/src/app.rs
+++ b/src/app.rs
@@ -212,6 +212,13 @@ impl AppState {
     }
 }
 
+/// Returns true if the platform supports native file dialogs.
+/// On macOS and Windows, rfd always has a working backend.
+/// On Linux without a display server or GTK, it may fail silently.
+pub fn has_native_file_dialog() -> bool {
+    cfg!(target_os = "macos") || cfg!(target_os = "windows")
+}
+
 pub fn open_file_dialog(title: &str) -> Option<PathBuf> {
     rfd::FileDialog::new().set_title(title).pick_file()
 }
@@ -3353,7 +3360,7 @@ pub fn discard_and_proceed(
                 window.set_left_path(SharedString::from(&path_str));
                 window.set_view_mode(0);
                 run_diff(window, state);
-            } else {
+            } else if !has_native_file_dialog() {
                 show_picker(11, "Select left file");
             }
         }
@@ -3369,7 +3376,7 @@ pub fn discard_and_proceed(
                 window.set_right_path(SharedString::from(&path_str));
                 window.set_view_mode(0);
                 run_diff(window, state);
-            } else {
+            } else if !has_native_file_dialog() {
                 show_picker(12, "Select right file");
             }
         }
@@ -3380,7 +3387,7 @@ pub fn discard_and_proceed(
                     path.to_string_lossy().to_string(),
                 ));
                 run_folder_compare(window, state);
-            } else {
+            } else if !has_native_file_dialog() {
                 show_picker(13, "Select left folder");
             }
         }
@@ -3391,7 +3398,7 @@ pub fn discard_and_proceed(
                     path.to_string_lossy().to_string(),
                 ));
                 run_folder_compare(window, state);
-            } else {
+            } else if !has_native_file_dialog() {
                 show_picker(14, "Select right folder");
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,17 +40,18 @@ use app::{
     copy_to_left, copy_to_right, delete_line, discard_and_proceed, edit_line, export_all_comments,
     export_csv_report, export_folder_html_report, export_html_report, export_patch,
     export_xlsx_report, first_diff, folder_copy_to_left, folder_copy_to_right, folder_delete_item,
-    force_close_tab, goto_line, insert_line_after, last_diff, navigate_bookmark, navigate_conflict,
-    navigate_diff, navigate_diff_by_status, navigate_search, new_blank_table, new_blank_table_3way,
-    new_blank_text, new_blank_text_3way, open_file_dialog, open_folder_dialog, open_folder_item,
-    open_in_editor, paste_clipboard_path_left, paste_clipboard_path_right, preview_folder_item,
-    print_diff, redo, reorder_tab, replace_all_text, replace_text, rescan, resolve_all_use_left,
-    resolve_all_use_right, resolve_conflict_use_left, resolve_conflict_use_right,
-    resolve_use_left_and_next, resolve_use_right_and_next, run_diff, run_folder_compare,
-    run_plugin, save_file, save_three_way_pane, search_text, select_diff, set_diff_comment,
-    set_diff_filter, set_row_selection, sort_folder, start_compare, start_three_way_compare,
-    switch_tab, three_way_delete_line, three_way_edit_line, three_way_insert_line_after,
-    toggle_bookmark, toggle_ignore_case, toggle_ignore_whitespace, undo,
+    force_close_tab, goto_line, has_native_file_dialog, insert_line_after, last_diff,
+    navigate_bookmark, navigate_conflict, navigate_diff, navigate_diff_by_status, navigate_search,
+    new_blank_table, new_blank_table_3way, new_blank_text, new_blank_text_3way, open_file_dialog,
+    open_folder_dialog, open_folder_item, open_in_editor, paste_clipboard_path_left,
+    paste_clipboard_path_right, preview_folder_item, print_diff, redo, reorder_tab,
+    replace_all_text, replace_text, rescan, resolve_all_use_left, resolve_all_use_right,
+    resolve_conflict_use_left, resolve_conflict_use_right, resolve_use_left_and_next,
+    resolve_use_right_and_next, run_diff, run_folder_compare, run_plugin, save_file,
+    save_three_way_pane, search_text, select_diff, set_diff_comment, set_diff_filter,
+    set_row_selection, sort_folder, start_compare, start_three_way_compare, switch_tab,
+    three_way_delete_line, three_way_edit_line, three_way_insert_line_after, toggle_bookmark,
+    toggle_ignore_case, toggle_ignore_whitespace, undo,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use slint::{Model, ModelRc, SharedString, VecModel};
@@ -501,7 +502,7 @@ fn main() {
                         path.to_string_lossy().to_string(),
                     ));
                     state.borrow_mut().current_tab_mut().left_folder = Some(path);
-                } else {
+                } else if !has_native_file_dialog() {
                     show_file_browser(
                         &window,
                         &browse_ctx,
@@ -523,7 +524,7 @@ fn main() {
                         window.set_view_mode(0);
                     }
                 }
-            } else {
+            } else if !has_native_file_dialog() {
                 show_file_browser(
                     &window,
                     &browse_ctx,
@@ -548,7 +549,7 @@ fn main() {
                         path.to_string_lossy().to_string(),
                     ));
                     state.borrow_mut().current_tab_mut().right_folder = Some(path);
-                } else {
+                } else if !has_native_file_dialog() {
                     show_file_browser(
                         &window,
                         &browse_ctx,
@@ -570,7 +571,7 @@ fn main() {
                         window.set_view_mode(0);
                     }
                 }
-            } else {
+            } else if !has_native_file_dialog() {
                 show_file_browser(
                     &window,
                     &browse_ctx,
@@ -593,7 +594,7 @@ fn main() {
                     path.to_string_lossy().to_string(),
                 ));
                 state.borrow_mut().current_tab_mut().left_folder = Some(path);
-            } else {
+            } else if !has_native_file_dialog() {
                 show_file_browser(
                     &window,
                     &browse_ctx,
@@ -616,7 +617,7 @@ fn main() {
                     path.to_string_lossy().to_string(),
                 ));
                 state.borrow_mut().current_tab_mut().right_folder = Some(path);
-            } else {
+            } else if !has_native_file_dialog() {
                 show_file_browser(
                     &window,
                     &browse_ctx,
@@ -1440,7 +1441,7 @@ fn main() {
                 window.set_open_base_path_input(SharedString::from(
                     path.to_string_lossy().to_string(),
                 ));
-            } else {
+            } else if !has_native_file_dialog() {
                 show_file_browser(
                     &window,
                     &browse_ctx,
@@ -1797,20 +1798,21 @@ fn main() {
                                         let items: Vec<FolderItem> = entries
                                             .iter()
                                             .map(
-                                                |(
-                                                    orig_left,
-                                                    temp_left,
-                                                    _orig_right,
-                                                    temp_right,
-                                                )| {
+                                                |(orig_left, temp_left, orig_right, temp_right)| {
                                                     let left_p = std::path::Path::new(temp_left);
                                                     let right_p = std::path::Path::new(temp_right);
                                                     let status =
                                                         compare_file_contents(left_p, right_p);
-                                                    let name = std::path::Path::new(orig_left)
+                                                    // Use orig_right as fallback when orig_left is /dev/null (new file)
+                                                    let display_path = if orig_left == "/dev/null" {
+                                                        orig_right
+                                                    } else {
+                                                        orig_left
+                                                    };
+                                                    let name = std::path::Path::new(display_path)
                                                         .file_name()
                                                         .map(|n| n.to_string_lossy().to_string())
-                                                        .unwrap_or_else(|| orig_left.clone());
+                                                        .unwrap_or_else(|| display_path.clone());
                                                     let left_meta =
                                                         std::fs::metadata(temp_left).ok();
                                                     let right_meta =

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -717,8 +717,8 @@ export component MainWindow inherits Window {
     }
 
     VerticalLayout {
-        // Tab bar (hidden when blank start screen)
-        if root.view-mode != 7 : TabBar {
+        // Tab bar (hidden only on initial blank screen with single tab)
+        if root.view-mode != 7 || root.tab-list.length > 1 : TabBar {
             tabs: root.tab-list;
             active-index: root.active-tab-index;
             tab-clicked(idx) => { root.switch-tab(idx); }


### PR DESCRIPTION
## Summary
- **macOS dialog fix**: Cancel on native file dialog no longer opens the built-in file browser fallback
- **Tab bar visibility**: + button keeps tab bar visible (was disappearing because new tab has view_mode 7)
- **IPC null filename**: Newly added files in git difftool now show correct name instead of "null" (was using `/dev/null` path)

## Test plan
- [ ] Open Left/Right → Cancel native dialog → nothing happens (no file browser popup)
- [ ] Tab bar + button → new tab opens, tab bar stays visible
- [ ] `git difftool` with new files → filename shown correctly, not "null"

🤖 Generated with [Claude Code](https://claude.com/claude-code)