### PR TITLE
v0.35.0: 3-way CSV table compare, detail pane redesign, IPC 3-file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6586,7 +6586,7 @@ dependencies = [
 
 [[package]]
 name = "winxmerge"
-version = "0.34.3"
+version = "0.35.0"
 dependencies = [
  "arboard",
  "calamine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winxmerge"
-version = "0.34.3"
+version = "0.35.0"
 edition = "2024"
 
 [lib]
@@ -76,7 +76,7 @@ identifier = "io.github.masak1yu.winxmerge"
 icon = ["assets/icons/app-icon-32.png", "assets/icons/app-icon-64.png",
         "assets/icons/app-icon-128.png", "assets/icons/app-icon-256.png",
         "assets/icons/app-icon-512.png", "assets/icons/app-icon.icns"]
-version = "0.34.3"
+version = "0.35.0"
 copyright = "WinXMerge contributors"
 category = "Developer Tool"
 short_description = "Cross-platform file diff and merge tool"

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,7 @@ use std::time::SystemTime;
 use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 
 use crate::archive::{compare_zip_archives, is_zip_bytes, is_zip_path};
-use crate::csv::{compare_csv_full, is_csv_path};
+use crate::csv::{compare_csv_full, compare_csv_full_3way, is_csv_path};
 use crate::diff::engine::{DiffOptions, compute_diff_with_options};
 use crate::diff::folder::{FolderCompareOptions, compare_folders_with_options};
 use crate::diff::three_way::{ThreeWayResult, ThreeWayStatus, compute_three_way_diff};
@@ -21,7 +21,8 @@ use crate::models::folder_item::FileCompareStatus;
 use crate::settings::AppSettings;
 use crate::{
     DetailLineData, DiffLineData, ExcelCellData, FolderItemData, MainWindow, PluginEntryData,
-    TabData, TableCellData, TableColumnInfo, TableRowData, ThreeWayLineData, WordSegment,
+    TabData, TableCellData, TableColumnInfo, TableDetailCellData, TableRowData, ThreeWayLineData,
+    WordSegment,
 };
 
 /// Line count threshold above which diff is computed on a background thread
@@ -419,12 +420,22 @@ fn restore_tab(window: &MainWindow, state: &AppState) {
         window.set_image_right_height(tab.image_right_h);
     }
 
-    if tab.view_mode == 4 || tab.view_mode == 6 {
+    if tab.view_mode == 4 || tab.view_mode == 6 || tab.view_mode == 8 {
         window.set_table_rows(ModelRc::new(VecModel::from(tab.table_rows.clone())));
         window.set_table_columns(ModelRc::new(VecModel::from(tab.table_columns.clone())));
         window.set_table_content_width_px(tab.table_content_width_px);
         window.set_diff_count(tab.diff_positions.len() as i32);
         window.set_current_diff_index(tab.current_diff);
+        // Restore highlight row
+        let highlight_row = if tab.current_diff >= 0 {
+            tab.diff_positions
+                .get(tab.current_diff as usize)
+                .map(|&p| p as i32)
+                .unwrap_or(-1)
+        } else {
+            -1
+        };
+        window.set_table_current_highlight_row(highlight_row);
 
         if tab.view_mode == 4 {
             let sheet_model: ModelRc<SharedString> = ModelRc::new(VecModel::from(
@@ -1096,9 +1107,12 @@ fn update_current_diff(window: &MainWindow, state: &mut AppState, new_index: i32
     // Update current diff index (Slint side handles highlighting reactively)
     window.set_current_diff_index(new_index);
 
-    if view_mode == 4 || view_mode == 6 {
-        // Table view: scroll table grid to row
+    if view_mode == 4 || view_mode == 6 || view_mode == 8 {
+        // Table view: scroll table grid to row and highlight
         window.invoke_scroll_table_to_row(current_pos as i32);
+        window.set_table_current_highlight_row(current_pos as i32);
+        // Update table detail pane
+        update_table_detail_pane(window, state, current_pos);
         window.set_status_text(SharedString::from(format!(
             "Difference {} of {}",
             new_index + 1,
@@ -1637,6 +1651,80 @@ pub fn copy_all_diffs_to_left(window: &MainWindow, state: &mut AppState) {
     sync_tab_list(window, state);
 }
 
+// --- Table detail pane ---
+
+/// Update the table detail pane with cell-by-cell comparison for the given row.
+fn update_table_detail_pane(window: &MainWindow, state: &AppState, row_idx: usize) {
+    let tab = state.current_tab();
+    if row_idx >= tab.table_rows.len() {
+        window.set_table_detail_cells(ModelRc::new(VecModel::from(
+            Vec::<TableDetailCellData>::new(),
+        )));
+        return;
+    }
+
+    let row = &tab.table_rows[row_idx];
+    let left_model = &row.left_cells;
+    let right_model = &row.right_cells;
+    let base_model = &row.base_cells;
+    let cell_count = left_model
+        .row_count()
+        .max(right_model.row_count())
+        .max(base_model.row_count());
+    let columns = &tab.table_columns;
+
+    let mut detail_cells = Vec::with_capacity(cell_count);
+    for i in 0..cell_count {
+        let col_name = columns
+            .get(i)
+            .map(|c| c.name.to_string())
+            .unwrap_or_else(|| crate::csv::col_to_name(i));
+        let left_cell = left_model.row_data(i);
+        let right_cell = right_model.row_data(i);
+        let base_cell = base_model.row_data(i);
+        let left_value = left_cell
+            .as_ref()
+            .map(|c| c.text.to_string())
+            .unwrap_or_default();
+        let right_value = right_cell
+            .as_ref()
+            .map(|c| c.text.to_string())
+            .unwrap_or_default();
+        let base_value = base_cell
+            .as_ref()
+            .map(|c| c.text.to_string())
+            .unwrap_or_default();
+        let left_status = left_cell.as_ref().map(|c| c.status).unwrap_or(0);
+        let right_status = right_cell.as_ref().map(|c| c.status).unwrap_or(0);
+        let base_status = base_cell.as_ref().map(|c| c.status).unwrap_or(0);
+        // Combined status for column header indicator
+        let status = if left_status != 0 {
+            left_status
+        } else if right_status != 0 {
+            right_status
+        } else {
+            base_status
+        };
+        let col_x_px = columns.get(i).map(|c| c.x_px).unwrap_or(0);
+        let col_width_px = columns.get(i).map(|c| c.width_px).unwrap_or(100);
+
+        detail_cells.push(TableDetailCellData {
+            col_name: SharedString::from(col_name),
+            left_value: SharedString::from(left_value),
+            base_value: SharedString::from(base_value),
+            right_value: SharedString::from(right_value),
+            status,
+            left_status,
+            right_status,
+            base_status,
+            col_x_px,
+            col_width_px,
+        });
+    }
+
+    window.set_table_detail_cells(ModelRc::new(VecModel::from(detail_cells)));
+}
+
 // --- Table copy functions (row-level copy for view-mode 4/6) ---
 
 /// Helper: rebuild diff_positions from table_rows and update window state.
@@ -1702,10 +1790,12 @@ pub fn table_copy_to_right(window: &MainWindow, state: &mut AppState, diff_index
         }
     }
 
+    let base_cells_clone = tab.table_rows[row_idx].base_cells.clone();
     tab.table_rows[row_idx] = TableRowData {
         row_number: tab.table_rows[row_idx].row_number,
         left_cells: ModelRc::new(VecModel::from(new_left_cells)),
         right_cells: ModelRc::new(VecModel::from(new_right_cells)),
+        base_cells: base_cells_clone,
         row_status: 0,
     };
 
@@ -1752,10 +1842,12 @@ pub fn table_copy_to_left(window: &MainWindow, state: &mut AppState, diff_index:
         }
     }
 
+    let base_cells_clone = tab.table_rows[row_idx].base_cells.clone();
     tab.table_rows[row_idx] = TableRowData {
         row_number: tab.table_rows[row_idx].row_number,
         left_cells: ModelRc::new(VecModel::from(new_left_cells)),
         right_cells: ModelRc::new(VecModel::from(new_right_cells)),
+        base_cells: base_cells_clone,
         row_status: 0,
     };
 
@@ -1779,6 +1871,180 @@ pub fn table_copy_left_and_next(window: &MainWindow, state: &mut AppState) {
     let diff_index = state.current_tab().current_diff;
     table_copy_to_left(window, state, diff_index);
     navigate_diff(window, state, true);
+}
+
+/// 3-way table: copy left cells to base cells for a single diff row (use-left).
+pub fn table_use_left(window: &MainWindow, state: &mut AppState, diff_index: i32) {
+    table_resolve_to_base(window, state, diff_index, true);
+}
+
+/// 3-way table: copy right cells to base cells for a single diff row (use-right).
+pub fn table_use_right(window: &MainWindow, state: &mut AppState, diff_index: i32) {
+    table_resolve_to_base(window, state, diff_index, false);
+}
+
+pub fn table_use_left_and_next(window: &MainWindow, state: &mut AppState) {
+    let diff_index = state.current_tab().current_diff;
+    table_use_left(window, state, diff_index);
+    navigate_diff(window, state, true);
+}
+
+pub fn table_use_right_and_next(window: &MainWindow, state: &mut AppState) {
+    let diff_index = state.current_tab().current_diff;
+    table_use_right(window, state, diff_index);
+    navigate_diff(window, state, true);
+}
+
+pub fn table_use_all_left(window: &MainWindow, state: &mut AppState) {
+    let positions: Vec<usize> = state.current_tab().diff_positions.clone();
+    for (i, _) in positions.iter().enumerate() {
+        table_resolve_to_base_inner(state, i);
+    }
+    apply_table_rows_to_window(window, state);
+    rebuild_table_diff_positions(window, state);
+}
+
+pub fn table_use_all_right(window: &MainWindow, state: &mut AppState) {
+    let positions: Vec<usize> = state.current_tab().diff_positions.clone();
+    for (i, _) in positions.iter().enumerate() {
+        table_resolve_to_base_inner_right(state, i);
+    }
+    apply_table_rows_to_window(window, state);
+    rebuild_table_diff_positions(window, state);
+}
+
+/// Internal: copy source (left or right) cells to base cells for a single diff row.
+fn table_resolve_to_base(
+    window: &MainWindow,
+    state: &mut AppState,
+    diff_index: i32,
+    use_left: bool,
+) {
+    {
+        let tab = state.current_tab();
+        if diff_index < 0 || diff_index as usize >= tab.diff_positions.len() {
+            return;
+        }
+    }
+    if use_left {
+        table_resolve_to_base_inner(state, diff_index as usize);
+    } else {
+        table_resolve_to_base_inner_right(state, diff_index as usize);
+    }
+
+    apply_table_rows_to_window(window, state);
+    rebuild_table_diff_positions(window, state);
+
+    let tab = state.current_tab();
+    if !tab.diff_positions.is_empty() {
+        let new_idx = (diff_index as usize).min(tab.diff_positions.len() - 1);
+        update_current_diff(window, state, new_idx as i32);
+    }
+    window.set_status_text(SharedString::from(if use_left {
+        "Left → Base copied"
+    } else {
+        "Right → Base copied"
+    }));
+}
+
+fn table_resolve_to_base_inner(state: &mut AppState, diff_index: usize) {
+    let tab = state.current_tab();
+    if diff_index >= tab.diff_positions.len() {
+        return;
+    }
+    let row_idx = tab.diff_positions[diff_index];
+    let row = &tab.table_rows[row_idx];
+    let src_model = &row.left_cells;
+    let cell_count = src_model.row_count();
+    let mut new_base = Vec::with_capacity(cell_count);
+    let mut new_left = Vec::with_capacity(cell_count);
+    let mut new_right = Vec::with_capacity(cell_count);
+    let right_model = &row.right_cells;
+    for i in 0..cell_count {
+        if let Some(lc) = src_model.row_data(i) {
+            new_base.push(TableCellData {
+                text: lc.text.clone(),
+                status: 0,
+                col_x_px: lc.col_x_px,
+                col_width_px: lc.col_width_px,
+            });
+            new_left.push(TableCellData {
+                text: lc.text.clone(),
+                status: 0,
+                col_x_px: lc.col_x_px,
+                col_width_px: lc.col_width_px,
+            });
+            // Right keeps its value; re-evaluate status vs new base (=left)
+            let rc = right_model.row_data(i);
+            let rv = rc.as_ref().map(|c| c.text.clone()).unwrap_or_default();
+            let st = if rv == lc.text { 0 } else { 1 };
+            new_right.push(TableCellData {
+                text: rv,
+                status: st,
+                col_x_px: lc.col_x_px,
+                col_width_px: lc.col_width_px,
+            });
+        }
+    }
+    let has_diff = new_right.iter().any(|c| c.status != 0);
+    let tab = state.current_tab_mut();
+    tab.table_rows[row_idx] = TableRowData {
+        row_number: tab.table_rows[row_idx].row_number,
+        left_cells: ModelRc::new(VecModel::from(new_left)),
+        right_cells: ModelRc::new(VecModel::from(new_right)),
+        base_cells: ModelRc::new(VecModel::from(new_base)),
+        row_status: if has_diff { 1 } else { 0 },
+    };
+}
+
+fn table_resolve_to_base_inner_right(state: &mut AppState, diff_index: usize) {
+    let tab = state.current_tab();
+    if diff_index >= tab.diff_positions.len() {
+        return;
+    }
+    let row_idx = tab.diff_positions[diff_index];
+    let row = &tab.table_rows[row_idx];
+    let src_model = &row.right_cells;
+    let cell_count = src_model.row_count();
+    let mut new_base = Vec::with_capacity(cell_count);
+    let mut new_right = Vec::with_capacity(cell_count);
+    let mut new_left = Vec::with_capacity(cell_count);
+    let left_model = &row.left_cells;
+    for i in 0..cell_count {
+        if let Some(rc) = src_model.row_data(i) {
+            new_base.push(TableCellData {
+                text: rc.text.clone(),
+                status: 0,
+                col_x_px: rc.col_x_px,
+                col_width_px: rc.col_width_px,
+            });
+            new_right.push(TableCellData {
+                text: rc.text.clone(),
+                status: 0,
+                col_x_px: rc.col_x_px,
+                col_width_px: rc.col_width_px,
+            });
+            // Left keeps its value; re-evaluate status vs new base (=right)
+            let lc = left_model.row_data(i);
+            let lv = lc.as_ref().map(|c| c.text.clone()).unwrap_or_default();
+            let st = if lv == rc.text { 0 } else { 1 };
+            new_left.push(TableCellData {
+                text: lv,
+                status: st,
+                col_x_px: rc.col_x_px,
+                col_width_px: rc.col_width_px,
+            });
+        }
+    }
+    let has_diff = new_left.iter().any(|c| c.status != 0);
+    let tab = state.current_tab_mut();
+    tab.table_rows[row_idx] = TableRowData {
+        row_number: tab.table_rows[row_idx].row_number,
+        left_cells: ModelRc::new(VecModel::from(new_left)),
+        right_cells: ModelRc::new(VecModel::from(new_right)),
+        base_cells: ModelRc::new(VecModel::from(new_base)),
+        row_status: if has_diff { 1 } else { 0 },
+    };
 }
 
 /// Copy all left cells to right for all diff rows (table view).
@@ -1812,10 +2078,12 @@ pub fn table_copy_all_right(window: &MainWindow, state: &mut AppState) {
                 });
             }
         }
+        let base_cells_clone = tab.table_rows[row_idx].base_cells.clone();
         tab.table_rows[row_idx] = TableRowData {
             row_number: tab.table_rows[row_idx].row_number,
             left_cells: ModelRc::new(VecModel::from(new_left_cells)),
             right_cells: ModelRc::new(VecModel::from(new_right_cells)),
+            base_cells: base_cells_clone,
             row_status: 0,
         };
     }
@@ -1855,10 +2123,12 @@ pub fn table_copy_all_left(window: &MainWindow, state: &mut AppState) {
                 });
             }
         }
+        let base_cells_clone = tab.table_rows[row_idx].base_cells.clone();
         tab.table_rows[row_idx] = TableRowData {
             row_number: tab.table_rows[row_idx].row_number,
             left_cells: ModelRc::new(VecModel::from(new_left_cells)),
             right_cells: ModelRc::new(VecModel::from(new_right_cells)),
+            base_cells: base_cells_clone,
             row_status: 0,
         };
     }
@@ -3959,6 +4229,21 @@ pub fn run_three_way_diff(window: &MainWindow, state: &mut AppState) {
     let left_bytes = fs::read(&left_path).unwrap_or_default();
     let right_bytes = fs::read(&right_path).unwrap_or_default();
 
+    // Route CSV files to 3-way table comparison
+    if is_csv_path(&left_path) && is_csv_path(&right_path) && is_csv_path(&base_path) {
+        run_csv_compare_3way(
+            window,
+            state,
+            &base_bytes,
+            &left_bytes,
+            &right_bytes,
+            &base_path,
+            &left_path,
+            &right_path,
+        );
+        return;
+    }
+
     let (base_text, base_enc) = decode_file(&base_bytes);
     let (left_text, left_enc) = decode_file(&left_bytes);
     let (right_text, right_enc) = decode_file(&right_bytes);
@@ -4705,6 +4990,28 @@ pub fn rescan(window: &MainWindow, state: &mut AppState) {
             &right_path,
         );
         window.set_status_text(SharedString::from("Files rescanned"));
+    } else if tab.view_mode == 8
+        && tab.base_path.is_some()
+        && tab.left_path.is_some()
+        && tab.right_path.is_some()
+    {
+        let base_path = tab.base_path.clone().unwrap();
+        let left_path = tab.left_path.clone().unwrap();
+        let right_path = tab.right_path.clone().unwrap();
+        let base_bytes = fs::read(&base_path).unwrap_or_default();
+        let left_bytes = fs::read(&left_path).unwrap_or_default();
+        let right_bytes = fs::read(&right_path).unwrap_or_default();
+        run_csv_compare_3way(
+            window,
+            state,
+            &base_bytes,
+            &left_bytes,
+            &right_bytes,
+            &base_path,
+            &left_path,
+            &right_path,
+        );
+        window.set_status_text(SharedString::from("Files rescanned"));
     }
 }
 
@@ -4979,6 +5286,7 @@ fn build_table_rows(
             row_number: (r + 1) as i32,
             left_cells: ModelRc::new(VecModel::from(left_cells)),
             right_cells: ModelRc::new(VecModel::from(right_cells)),
+            base_cells: ModelRc::new(VecModel::from(Vec::<TableCellData>::new())),
             row_status,
         });
     }
@@ -4999,6 +5307,131 @@ fn build_columns(max_cols: usize, col_width: i32) -> (Vec<TableColumnInfo>, i32)
         x += col_width;
     }
     (columns, x) // x is total content width
+}
+
+/// Build table rows for 3-way comparison.
+/// Maps csv.rs 3-way cell_status (0-7) to per-pane TableCellData statuses.
+fn build_table_rows_3way(
+    base_grid: &[Vec<String>],
+    left_grid: &[Vec<String>],
+    right_grid: &[Vec<String>],
+    cell_status: &[Vec<i32>],
+    max_rows: usize,
+    max_cols: usize,
+    columns: &[TableColumnInfo],
+) -> Vec<TableRowData> {
+    let mut rows = Vec::with_capacity(max_rows);
+
+    for r in 0..max_rows {
+        let base_row = base_grid.get(r);
+        let left_row = left_grid.get(r);
+        let right_row = right_grid.get(r);
+        let status_row = cell_status.get(r);
+
+        let mut base_cells = Vec::with_capacity(max_cols);
+        let mut left_cells = Vec::with_capacity(max_cols);
+        let mut right_cells = Vec::with_capacity(max_cols);
+        let mut has_diff = false;
+        let mut has_conflict = false;
+        let mut all_base_only = true;
+        let mut all_left_only = true;
+        let mut all_right_only = true;
+
+        for c in 0..max_cols {
+            let bv = base_row
+                .and_then(|row| row.get(c))
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let lv = left_row
+                .and_then(|row| row.get(c))
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let rv = right_row
+                .and_then(|row| row.get(c))
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let three_way_status = status_row.and_then(|sr| sr.get(c)).copied().unwrap_or(0);
+
+            // Map 3-way cell status to per-pane display statuses
+            // base_st: 0=normal, 2=removed(base-only)
+            // left_st: 0=normal, 1=modified, 3=added(left-only), 5=conflict
+            // right_st: 0=normal, 1=modified, 3=added(right-only), 5=conflict
+            let (base_st, left_st, right_st) = match three_way_status {
+                0 => (0, 0, 0), // identical
+                1 => (0, 1, 0), // left-changed
+                2 => (0, 0, 1), // right-changed
+                3 => (0, 1, 1), // both-changed-same
+                4 => (0, 5, 5), // conflict
+                5 => (2, 4, 4), // base-only (deleted in both)
+                6 => (4, 3, 4), // left-only
+                7 => (4, 4, 3), // right-only
+                _ => (0, 0, 0),
+            };
+
+            if three_way_status != 0 {
+                has_diff = true;
+            }
+            if three_way_status == 4 {
+                has_conflict = true;
+            }
+            if three_way_status != 5 {
+                all_base_only = false;
+            }
+            if three_way_status != 6 {
+                all_left_only = false;
+            }
+            if three_way_status != 7 {
+                all_right_only = false;
+            }
+
+            let col_x_px = columns.get(c).map(|col| col.x_px).unwrap_or(0);
+            let col_width_px = columns.get(c).map(|col| col.width_px).unwrap_or(100);
+
+            base_cells.push(TableCellData {
+                text: SharedString::from(bv),
+                status: base_st,
+                col_x_px,
+                col_width_px,
+            });
+            left_cells.push(TableCellData {
+                text: SharedString::from(lv),
+                status: left_st,
+                col_x_px,
+                col_width_px,
+            });
+            right_cells.push(TableCellData {
+                text: SharedString::from(rv),
+                status: right_st,
+                col_x_px,
+                col_width_px,
+            });
+        }
+
+        // Row-level status for location pane
+        let row_status = if !has_diff {
+            0
+        } else if has_conflict {
+            4 // conflict
+        } else if all_base_only {
+            5 // base-only
+        } else if all_left_only {
+            6 // left-only
+        } else if all_right_only {
+            7 // right-only
+        } else {
+            1 // has changes
+        };
+
+        rows.push(TableRowData {
+            row_number: (r + 1) as i32,
+            left_cells: ModelRc::new(VecModel::from(left_cells)),
+            right_cells: ModelRc::new(VecModel::from(right_cells)),
+            base_cells: ModelRc::new(VecModel::from(base_cells)),
+            row_status,
+        });
+    }
+
+    rows
 }
 
 fn run_excel_compare(
@@ -5248,6 +5681,86 @@ fn run_csv_compare(
     sync_tab_list(window, state);
 }
 
+fn run_csv_compare_3way(
+    window: &MainWindow,
+    state: &mut AppState,
+    base_bytes: &[u8],
+    left_bytes: &[u8],
+    right_bytes: &[u8],
+    base_path: &std::path::Path,
+    left_path: &std::path::Path,
+    right_path: &std::path::Path,
+) {
+    use crate::encoding::decode_file;
+
+    let (base_text, _) = decode_file(base_bytes);
+    let (left_text, _) = decode_file(left_bytes);
+    let (right_text, _) = decode_file(right_bytes);
+
+    let result = compare_csv_full_3way(&base_text, &left_text, &right_text);
+
+    let (columns, content_width_px) = build_columns(result.max_cols, 100);
+    let table_rows = build_table_rows_3way(
+        &result.base_grid,
+        &result.left_grid,
+        &result.right_grid,
+        &result.cell_status,
+        result.max_rows,
+        result.max_cols,
+        &columns,
+    );
+
+    let left_name = left_path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let right_name = right_path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let diff_count = result.diff_count;
+    let conflict_count = result.conflict_count;
+
+    let tab = state.current_tab_mut();
+    tab.view_mode = 8;
+    tab.title = format!("{} ↔ {} (3-way)", left_name, right_name);
+    tab.table_rows = table_rows.clone();
+    tab.table_columns = columns.clone();
+    tab.table_content_width_px = content_width_px;
+    tab.excel_cells = Vec::new();
+    tab.excel_sheet_names = Vec::new();
+    tab.excel_sheet_data.clear();
+
+    window.set_table_rows(ModelRc::new(VecModel::from(table_rows)));
+    window.set_table_columns(ModelRc::new(VecModel::from(columns)));
+    window.set_table_content_width_px(content_width_px);
+
+    // Build diff positions from row statuses
+    let diff_positions: Vec<usize> = tab
+        .table_rows
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.row_status != 0)
+        .map(|(i, _)| i)
+        .collect();
+    let diff_pos_count = diff_positions.len();
+    tab.diff_positions = diff_positions;
+    tab.current_diff = if diff_pos_count > 0 { 0 } else { -1 };
+    window.set_diff_count(diff_pos_count as i32);
+    window.set_current_diff_index(tab.current_diff);
+
+    window.set_view_mode(8);
+    window.set_left_path(SharedString::from(left_path.to_string_lossy().to_string()));
+    window.set_right_path(SharedString::from(right_path.to_string_lossy().to_string()));
+    window.set_base_path(SharedString::from(base_path.to_string_lossy().to_string()));
+    window.set_status_text(SharedString::from(format!(
+        "[CSV 3-way] {} ↔ {} — {} diffs, {} conflicts",
+        left_name, right_name, diff_count, conflict_count
+    )));
+    sync_tab_list(window, state);
+}
+
 fn rgba_to_slint_image(rgba: &[u8], width: u32, height: u32) -> slint::Image {
     let mut pixel_buffer = slint::SharedPixelBuffer::<slint::Rgba8Pixel>::new(width, height);
     pixel_buffer.make_mut_bytes().copy_from_slice(rgba);
@@ -5492,6 +6005,15 @@ pub fn paste_clipboard_path_right(window: &MainWindow) {
         if let Ok(text) = cb.get_text() {
             let path = text.trim().trim_start_matches("file://");
             window.set_open_right_path_input(SharedString::from(path));
+        }
+    }
+}
+
+pub fn paste_clipboard_path_base(window: &MainWindow) {
+    if let Ok(mut cb) = arboard::Clipboard::new() {
+        if let Ok(text) = cb.get_text() {
+            let path = text.trim().trim_start_matches("file://");
+            window.set_open_base_path_input(SharedString::from(path));
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,12 +7,12 @@ use std::time::SystemTime;
 use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 
 use crate::archive::{compare_zip_archives, is_zip_bytes, is_zip_path};
-use crate::csv::{compare_csv, is_csv_path};
+use crate::csv::{compare_csv_full, is_csv_path};
 use crate::diff::engine::{DiffOptions, compute_diff_with_options};
 use crate::diff::folder::{FolderCompareOptions, compare_folders_with_options};
 use crate::diff::three_way::{ThreeWayResult, ThreeWayStatus, compute_three_way_diff};
 use crate::encoding::{decode_file, detect_eol, encode_text, is_binary};
-use crate::excel::{compare_excel, is_excel_path};
+use crate::excel::{compare_excel_full, is_excel_path};
 use crate::highlight::{detect_file_type, highlight_lines};
 use crate::image_compare::{compare_images, is_image_path};
 use crate::models::diff_line::DiffResult;
@@ -21,7 +21,7 @@ use crate::models::folder_item::FileCompareStatus;
 use crate::settings::AppSettings;
 use crate::{
     DetailLineData, DiffLineData, ExcelCellData, FolderItemData, MainWindow, PluginEntryData,
-    TabData, ThreeWayLineData, WordSegment,
+    TabData, TableCellData, TableColumnInfo, TableRowData, ThreeWayLineData, WordSegment,
 };
 
 /// Line count threshold above which diff is computed on a background thread
@@ -47,6 +47,13 @@ pub struct PendingDiffResult {
 struct TextSnapshot {
     left_text: String,
     right_text: String,
+}
+
+/// Cached table data for a single Excel sheet (for fast sheet switching)
+pub struct SheetTableCache {
+    pub rows: Vec<TableRowData>,
+    pub columns: Vec<TableColumnInfo>,
+    pub content_width_px: i32,
 }
 
 /// Per-tab state
@@ -121,6 +128,14 @@ pub struct TabState {
     pub folder_sort_ascending: bool,
     /// True when folder view was built from IPC-received file pairs (not real directory scan)
     pub is_virtual_folder: bool,
+    /// Table grid rows for side-by-side table view (view_mode 4 and 6)
+    pub table_rows: Vec<TableRowData>,
+    /// Column info for table grid view
+    pub table_columns: Vec<TableColumnInfo>,
+    /// Total content width in pixels for table grid view
+    pub table_content_width_px: i32,
+    /// Cached per-sheet table data for Excel sheet switching
+    pub excel_sheet_data: std::collections::BTreeMap<String, SheetTableCache>,
 }
 
 impl TabState {
@@ -180,6 +195,10 @@ impl TabState {
             folder_sort_column: -1,
             folder_sort_ascending: true,
             is_virtual_folder: false,
+            table_rows: Vec::new(),
+            table_columns: Vec::new(),
+            table_content_width_px: 0,
+            excel_sheet_data: std::collections::BTreeMap::new(),
         }
     }
 }
@@ -400,26 +419,25 @@ fn restore_tab(window: &MainWindow, state: &AppState) {
         window.set_image_right_height(tab.image_right_h);
     }
 
-    if tab.view_mode == 4 {
-        let sheet_model: ModelRc<SharedString> = ModelRc::new(VecModel::from(
-            std::iter::once(SharedString::from(""))
-                .chain(
-                    tab.excel_sheet_names
-                        .iter()
-                        .map(|s| SharedString::from(s.as_str())),
-                )
-                .collect::<Vec<_>>(),
-        ));
-        window.set_excel_cells(ModelRc::new(VecModel::from(tab.excel_cells.clone())));
-        window.set_excel_sheet_names(sheet_model);
-    }
+    if tab.view_mode == 4 || tab.view_mode == 6 {
+        window.set_table_rows(ModelRc::new(VecModel::from(tab.table_rows.clone())));
+        window.set_table_columns(ModelRc::new(VecModel::from(tab.table_columns.clone())));
+        window.set_table_content_width_px(tab.table_content_width_px);
+        window.set_diff_count(tab.diff_positions.len() as i32);
+        window.set_current_diff_index(tab.current_diff);
 
-    if tab.view_mode == 6 {
-        let sheet_model: ModelRc<SharedString> =
-            ModelRc::new(VecModel::from(vec![SharedString::from("")]));
-        window.set_excel_cells(ModelRc::new(VecModel::from(tab.excel_cells.clone())));
-        window.set_excel_sheet_names(sheet_model);
-        window.set_excel_active_sheet(SharedString::from(""));
+        if tab.view_mode == 4 {
+            let sheet_model: ModelRc<SharedString> = ModelRc::new(VecModel::from(
+                std::iter::once(SharedString::from(""))
+                    .chain(
+                        tab.excel_sheet_names
+                            .iter()
+                            .map(|s| SharedString::from(s.as_str())),
+                    )
+                    .collect::<Vec<_>>(),
+            ));
+            window.set_excel_sheet_names(sheet_model);
+        }
     }
 
     if tab.view_mode == 7 {
@@ -1073,6 +1091,23 @@ fn update_current_diff(window: &MainWindow, state: &mut AppState, new_index: i32
     tab.current_diff = new_index;
     let current_pos = tab.diff_positions[new_index as usize];
     let total = tab.diff_positions.len();
+    let view_mode = tab.view_mode;
+
+    // Update current diff index (Slint side handles highlighting reactively)
+    window.set_current_diff_index(new_index);
+
+    if view_mode == 4 || view_mode == 6 {
+        // Table view: scroll table grid to row
+        window.invoke_scroll_table_to_row(current_pos as i32);
+        window.set_status_text(SharedString::from(format!(
+            "Difference {} of {}",
+            new_index + 1,
+            total
+        )));
+        return;
+    }
+
+    let tab = state.current_tab();
     let stats = tab.diff_stats.clone();
     let comment = tab
         .diff_comments
@@ -1080,8 +1115,6 @@ fn update_current_diff(window: &MainWindow, state: &mut AppState, new_index: i32
         .cloned()
         .unwrap_or_default();
 
-    // Update current diff index (Slint side handles highlighting reactively)
-    window.set_current_diff_index(new_index);
     // Scroll to the diff position
     window.invoke_scroll_diff_to_row(current_pos as i32);
 
@@ -1602,6 +1635,236 @@ pub fn copy_all_diffs_to_left(window: &MainWindow, state: &mut AppState) {
     window.set_can_undo(true);
     window.set_can_redo(false);
     sync_tab_list(window, state);
+}
+
+// --- Table copy functions (row-level copy for view-mode 4/6) ---
+
+/// Helper: rebuild diff_positions from table_rows and update window state.
+fn rebuild_table_diff_positions(window: &MainWindow, state: &mut AppState) {
+    let tab = state.current_tab_mut();
+    let diff_positions: Vec<usize> = tab
+        .table_rows
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.row_status != 0)
+        .map(|(i, _)| i)
+        .collect();
+    let diff_pos_count = diff_positions.len();
+    tab.diff_positions = diff_positions;
+    if tab.current_diff >= diff_pos_count as i32 {
+        tab.current_diff = if diff_pos_count > 0 {
+            diff_pos_count as i32 - 1
+        } else {
+            -1
+        };
+    }
+    window.set_diff_count(diff_pos_count as i32);
+    window.set_current_diff_index(tab.current_diff);
+}
+
+/// Helper: apply table_rows to the window VecModel.
+fn apply_table_rows_to_window(window: &MainWindow, state: &AppState) {
+    let tab = state.current_tab();
+    window.set_table_rows(ModelRc::new(VecModel::from(tab.table_rows.clone())));
+}
+
+/// Copy left cells to right for a single diff row (table view).
+pub fn table_copy_to_right(window: &MainWindow, state: &mut AppState, diff_index: i32) {
+    {
+        let tab = state.current_tab();
+        if diff_index < 0 || diff_index as usize >= tab.diff_positions.len() {
+            return;
+        }
+    }
+    let row_idx = state.current_tab().diff_positions[diff_index as usize];
+    let tab = state.current_tab_mut();
+    let row = &tab.table_rows[row_idx];
+
+    // Read left cells
+    let left_model = &row.left_cells;
+    let cell_count = left_model.row_count();
+    let mut new_right_cells = Vec::with_capacity(cell_count);
+    let mut new_left_cells = Vec::with_capacity(cell_count);
+    for i in 0..cell_count {
+        if let Some(lc) = left_model.row_data(i) {
+            new_right_cells.push(TableCellData {
+                text: lc.text.clone(),
+                status: 0,
+                col_x_px: lc.col_x_px,
+                col_width_px: lc.col_width_px,
+            });
+            new_left_cells.push(TableCellData {
+                text: lc.text.clone(),
+                status: 0,
+                col_x_px: lc.col_x_px,
+                col_width_px: lc.col_width_px,
+            });
+        }
+    }
+
+    tab.table_rows[row_idx] = TableRowData {
+        row_number: tab.table_rows[row_idx].row_number,
+        left_cells: ModelRc::new(VecModel::from(new_left_cells)),
+        right_cells: ModelRc::new(VecModel::from(new_right_cells)),
+        row_status: 0,
+    };
+
+    apply_table_rows_to_window(window, state);
+    rebuild_table_diff_positions(window, state);
+
+    let tab = state.current_tab();
+    if !tab.diff_positions.is_empty() {
+        let new_idx = (diff_index as usize).min(tab.diff_positions.len() - 1);
+        update_current_diff(window, state, new_idx as i32);
+    }
+}
+
+/// Copy right cells to left for a single diff row (table view).
+pub fn table_copy_to_left(window: &MainWindow, state: &mut AppState, diff_index: i32) {
+    {
+        let tab = state.current_tab();
+        if diff_index < 0 || diff_index as usize >= tab.diff_positions.len() {
+            return;
+        }
+    }
+    let row_idx = state.current_tab().diff_positions[diff_index as usize];
+    let tab = state.current_tab_mut();
+    let row = &tab.table_rows[row_idx];
+
+    let right_model = &row.right_cells;
+    let cell_count = right_model.row_count();
+    let mut new_left_cells = Vec::with_capacity(cell_count);
+    let mut new_right_cells = Vec::with_capacity(cell_count);
+    for i in 0..cell_count {
+        if let Some(rc) = right_model.row_data(i) {
+            new_left_cells.push(TableCellData {
+                text: rc.text.clone(),
+                status: 0,
+                col_x_px: rc.col_x_px,
+                col_width_px: rc.col_width_px,
+            });
+            new_right_cells.push(TableCellData {
+                text: rc.text.clone(),
+                status: 0,
+                col_x_px: rc.col_x_px,
+                col_width_px: rc.col_width_px,
+            });
+        }
+    }
+
+    tab.table_rows[row_idx] = TableRowData {
+        row_number: tab.table_rows[row_idx].row_number,
+        left_cells: ModelRc::new(VecModel::from(new_left_cells)),
+        right_cells: ModelRc::new(VecModel::from(new_right_cells)),
+        row_status: 0,
+    };
+
+    apply_table_rows_to_window(window, state);
+    rebuild_table_diff_positions(window, state);
+
+    let tab = state.current_tab();
+    if !tab.diff_positions.is_empty() {
+        let new_idx = (diff_index as usize).min(tab.diff_positions.len() - 1);
+        update_current_diff(window, state, new_idx as i32);
+    }
+}
+
+pub fn table_copy_right_and_next(window: &MainWindow, state: &mut AppState) {
+    let diff_index = state.current_tab().current_diff;
+    table_copy_to_right(window, state, diff_index);
+    navigate_diff(window, state, true);
+}
+
+pub fn table_copy_left_and_next(window: &MainWindow, state: &mut AppState) {
+    let diff_index = state.current_tab().current_diff;
+    table_copy_to_left(window, state, diff_index);
+    navigate_diff(window, state, true);
+}
+
+/// Copy all left cells to right for all diff rows (table view).
+pub fn table_copy_all_right(window: &MainWindow, state: &mut AppState) {
+    let tab = state.current_tab();
+    if tab.diff_positions.is_empty() {
+        return;
+    }
+    let positions: Vec<usize> = tab.diff_positions.clone();
+
+    let tab = state.current_tab_mut();
+    for &row_idx in &positions {
+        let row = &tab.table_rows[row_idx];
+        let left_model = &row.left_cells;
+        let cell_count = left_model.row_count();
+        let mut new_right_cells = Vec::with_capacity(cell_count);
+        let mut new_left_cells = Vec::with_capacity(cell_count);
+        for i in 0..cell_count {
+            if let Some(lc) = left_model.row_data(i) {
+                new_right_cells.push(TableCellData {
+                    text: lc.text.clone(),
+                    status: 0,
+                    col_x_px: lc.col_x_px,
+                    col_width_px: lc.col_width_px,
+                });
+                new_left_cells.push(TableCellData {
+                    text: lc.text.clone(),
+                    status: 0,
+                    col_x_px: lc.col_x_px,
+                    col_width_px: lc.col_width_px,
+                });
+            }
+        }
+        tab.table_rows[row_idx] = TableRowData {
+            row_number: tab.table_rows[row_idx].row_number,
+            left_cells: ModelRc::new(VecModel::from(new_left_cells)),
+            right_cells: ModelRc::new(VecModel::from(new_right_cells)),
+            row_status: 0,
+        };
+    }
+
+    apply_table_rows_to_window(window, state);
+    rebuild_table_diff_positions(window, state);
+}
+
+/// Copy all right cells to left for all diff rows (table view).
+pub fn table_copy_all_left(window: &MainWindow, state: &mut AppState) {
+    let tab = state.current_tab();
+    if tab.diff_positions.is_empty() {
+        return;
+    }
+    let positions: Vec<usize> = tab.diff_positions.clone();
+
+    let tab = state.current_tab_mut();
+    for &row_idx in &positions {
+        let row = &tab.table_rows[row_idx];
+        let right_model = &row.right_cells;
+        let cell_count = right_model.row_count();
+        let mut new_left_cells = Vec::with_capacity(cell_count);
+        let mut new_right_cells = Vec::with_capacity(cell_count);
+        for i in 0..cell_count {
+            if let Some(rc) = right_model.row_data(i) {
+                new_left_cells.push(TableCellData {
+                    text: rc.text.clone(),
+                    status: 0,
+                    col_x_px: rc.col_x_px,
+                    col_width_px: rc.col_width_px,
+                });
+                new_right_cells.push(TableCellData {
+                    text: rc.text.clone(),
+                    status: 0,
+                    col_x_px: rc.col_x_px,
+                    col_width_px: rc.col_width_px,
+                });
+            }
+        }
+        tab.table_rows[row_idx] = TableRowData {
+            row_number: tab.table_rows[row_idx].row_number,
+            left_cells: ModelRc::new(VecModel::from(new_left_cells)),
+            right_cells: ModelRc::new(VecModel::from(new_right_cells)),
+            row_status: 0,
+        };
+    }
+
+    apply_table_rows_to_window(window, state);
+    rebuild_table_diff_positions(window, state);
 }
 
 pub fn copy_all_text(window: &MainWindow, state: &AppState, is_left: bool) {
@@ -3286,6 +3549,10 @@ pub fn new_blank_table(
         tab.right_path = None;
         tab.title = "Untitled".to_string();
         tab.excel_cells = Vec::new();
+        tab.table_rows = Vec::new();
+        tab.table_columns = Vec::new();
+        tab.table_content_width_px = 0;
+        tab.excel_sheet_data.clear();
         tab.diff_positions.clear();
         tab.diff_stats = String::new();
         tab.has_unsaved_changes = false;
@@ -3294,11 +3561,9 @@ pub fn new_blank_table(
     }
 
     window.set_view_mode(6);
-    window.set_excel_cells(ModelRc::new(VecModel::from(Vec::<ExcelCellData>::new())));
-    let sheet_model: ModelRc<SharedString> =
-        ModelRc::new(VecModel::from(vec![SharedString::from("")]));
-    window.set_excel_sheet_names(sheet_model);
-    window.set_excel_active_sheet(SharedString::from(""));
+    window.set_table_rows(ModelRc::new(VecModel::from(Vec::<TableRowData>::new())));
+    window.set_table_columns(ModelRc::new(VecModel::from(Vec::<TableColumnInfo>::new())));
+    window.set_table_content_width_px(0);
     window.set_diff_count(0);
     window.set_left_path(SharedString::from(""));
     window.set_right_path(SharedString::from(""));
@@ -4412,6 +4677,34 @@ pub fn rescan(window: &MainWindow, state: &mut AppState) {
     } else if tab.view_mode == 1 {
         run_folder_compare(window, state);
         window.set_status_text(SharedString::from("Folders rescanned"));
+    } else if tab.view_mode == 6 && tab.left_path.is_some() && tab.right_path.is_some() {
+        let left_path = tab.left_path.clone().unwrap();
+        let right_path = tab.right_path.clone().unwrap();
+        let left_bytes = fs::read(&left_path).unwrap_or_default();
+        let right_bytes = fs::read(&right_path).unwrap_or_default();
+        run_csv_compare(
+            window,
+            state,
+            &left_bytes,
+            &right_bytes,
+            &left_path,
+            &right_path,
+        );
+        window.set_status_text(SharedString::from("Files rescanned"));
+    } else if tab.view_mode == 4 && tab.left_path.is_some() && tab.right_path.is_some() {
+        let left_path = tab.left_path.clone().unwrap();
+        let right_path = tab.right_path.clone().unwrap();
+        let left_bytes = fs::read(&left_path).unwrap_or_default();
+        let right_bytes = fs::read(&right_path).unwrap_or_default();
+        run_excel_compare(
+            window,
+            state,
+            &left_bytes,
+            &right_bytes,
+            &left_path,
+            &right_path,
+        );
+        window.set_status_text(SharedString::from("Files rescanned"));
     }
 }
 
@@ -4612,6 +4905,102 @@ fn run_zip_compare(
     sync_tab_list(window, state);
 }
 
+/// Build TableRowData from full grids and cell_status matrix for the side-by-side table view.
+fn build_table_rows(
+    left_grid: &[Vec<String>],
+    right_grid: &[Vec<String>],
+    cell_status: &[Vec<i32>],
+    max_rows: usize,
+    max_cols: usize,
+    columns: &[TableColumnInfo],
+) -> Vec<TableRowData> {
+    let mut rows = Vec::with_capacity(max_rows);
+
+    for r in 0..max_rows {
+        let left_row = left_grid.get(r);
+        let right_row = right_grid.get(r);
+        let status_row = cell_status.get(r);
+
+        let mut left_cells = Vec::with_capacity(max_cols);
+        let mut right_cells = Vec::with_capacity(max_cols);
+        let mut has_diff = false;
+        let mut row_left_only = true;
+        let mut row_right_only = true;
+
+        for c in 0..max_cols {
+            let lv = left_row
+                .and_then(|row| row.get(c))
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let rv = right_row
+                .and_then(|row| row.get(c))
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let status = status_row.and_then(|sr| sr.get(c)).copied().unwrap_or(0);
+
+            if status != 0 {
+                has_diff = true;
+            }
+            if status != 2 {
+                row_left_only = false;
+            }
+            if status != 3 {
+                row_right_only = false;
+            }
+
+            let col_x_px = columns.get(c).map(|col| col.x_px).unwrap_or(0);
+            let col_width_px = columns.get(c).map(|col| col.width_px).unwrap_or(100);
+
+            left_cells.push(TableCellData {
+                text: SharedString::from(lv),
+                status: if status == 3 { 3 } else { status },
+                col_x_px,
+                col_width_px,
+            });
+            right_cells.push(TableCellData {
+                text: SharedString::from(rv),
+                status: if status == 2 { 2 } else { status },
+                col_x_px,
+                col_width_px,
+            });
+        }
+
+        let row_status = if !has_diff {
+            0
+        } else if row_left_only {
+            2
+        } else if row_right_only {
+            3
+        } else {
+            1
+        };
+
+        rows.push(TableRowData {
+            row_number: (r + 1) as i32,
+            left_cells: ModelRc::new(VecModel::from(left_cells)),
+            right_cells: ModelRc::new(VecModel::from(right_cells)),
+            row_status,
+        });
+    }
+
+    rows
+}
+
+/// Build column info (name, width, x-offset) for the given column count.
+fn build_columns(max_cols: usize, col_width: i32) -> (Vec<TableColumnInfo>, i32) {
+    let mut columns = Vec::with_capacity(max_cols);
+    let mut x = 0i32;
+    for c in 0..max_cols {
+        columns.push(TableColumnInfo {
+            name: SharedString::from(crate::csv::col_to_name(c)),
+            width_px: col_width,
+            x_px: x,
+        });
+        x += col_width;
+    }
+    (columns, x) // x is total content width
+}
+
 fn run_excel_compare(
     window: &MainWindow,
     state: &mut AppState,
@@ -4620,26 +5009,7 @@ fn run_excel_compare(
     left_path: &std::path::Path,
     right_path: &std::path::Path,
 ) {
-    let diffs = compare_excel(left_bytes, right_bytes);
-
-    // Collect unique sheet names (preserve order via BTreeSet for determinism)
-    let mut sheet_set: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-    for d in &diffs {
-        sheet_set.insert(d.sheet.clone());
-    }
-    let sheet_names: Vec<String> = sheet_set.into_iter().collect();
-
-    let cell_data: Vec<ExcelCellData> = diffs
-        .iter()
-        .map(|d| ExcelCellData {
-            sheet_name: SharedString::from(&d.sheet),
-            row: d.row as i32,
-            col_name: SharedString::from(&d.col_name),
-            left_value: SharedString::from(&d.left_value),
-            right_value: SharedString::from(&d.right_value),
-            status: d.status,
-        })
-        .collect();
+    let result = compare_excel_full(left_bytes, right_bytes);
 
     let left_name = left_path
         .file_name()
@@ -4650,32 +5020,158 @@ fn run_excel_compare(
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_default();
 
-    let diff_count = diffs.len();
+    // Build SheetTableCache for each sheet
+    let mut sheet_cache: std::collections::BTreeMap<String, SheetTableCache> =
+        std::collections::BTreeMap::new();
+    for (sheet_name, data) in &result.sheets {
+        let (columns, content_width_px) = build_columns(data.max_cols, 100);
+        let rows = build_table_rows(
+            &data.left_grid,
+            &data.right_grid,
+            &data.cell_status,
+            data.max_rows,
+            data.max_cols,
+            &columns,
+        );
+        sheet_cache.insert(
+            sheet_name.clone(),
+            SheetTableCache {
+                rows,
+                columns,
+                content_width_px,
+            },
+        );
+    }
+
+    // Build combined "All sheets" view: concatenate all sheets
+    let mut all_rows = Vec::new();
+    let mut all_max_cols: usize = 0;
+    for data in result.sheets.values() {
+        all_max_cols = all_max_cols.max(data.max_cols);
+    }
+    let (all_columns, all_content_width_px) = build_columns(all_max_cols, 100);
+    for data in result.sheets.values() {
+        let rows = build_table_rows(
+            &data.left_grid,
+            &data.right_grid,
+            &data.cell_status,
+            data.max_rows,
+            all_max_cols,
+            &all_columns,
+        );
+        all_rows.extend(rows);
+    }
+
+    let sheet_names = result.sheet_names.clone();
+    let total_diff = result.total_diff_count;
 
     let tab = state.current_tab_mut();
-    tab.excel_cells = cell_data.clone();
-    tab.excel_sheet_names = sheet_names.clone();
     tab.view_mode = 4;
     tab.title = format!("{} ↔ {}", left_name, right_name);
+    tab.table_rows = all_rows.clone();
+    tab.table_columns = all_columns.clone();
+    tab.table_content_width_px = all_content_width_px;
+    tab.excel_sheet_names = sheet_names.clone();
+    tab.excel_sheet_data = sheet_cache;
+    tab.excel_cells = Vec::new();
 
-    // Prepend empty string so user can select "All sheets"
+    // Build diff positions from row statuses
+    let diff_positions: Vec<usize> = tab
+        .table_rows
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.row_status != 0)
+        .map(|(i, _)| i)
+        .collect();
+    let diff_pos_count = diff_positions.len();
+    tab.diff_positions = diff_positions;
+    tab.current_diff = if diff_pos_count > 0 { 0 } else { -1 };
+
+    // Set window properties
+    window.set_table_rows(ModelRc::new(VecModel::from(all_rows)));
+    window.set_table_columns(ModelRc::new(VecModel::from(all_columns)));
+    window.set_table_content_width_px(all_content_width_px);
+    window.set_diff_count(diff_pos_count as i32);
+    window.set_current_diff_index(tab.current_diff);
+
+    // Sheet selector: prepend empty string for "All sheets"
     let sheet_model: ModelRc<SharedString> = ModelRc::new(VecModel::from(
         std::iter::once(SharedString::from(""))
             .chain(sheet_names.iter().map(|s| SharedString::from(s.as_str())))
             .collect::<Vec<_>>(),
     ));
-
-    window.set_excel_cells(ModelRc::new(VecModel::from(cell_data)));
     window.set_excel_sheet_names(sheet_model);
     window.set_excel_active_sheet(SharedString::from(""));
+
     window.set_view_mode(4);
     window.set_left_path(SharedString::from(left_path.to_string_lossy().to_string()));
     window.set_right_path(SharedString::from(right_path.to_string_lossy().to_string()));
     window.set_status_text(SharedString::from(format!(
         "[Excel] {} ↔ {} — {} cells changed",
-        left_name, right_name, diff_count
+        left_name, right_name, total_diff
     )));
     sync_tab_list(window, state);
+}
+
+/// Switch the displayed Excel sheet in table grid view.
+/// Empty sheet_name means "All sheets".
+pub fn switch_excel_sheet(window: &MainWindow, state: &mut AppState, sheet_name: &str) {
+    let tab = state.current_tab_mut();
+    if tab.view_mode != 4 {
+        return;
+    }
+
+    if sheet_name.is_empty() {
+        // "All sheets" — concatenate all cached sheets
+        let mut all_rows = Vec::new();
+        let mut max_content_width: i32 = 0;
+        for cache in tab.excel_sheet_data.values() {
+            max_content_width = max_content_width.max(cache.content_width_px);
+        }
+        // Compute max columns count from caches to build unified columns
+        let mut max_cols: usize = 0;
+        for cache in tab.excel_sheet_data.values() {
+            max_cols = max_cols.max(cache.columns.len());
+        }
+        for cache in tab.excel_sheet_data.values() {
+            all_rows.extend(cache.rows.clone());
+        }
+        let (columns, content_width_px) = build_columns(max_cols, 100);
+        tab.table_rows = all_rows.clone();
+        tab.table_columns = columns.clone();
+        tab.table_content_width_px = content_width_px;
+
+        window.set_table_rows(ModelRc::new(VecModel::from(all_rows)));
+        window.set_table_columns(ModelRc::new(VecModel::from(columns)));
+        window.set_table_content_width_px(content_width_px);
+    } else if let Some(cache) = tab.excel_sheet_data.get(sheet_name) {
+        let rows = cache.rows.clone();
+        let columns = cache.columns.clone();
+        let content_width_px = cache.content_width_px;
+
+        tab.table_rows = rows.clone();
+        tab.table_columns = columns.clone();
+        tab.table_content_width_px = content_width_px;
+
+        window.set_table_rows(ModelRc::new(VecModel::from(rows)));
+        window.set_table_columns(ModelRc::new(VecModel::from(columns)));
+        window.set_table_content_width_px(content_width_px);
+    }
+
+    // Rebuild diff positions for the new sheet
+    let tab = state.current_tab_mut();
+    let diff_positions: Vec<usize> = tab
+        .table_rows
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.row_status != 0)
+        .map(|(i, _)| i)
+        .collect();
+    let diff_pos_count = diff_positions.len();
+    tab.diff_positions = diff_positions;
+    tab.current_diff = if diff_pos_count > 0 { 0 } else { -1 };
+    window.set_diff_count(diff_pos_count as i32);
+    window.set_current_diff_index(tab.current_diff);
 }
 
 fn run_csv_compare(
@@ -4691,19 +5187,17 @@ fn run_csv_compare(
     let (left_text, _) = decode_file(left_bytes);
     let (right_text, _) = decode_file(right_bytes);
 
-    let diffs = compare_csv(&left_text, &right_text);
+    let result = compare_csv_full(&left_text, &right_text);
 
-    let cell_data: Vec<ExcelCellData> = diffs
-        .iter()
-        .map(|d| ExcelCellData {
-            sheet_name: SharedString::from(""),
-            row: d.row as i32,
-            col_name: SharedString::from(&d.col_name),
-            left_value: SharedString::from(&d.left_value),
-            right_value: SharedString::from(&d.right_value),
-            status: d.status,
-        })
-        .collect();
+    let (columns, content_width_px) = build_columns(result.max_cols, 100);
+    let table_rows = build_table_rows(
+        &result.left_grid,
+        &result.right_grid,
+        &result.cell_status,
+        result.max_rows,
+        result.max_cols,
+        &columns,
+    );
 
     let left_name = left_path
         .file_name()
@@ -4714,20 +5208,36 @@ fn run_csv_compare(
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_default();
 
-    let diff_count = diffs.len();
+    let diff_count = result.diff_count;
 
     let tab = state.current_tab_mut();
-    tab.excel_cells = cell_data.clone();
-    tab.excel_sheet_names = Vec::new();
     tab.view_mode = 6;
     tab.title = format!("{} ↔ {}", left_name, right_name);
+    tab.table_rows = table_rows.clone();
+    tab.table_columns = columns.clone();
+    tab.table_content_width_px = content_width_px;
+    tab.excel_cells = Vec::new();
+    tab.excel_sheet_names = Vec::new();
+    tab.excel_sheet_data.clear();
 
-    let sheet_model: ModelRc<SharedString> =
-        ModelRc::new(VecModel::from(vec![SharedString::from("")]));
+    window.set_table_rows(ModelRc::new(VecModel::from(table_rows)));
+    window.set_table_columns(ModelRc::new(VecModel::from(columns)));
+    window.set_table_content_width_px(content_width_px);
 
-    window.set_excel_cells(ModelRc::new(VecModel::from(cell_data)));
-    window.set_excel_sheet_names(sheet_model);
-    window.set_excel_active_sheet(SharedString::from(""));
+    // Build diff positions from row statuses
+    let diff_positions: Vec<usize> = tab
+        .table_rows
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.row_status != 0)
+        .map(|(i, _)| i)
+        .collect();
+    let diff_pos_count = diff_positions.len();
+    tab.diff_positions = diff_positions;
+    tab.current_diff = if diff_pos_count > 0 { 0 } else { -1 };
+    window.set_diff_count(diff_pos_count as i32);
+    window.set_current_diff_index(tab.current_diff);
+
     window.set_view_mode(6);
     window.set_left_path(SharedString::from(left_path.to_string_lossy().to_string()));
     window.set_right_path(SharedString::from(right_path.to_string_lossy().to_string()));

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -160,6 +160,131 @@ pub fn compare_csv_full(left_text: &str, right_text: &str) -> CsvTableResult {
     }
 }
 
+/// 3-way full comparison result including all three grids and per-cell status.
+#[derive(Debug, Clone)]
+pub struct CsvTableResult3Way {
+    pub base_grid: Vec<Vec<String>>,
+    pub left_grid: Vec<Vec<String>>,
+    pub right_grid: Vec<Vec<String>>,
+    pub max_rows: usize,
+    pub max_cols: usize,
+    /// cell_status[row][col]:
+    /// 0=identical (all three same)
+    /// 1=left-changed (left differs from base, right same as base)
+    /// 2=right-changed (right differs from base, left same as base)
+    /// 3=both-changed-same (both differ from base, but same as each other)
+    /// 4=conflict (both differ from base, and different from each other)
+    /// 5=base-only (row only in base)
+    /// 6=left-only (row only in left)
+    /// 7=right-only (row only in right)
+    pub cell_status: Vec<Vec<i32>>,
+    pub diff_count: usize,
+    pub conflict_count: usize,
+}
+
+/// Compare three CSV/TSV texts and return full grids with per-cell 3-way status.
+pub fn compare_csv_full_3way(
+    base_text: &str,
+    left_text: &str,
+    right_text: &str,
+) -> CsvTableResult3Way {
+    let delim = detect_delimiter(base_text);
+    let base_grid = parse_csv(base_text, delim);
+    let left_grid = parse_csv(left_text, delim);
+    let right_grid = parse_csv(right_text, delim);
+
+    let max_rows = base_grid.len().max(left_grid.len()).max(right_grid.len());
+    let max_cols = base_grid
+        .iter()
+        .chain(left_grid.iter())
+        .chain(right_grid.iter())
+        .map(|r| r.len())
+        .max()
+        .unwrap_or(0);
+
+    let mut cell_status = Vec::with_capacity(max_rows);
+    let mut diff_count = 0;
+    let mut conflict_count = 0;
+
+    for r in 0..max_rows {
+        let base_row = base_grid.get(r);
+        let left_row = left_grid.get(r);
+        let right_row = right_grid.get(r);
+        let mut row_status = Vec::with_capacity(max_cols);
+
+        let has_base = base_row.is_some();
+        let has_left = left_row.is_some();
+        let has_right = right_row.is_some();
+
+        for c in 0..max_cols {
+            let bv = base_row
+                .and_then(|row| row.get(c))
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let lv = left_row
+                .and_then(|row| row.get(c))
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let rv = right_row
+                .and_then(|row| row.get(c))
+                .map(|s| s.as_str())
+                .unwrap_or("");
+
+            let status = if !has_base && has_left && !has_right {
+                6 // left-only row
+            } else if !has_base && !has_left && has_right {
+                7 // right-only row
+            } else if has_base && !has_left && !has_right {
+                5 // base-only row (deleted in both)
+            } else if !has_base && has_left && has_right {
+                // Row added in both sides
+                if lv == rv {
+                    3 // both-changed-same
+                } else {
+                    4 // conflict
+                }
+            } else {
+                // Normal 3-way compare
+                let left_changed = lv != bv;
+                let right_changed = rv != bv;
+                match (left_changed, right_changed) {
+                    (false, false) => 0, // identical
+                    (true, false) => 1,  // left-changed
+                    (false, true) => 2,  // right-changed
+                    (true, true) => {
+                        if lv == rv {
+                            3 // both-changed-same
+                        } else {
+                            4 // conflict
+                        }
+                    }
+                }
+            };
+
+            if status != 0 {
+                diff_count += 1;
+            }
+            if status == 4 {
+                conflict_count += 1;
+            }
+            row_status.push(status);
+        }
+
+        cell_status.push(row_status);
+    }
+
+    CsvTableResult3Way {
+        base_grid,
+        left_grid,
+        right_grid,
+        max_rows,
+        max_cols,
+        cell_status,
+        diff_count,
+        conflict_count,
+    }
+}
+
 /// Compare two CSV/TSV texts and return cell-level differences.
 #[allow(dead_code)]
 pub fn compare_csv(left_text: &str, right_text: &str) -> Vec<CsvCellDiff> {

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -1,6 +1,7 @@
 /// CSV / TSV table comparison
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct CsvCellDiff {
     pub row: usize, // 1-based
     #[allow(dead_code)]
@@ -28,7 +29,7 @@ fn detect_delimiter(text: &str) -> u8 {
     if tabs > commas { b'\t' } else { b',' }
 }
 
-fn col_to_name(mut col: usize) -> String {
+pub fn col_to_name(mut col: usize) -> String {
     let mut name = String::new();
     loop {
         name.insert(0, (b'A' + (col % 26) as u8) as char);
@@ -42,7 +43,7 @@ fn col_to_name(mut col: usize) -> String {
 
 /// Parse CSV/TSV text into a 2-D table of cell strings.
 /// Handles quoted fields with embedded delimiters and newlines.
-fn parse_csv(text: &str, delimiter: u8) -> Vec<Vec<String>> {
+pub fn parse_csv(text: &str, delimiter: u8) -> Vec<Vec<String>> {
     let mut rows: Vec<Vec<String>> = Vec::new();
     let mut row: Vec<String> = Vec::new();
     let mut field = String::new();
@@ -89,7 +90,78 @@ fn parse_csv(text: &str, delimiter: u8) -> Vec<Vec<String>> {
     rows
 }
 
+/// Full comparison result including both grids and per-cell status.
+#[derive(Debug, Clone)]
+pub struct CsvTableResult {
+    pub left_grid: Vec<Vec<String>>,
+    pub right_grid: Vec<Vec<String>>,
+    pub max_rows: usize,
+    pub max_cols: usize,
+    /// cell_status[row][col] = 0(identical)/1(different)/2(left-only)/3(right-only)
+    pub cell_status: Vec<Vec<i32>>,
+    pub diff_count: usize,
+}
+
+/// Compare two CSV/TSV texts and return full grids with per-cell status.
+pub fn compare_csv_full(left_text: &str, right_text: &str) -> CsvTableResult {
+    let delim = detect_delimiter(left_text);
+    let left_grid = parse_csv(left_text, delim);
+    let right_grid = parse_csv(right_text, delim);
+
+    let max_rows = left_grid.len().max(right_grid.len());
+    let max_cols = left_grid
+        .iter()
+        .chain(right_grid.iter())
+        .map(|r| r.len())
+        .max()
+        .unwrap_or(0);
+
+    let mut cell_status = Vec::with_capacity(max_rows);
+    let mut diff_count = 0;
+
+    for r in 0..max_rows {
+        let left_row = left_grid.get(r);
+        let right_row = right_grid.get(r);
+        let mut row_status = Vec::with_capacity(max_cols);
+
+        for c in 0..max_cols {
+            let lv = left_row
+                .and_then(|row| row.get(c))
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let rv = right_row
+                .and_then(|row| row.get(c))
+                .map(|s| s.as_str())
+                .unwrap_or("");
+
+            let status = match (left_row.is_some(), right_row.is_some()) {
+                (true, false) => 2,
+                (false, true) => 3,
+                _ if lv == rv => 0,
+                _ => 1,
+            };
+
+            if status != 0 {
+                diff_count += 1;
+            }
+            row_status.push(status);
+        }
+
+        cell_status.push(row_status);
+    }
+
+    CsvTableResult {
+        left_grid,
+        right_grid,
+        max_rows,
+        max_cols,
+        cell_status,
+        diff_count,
+    }
+}
+
 /// Compare two CSV/TSV texts and return cell-level differences.
+#[allow(dead_code)]
 pub fn compare_csv(left_text: &str, right_text: &str) -> Vec<CsvCellDiff> {
     let delim = detect_delimiter(left_text);
     let left_rows = parse_csv(left_text, delim);

--- a/src/excel.rs
+++ b/src/excel.rs
@@ -2,6 +2,7 @@ use calamine::{Reader, open_workbook_auto_from_rs};
 use std::io::Cursor;
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct ExcelCellDiff {
     pub sheet: String,
     pub row: usize, // 1-based
@@ -23,6 +24,7 @@ pub fn is_excel_path(path: &std::path::Path) -> bool {
 }
 
 /// Convert column index (0-based) to Excel column name (A, B, ... Z, AA, AB, ...)
+#[allow(dead_code)]
 pub fn col_to_name(mut col: usize) -> String {
     let mut name = String::new();
     loop {
@@ -35,7 +37,7 @@ pub fn col_to_name(mut col: usize) -> String {
     name
 }
 
-fn read_workbook(data: &[u8]) -> std::collections::BTreeMap<String, Vec<Vec<String>>> {
+pub fn read_workbook(data: &[u8]) -> std::collections::BTreeMap<String, Vec<Vec<String>>> {
     let cursor = Cursor::new(data.to_vec());
     let mut wb = match open_workbook_auto_from_rs(cursor) {
         Ok(w) => w,
@@ -56,7 +58,119 @@ fn read_workbook(data: &[u8]) -> std::collections::BTreeMap<String, Vec<Vec<Stri
     result
 }
 
+/// Per-sheet full grid comparison data.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct SheetTableData {
+    pub left_grid: Vec<Vec<String>>,
+    pub right_grid: Vec<Vec<String>>,
+    pub max_rows: usize,
+    pub max_cols: usize,
+    /// cell_status[row][col] = 0(identical)/1(different)/2(left-only)/3(right-only)
+    pub cell_status: Vec<Vec<i32>>,
+    pub diff_count: usize,
+}
+
+/// Full Excel comparison result with per-sheet grids and status.
+#[derive(Debug, Clone)]
+pub struct ExcelTableResult {
+    pub sheet_names: Vec<String>,
+    pub sheets: std::collections::BTreeMap<String, SheetTableData>,
+    pub total_diff_count: usize,
+}
+
+/// Compare two Excel files and return full grids with per-cell status for each sheet.
+pub fn compare_excel_full(left_data: &[u8], right_data: &[u8]) -> ExcelTableResult {
+    let left_wb = read_workbook(left_data);
+    let right_wb = read_workbook(right_data);
+
+    let mut all_sheets: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for k in left_wb.keys() {
+        all_sheets.insert(k.clone());
+    }
+    for k in right_wb.keys() {
+        all_sheets.insert(k.clone());
+    }
+
+    let sheet_names: Vec<String> = all_sheets.iter().cloned().collect();
+    let mut sheets = std::collections::BTreeMap::new();
+    let mut total_diff_count = 0;
+
+    for sheet in &all_sheets {
+        let left_rows = left_wb.get(sheet).cloned().unwrap_or_default();
+        let right_rows = right_wb.get(sheet).cloned().unwrap_or_default();
+
+        let max_rows = left_rows.len().max(right_rows.len());
+        let max_cols = left_rows
+            .iter()
+            .chain(right_rows.iter())
+            .map(|r| r.len())
+            .max()
+            .unwrap_or(0);
+
+        let mut cell_status = Vec::with_capacity(max_rows);
+        let mut diff_count = 0;
+
+        let left_exists = left_wb.contains_key(sheet);
+        let right_exists = right_wb.contains_key(sheet);
+
+        for row_idx in 0..max_rows {
+            let left_row = left_rows.get(row_idx);
+            let right_row = right_rows.get(row_idx);
+            let mut row_status = Vec::with_capacity(max_cols);
+
+            for col_idx in 0..max_cols {
+                let lv = left_row
+                    .and_then(|r| r.get(col_idx))
+                    .map(|s| s.as_str())
+                    .unwrap_or("");
+                let rv = right_row
+                    .and_then(|r| r.get(col_idx))
+                    .map(|s| s.as_str())
+                    .unwrap_or("");
+
+                let status = if left_exists && !right_exists {
+                    2
+                } else if !left_exists && right_exists {
+                    3
+                } else if lv == rv {
+                    0
+                } else {
+                    1
+                };
+
+                if status != 0 {
+                    diff_count += 1;
+                }
+                row_status.push(status);
+            }
+
+            cell_status.push(row_status);
+        }
+
+        total_diff_count += diff_count;
+        sheets.insert(
+            sheet.clone(),
+            SheetTableData {
+                left_grid: left_rows,
+                right_grid: right_rows,
+                max_rows,
+                max_cols,
+                cell_status,
+                diff_count,
+            },
+        );
+    }
+
+    ExcelTableResult {
+        sheet_names,
+        sheets,
+        total_diff_count,
+    }
+}
+
 /// Compare two Excel files and return a list of cell differences.
+#[allow(dead_code)]
 pub fn compare_excel(left_data: &[u8], right_data: &[u8]) -> Vec<ExcelCellDiff> {
     let left_wb = read_workbook(left_data);
     let right_wb = read_workbook(right_data);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1894,6 +1894,66 @@ fn main() {
         });
     }
 
+    // Table sheet switching (Excel grid view)
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_table_sheet_changed(move |sheet_name| {
+            let window = window_weak.unwrap();
+            crate::app::switch_excel_sheet(&window, &mut state.borrow_mut(), &sheet_name);
+        });
+    }
+
+    // Table copy callbacks (view-mode 4/6)
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_table_copy_to_right(move |diff_index| {
+            let window = window_weak.unwrap();
+            crate::app::table_copy_to_right(&window, &mut state.borrow_mut(), diff_index);
+        });
+    }
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_table_copy_to_left(move |diff_index| {
+            let window = window_weak.unwrap();
+            crate::app::table_copy_to_left(&window, &mut state.borrow_mut(), diff_index);
+        });
+    }
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_table_copy_right_and_next(move || {
+            let window = window_weak.unwrap();
+            crate::app::table_copy_right_and_next(&window, &mut state.borrow_mut());
+        });
+    }
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_table_copy_left_and_next(move || {
+            let window = window_weak.unwrap();
+            crate::app::table_copy_left_and_next(&window, &mut state.borrow_mut());
+        });
+    }
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_table_copy_all_right(move || {
+            let window = window_weak.unwrap();
+            crate::app::table_copy_all_right(&window, &mut state.borrow_mut());
+        });
+    }
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_table_copy_all_left(move || {
+            let window = window_weak.unwrap();
+            crate::app::table_copy_all_left(&window, &mut state.borrow_mut());
+        });
+    }
+
     // Diff status filter
     {
         let window_weak = window.as_weak();

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,15 +43,15 @@ use app::{
     force_close_tab, goto_line, has_native_file_dialog, insert_line_after, last_diff,
     navigate_bookmark, navigate_conflict, navigate_diff, navigate_diff_by_status, navigate_search,
     new_blank_table, new_blank_table_3way, new_blank_text, new_blank_text_3way, open_file_dialog,
-    open_folder_dialog, open_folder_item, open_in_editor, paste_clipboard_path_left,
-    paste_clipboard_path_right, preview_folder_item, print_diff, redo, reorder_tab,
-    replace_all_text, replace_text, rescan, resolve_all_use_left, resolve_all_use_right,
-    resolve_conflict_use_left, resolve_conflict_use_right, resolve_use_left_and_next,
-    resolve_use_right_and_next, run_diff, run_folder_compare, run_plugin, save_file,
-    save_three_way_pane, search_text, select_diff, set_diff_comment, set_diff_filter,
-    set_row_selection, sort_folder, start_compare, start_three_way_compare, switch_tab,
-    three_way_delete_line, three_way_edit_line, three_way_insert_line_after, toggle_bookmark,
-    toggle_ignore_case, toggle_ignore_whitespace, undo,
+    open_folder_dialog, open_folder_item, open_in_editor, paste_clipboard_path_base,
+    paste_clipboard_path_left, paste_clipboard_path_right, preview_folder_item, print_diff, redo,
+    reorder_tab, replace_all_text, replace_text, rescan, resolve_all_use_left,
+    resolve_all_use_right, resolve_conflict_use_left, resolve_conflict_use_right,
+    resolve_use_left_and_next, resolve_use_right_and_next, run_diff, run_folder_compare,
+    run_plugin, save_file, save_three_way_pane, search_text, select_diff, set_diff_comment,
+    set_diff_filter, set_row_selection, sort_folder, start_compare, start_three_way_compare,
+    switch_tab, three_way_delete_line, three_way_edit_line, three_way_insert_line_after,
+    toggle_bookmark, toggle_ignore_case, toggle_ignore_whitespace, undo,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use slint::{Model, ModelRc, SharedString, VecModel};
@@ -1741,17 +1741,29 @@ fn main() {
                     {
                         // Phase 1: Drain incoming IPC messages into buffer
                         while let Ok(pairs) = ipc_rx.try_recv() {
-                            let mut buf = ipc_buffer_clone.borrow_mut();
-                            // pairs is Vec<(orig, temp)>, expected in left/right order
-                            if pairs.len() >= 2 {
+                            if pairs.len() == 3 {
+                                // 3-way merge: handle immediately (base, left, right)
+                                let mut s = state.borrow_mut();
+                                add_tab(&window, &mut s);
+                                start_three_way_compare(
+                                    &window,
+                                    &mut s,
+                                    &pairs[0].1, // temp_base
+                                    &pairs[1].1, // temp_left
+                                    &pairs[2].1, // temp_right
+                                );
+                                app::sync_tab_list(&window, &s);
+                            } else if pairs.len() >= 2 {
+                                let mut buf = ipc_buffer_clone.borrow_mut();
+                                // pairs is Vec<(orig, temp)>, expected in left/right order
                                 buf.push((
                                     pairs[0].0.clone(),
                                     pairs[0].1.clone(),
                                     pairs[1].0.clone(),
                                     pairs[1].1.clone(),
                                 ));
+                                ipc_last_clone.set(Some(std::time::Instant::now()));
                             }
-                            ipc_last_clone.set(Some(std::time::Instant::now()));
                         }
 
                         // Phase 2: Flush if 500ms elapsed since last receive
@@ -1953,6 +1965,55 @@ fn main() {
             crate::app::table_copy_all_left(&window, &mut state.borrow_mut());
         });
     }
+    // 3-way table resolve callbacks
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_table_use_left(move |diff_index| {
+            let window = window_weak.unwrap();
+            crate::app::table_use_left(&window, &mut state.borrow_mut(), diff_index);
+        });
+    }
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_table_use_right(move |diff_index| {
+            let window = window_weak.unwrap();
+            crate::app::table_use_right(&window, &mut state.borrow_mut(), diff_index);
+        });
+    }
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_table_use_left_and_next(move || {
+            let window = window_weak.unwrap();
+            crate::app::table_use_left_and_next(&window, &mut state.borrow_mut());
+        });
+    }
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_table_use_right_and_next(move || {
+            let window = window_weak.unwrap();
+            crate::app::table_use_right_and_next(&window, &mut state.borrow_mut());
+        });
+    }
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_table_use_all_left(move || {
+            let window = window_weak.unwrap();
+            crate::app::table_use_all_left(&window, &mut state.borrow_mut());
+        });
+    }
+    {
+        let window_weak = window.as_weak();
+        let state = state.clone();
+        window.on_table_use_all_right(move || {
+            let window = window_weak.unwrap();
+            crate::app::table_use_all_right(&window, &mut state.borrow_mut());
+        });
+    }
 
     // Diff status filter
     {
@@ -1976,6 +2037,13 @@ fn main() {
         let window_weak = window.as_weak();
         window.on_paste_right_path(move || {
             paste_clipboard_path_right(&window_weak.unwrap());
+        });
+    }
+
+    {
+        let window_weak = window.as_weak();
+        window.on_paste_base_path(move || {
+            paste_clipboard_path_base(&window_weak.unwrap());
         });
     }
 

--- a/testdata/base.csv
+++ b/testdata/base.csv
@@ -1,0 +1,8 @@
+Name,Age,City,Score,Department,Email,Phone,StartDate,Salary,Rating,Project,Level,Status,Notes
+Alice,30,Tokyo,95,Engineering,alice@example.com,090-1111-2222,2020-04-01,800000,A,Alpha,Senior,Active,Team lead
+Bob,25,Osaka,85,Marketing,bob@example.com,090-3333-4444,2021-06-15,580000,B,Beta,Junior,Active,New hire
+Charlie,35,Nagoya,92,Engineering,charlie@example.com,090-5555-6666,2018-01-10,900000,A,Alpha,Lead,Active,Architect
+Diana,28,Kyoto,87,Design,diana@example.com,090-7777-8888,2022-03-20,650000,B,Gamma,Mid,Active,UI specialist
+Frank,40,Sapporo,78,Sales,frank@example.com,090-9999-0000,2015-08-01,750000,C,Delta,Senior,Active,Regional manager
+Grace,33,Kobe,91,Engineering,grace@example.com,080-1234-5678,2019-11-01,850000,A,Alpha,Senior,Active,Backend dev
+Hank,29,Sendai,84,Support,hank@example.com,080-2345-6789,2021-09-10,550000,B,Epsilon,Junior,Active,Tier 2

--- a/testdata/left.csv
+++ b/testdata/left.csv
@@ -1,0 +1,8 @@
+Name,Age,City,Score,Department,Email,Phone,StartDate,Salary,Rating,Project,Level,Status,Notes
+Alice,30,Tokyo,95,Engineering,alice@example.com,090-1111-2222,2020-04-01,800000,A,Alpha,Senior,Active,Team lead
+Bob,25,Osaka,88,Marketing,bob@example.com,090-3333-4444,2021-06-15,600000,B,Beta,Junior,Active,New hire
+Charlie,35,Nagoya,92,Engineering,charlie@example.com,090-5555-6666,2018-01-10,900000,A,Alpha,Lead,Active,Architect
+Diana,28,Kyoto,87,Design,diana@example.com,090-7777-8888,2022-03-20,650000,B,Gamma,Mid,Active,UI specialist
+Frank,40,Sapporo,78,Sales,frank@example.com,090-9999-0000,2015-08-01,750000,C,Delta,Senior,Active,Regional manager
+Grace,33,Kobe,91,Engineering,grace@example.com,080-1234-5678,2019-11-01,850000,A,Alpha,Senior,Active,Backend dev
+Hank,29,Sendai,84,Support,hank@example.com,080-2345-6789,2021-09-10,550000,B,Epsilon,Junior,Active,Tier 2

--- a/testdata/right.csv
+++ b/testdata/right.csv
@@ -1,0 +1,8 @@
+Name,Age,City,Score,Department,Email,Phone,StartDate,Salary,Rating,Project,Level,Status,Notes
+Alice,31,Tokyo,95,Engineering,alice@example.com,090-1111-2222,2020-04-01,820000,A,Alpha,Senior,Active,Team lead
+Bob,25,Yokohama,90,Marketing,bob@example.com,090-3333-4444,2021-06-15,600000,A,Beta,Junior,Active,Promoted
+Charlie,35,Nagoya,92,Engineering,charlie@example.com,090-5555-6666,2018-01-10,900000,A,Alpha,Lead,Active,Architect
+Eve,22,Fukuoka,91,Research,eve@example.com,070-1111-2222,2023-01-05,580000,A,Zeta,Junior,Active,New member
+Frank,40,Sapporo,80,Sales,frank@example.com,090-9999-0000,2015-08-01,770000,B,Delta,Senior,Active,Regional manager
+Grace,33,Kobe,91,Engineering,grace@example.com,080-1234-5678,2019-11-01,850000,A,Alpha,Senior,Inactive,On leave
+Hank,29,Sendai,84,Support,hank@example.com,080-2345-6789,2021-09-10,570000,B,Epsilon,Mid,Active,Promoted to Tier 3

--- a/ui/dialogs/open-dialog.slint
+++ b/ui/dialogs/open-dialog.slint
@@ -48,6 +48,7 @@ export component OpenDialog inherits Rectangle {
     callback open-recent(int);
     callback paste-left();
     callback paste-right();
+    callback paste-base();
 
     if visible-flag : Rectangle {
         width: 100%;
@@ -143,6 +144,7 @@ export component OpenDialog inherits Rectangle {
                             edited(text) => { root.base-path-input = text; }
                         }
                         Button { text: @tr("Browse..."); clicked => { root.browse-base(); } }
+                        PasteButton { clicked => { root.paste-base(); } }
                     }
                 }
 

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -12,6 +12,7 @@ import { NewTableDialog } from "dialogs/new-table-dialog.slint";
 import { ThemeColors } from "theme.slint";
 import { ExcelView, ExcelCellData } from "widgets/excel-view.slint";
 import { CsvView } from "widgets/csv-view.slint";
+import { TableGridView, TableRowData, TableCellData, TableColumnInfo } from "widgets/table-grid-view.slint";
 import { ImageView } from "widgets/image-view.slint";
 
 export struct PluginEntryData {
@@ -25,7 +26,7 @@ export struct DetailLineData {
     status: int,  // 1=added, 2=removed, 3=modified, 4=moved
 }
 
-export { DiffLineData, WordSegment, ExcelCellData, FolderItemData, TabData, RecentEntryData, ThreeWayLineData, ThemeColors, FileEntryData }
+export { DiffLineData, WordSegment, ExcelCellData, FolderItemData, TabData, RecentEntryData, ThreeWayLineData, ThemeColors, FileEntryData, TableRowData, TableCellData, TableColumnInfo }
 
 // Toolbar icon button: fixed 32x32 with image icon + optional overlay text
 component ToolBtn inherits Rectangle {
@@ -471,6 +472,19 @@ export component MainWindow inherits Window {
     in property <[string]> excel-sheet-names;
     in-out property <string> excel-active-sheet: "";
 
+    // Table grid comparison (view_mode == 4 and 6)
+    in-out property <[TableRowData]> table-rows;
+    in-out property <[TableColumnInfo]> table-columns;
+    in-out property <int> table-content-width-px: 0;
+    in-out property <length> table-scroll-y: 0px;
+    callback table-sheet-changed(string);
+    callback table-copy-to-right(int);
+    callback table-copy-to-left(int);
+    callback table-copy-right-and-next();
+    callback table-copy-left-and-next();
+    callback table-copy-all-right();
+    callback table-copy-all-left();
+
     // Diff comments
     in-out property <string> current-diff-comment: "";
     callback diff-comment-changed(string);
@@ -530,6 +544,11 @@ export component MainWindow inherits Window {
     // Scroll diff view to a specific row (with 3 context lines above)
     public function scroll-diff-to-row(row: int) {
         root.diff-scroll-y = -((row > 3 ? row - 3 : 0) * (root.opt-font-size + 2) * 1px);
+    }
+
+    // Scroll table grid view to a specific row (22px per row, 3 rows context)
+    public function scroll-table-to-row(row: int) {
+        root.table-scroll-y = -((row > 3 ? row - 3 : 0) * 22px);
     }
 
     // Helper: check unsaved before action
@@ -901,19 +920,19 @@ export component MainWindow inherits Window {
 
                 ToolSep {}
 
-                tb-first := ToolBtn { icon: @image-url("icons/first.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { root.first-diff(); } }
-                tb-prev := ToolBtn { icon: @image-url("icons/prev.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 3 { root.prev-conflict(); } else { root.prev-diff(); } } }
-                tb-next := ToolBtn { icon: @image-url("icons/next.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 3 { root.next-conflict(); } else { root.next-diff(); } } }
-                tb-last := ToolBtn { icon: @image-url("icons/last.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { root.last-diff(); } }
+                tb-first := ToolBtn { icon: @image-url("icons/first.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { root.first-diff(); } }
+                tb-prev := ToolBtn { icon: @image-url("icons/prev.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 3 { root.prev-conflict(); } else { root.prev-diff(); } } }
+                tb-next := ToolBtn { icon: @image-url("icons/next.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 3 { root.next-conflict(); } else { root.next-diff(); } } }
+                tb-last := ToolBtn { icon: @image-url("icons/last.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { root.last-diff(); } }
 
-                sep-nav := ToolSep { visible: root.view-mode == 0 || root.view-mode == 3; }
+                sep-nav := ToolSep { visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; }
 
-                tb-copy-r := ToolBtn { icon: @image-url("icons/copy-right.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 3 { root.use-left(root.current-conflict-index); } else { root.copy-to-right(root.current-diff-index); } } }
-                tb-copy-l := ToolBtn { icon: @image-url("icons/copy-left.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 3 { root.use-right(root.current-conflict-index); } else { root.copy-to-left(root.current-diff-index); } } }
-                tb-copy-r-next := ToolBtn { icon: @image-url("icons/copy-right-next.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 3 { root.use-left-and-next(); } else { root.copy-right-and-next(); } } }
-                tb-copy-l-next := ToolBtn { icon: @image-url("icons/copy-left-next.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 3 { root.use-right-and-next(); } else { root.copy-left-and-next(); } } }
-                tb-all-r := ToolBtn { icon: @image-url("icons/copy-all-right.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 3 { root.use-all-left(); } else { root.copy-all-diffs-right(); } } }
-                tb-all-l := ToolBtn { icon: @image-url("icons/copy-all-left.svg"); visible: root.view-mode == 0 || root.view-mode == 3; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 3 { root.use-all-right(); } else { root.copy-all-diffs-left(); } } }
+                tb-copy-r := ToolBtn { icon: @image-url("icons/copy-right.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-to-right(root.current-diff-index); } else if root.view-mode == 3 { root.use-left(root.current-conflict-index); } else { root.copy-to-right(root.current-diff-index); } } }
+                tb-copy-l := ToolBtn { icon: @image-url("icons/copy-left.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-to-left(root.current-diff-index); } else if root.view-mode == 3 { root.use-right(root.current-conflict-index); } else { root.copy-to-left(root.current-diff-index); } } }
+                tb-copy-r-next := ToolBtn { icon: @image-url("icons/copy-right-next.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-right-and-next(); } else if root.view-mode == 3 { root.use-left-and-next(); } else { root.copy-right-and-next(); } } }
+                tb-copy-l-next := ToolBtn { icon: @image-url("icons/copy-left-next.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-left-and-next(); } else if root.view-mode == 3 { root.use-right-and-next(); } else { root.copy-left-and-next(); } } }
+                tb-all-r := ToolBtn { icon: @image-url("icons/copy-all-right.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-all-right(); } else if root.view-mode == 3 { root.use-all-left(); } else { root.copy-all-diffs-right(); } } }
+                tb-all-l := ToolBtn { icon: @image-url("icons/copy-all-left.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-all-left(); } else if root.view-mode == 3 { root.use-all-right(); } else { root.copy-all-diffs-left(); } } }
 
                 ToolSep {}
 
@@ -1211,17 +1230,30 @@ export component MainWindow inherits Window {
             move-focus-down(row, pane) => { root.three-way-move-focus-down(row, pane); }
         }
 
-        // Excel compare view
-        if root.view-mode == 4 : ExcelView {
-            cells: root.excel-cells;
+        // Excel compare view (side-by-side grid)
+        if root.view-mode == 4 : TableGridView {
+            left-title: root.left-path;
+            right-title: root.right-path;
+            rows: root.table-rows;
+            columns: root.table-columns;
+            content-width-px: root.table-content-width-px;
+            scroll-y <=> root.table-scroll-y;
+            has-sheets: true;
             sheet-names: root.excel-sheet-names;
             active-sheet <=> root.excel-active-sheet;
+            sheet-changed(name) => { root.table-sheet-changed(name); }
             vertical-stretch: 1;
         }
 
-        // CSV/TSV compare view
-        if root.view-mode == 6 : CsvView {
-            cells: root.excel-cells;
+        // CSV/TSV compare view (side-by-side grid)
+        if root.view-mode == 6 : TableGridView {
+            left-title: root.left-path;
+            right-title: root.right-path;
+            rows: root.table-rows;
+            columns: root.table-columns;
+            content-width-px: root.table-content-width-px;
+            scroll-y <=> root.table-scroll-y;
+            has-sheets: false;
             vertical-stretch: 1;
         }
 

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -1,4 +1,4 @@
-import { Button, HorizontalBox, VerticalBox, Palette, CheckBox, LineEdit, ScrollView, ListView } from "std-widgets.slint";
+import { Button, HorizontalBox, VerticalBox, Palette, CheckBox, LineEdit, ScrollView, ListView, Slider } from "std-widgets.slint";
 import { DiffView, DiffLineData, WordSegment } from "widgets/diff-view.slint";
 import { DiffView3Way, ThreeWayLineData } from "widgets/diff-view-3way.slint";
 import { FolderView, FolderItemData } from "widgets/folder-view.slint";
@@ -12,7 +12,7 @@ import { NewTableDialog } from "dialogs/new-table-dialog.slint";
 import { ThemeColors } from "theme.slint";
 import { ExcelView, ExcelCellData } from "widgets/excel-view.slint";
 import { CsvView } from "widgets/csv-view.slint";
-import { TableGridView, TableRowData, TableCellData, TableColumnInfo } from "widgets/table-grid-view.slint";
+import { TableGridView, TableRowData, TableCellData, TableColumnInfo, TableDetailCellData } from "widgets/table-grid-view.slint";
 import { ImageView } from "widgets/image-view.slint";
 
 export struct PluginEntryData {
@@ -26,7 +26,7 @@ export struct DetailLineData {
     status: int,  // 1=added, 2=removed, 3=modified, 4=moved
 }
 
-export { DiffLineData, WordSegment, ExcelCellData, FolderItemData, TabData, RecentEntryData, ThreeWayLineData, ThemeColors, FileEntryData, TableRowData, TableCellData, TableColumnInfo }
+export { DiffLineData, WordSegment, ExcelCellData, FolderItemData, TabData, RecentEntryData, ThreeWayLineData, ThemeColors, FileEntryData, TableRowData, TableCellData, TableColumnInfo, TableDetailCellData }
 
 // Toolbar icon button: fixed 32x32 with image icon + optional overlay text
 component ToolBtn inherits Rectangle {
@@ -169,7 +169,7 @@ export component MainWindow inherits Window {
     // Folder comparison properties
     in-out property <[FolderItemData]> folder-items;
     in-out property <int> folder-selected-index: -1;
-    // 0=file diff, 1=folder compare, 3=3way, 4=excel, 5=image, 6=csv, 7=blank
+    // 0=file diff, 1=folder compare, 3=3way, 4=excel, 5=image, 6=csv, 7=blank, 8=csv-3way
     in-out property <int> view-mode: 7;
 
     // Open dialog modal
@@ -477,6 +477,10 @@ export component MainWindow inherits Window {
     in-out property <[TableColumnInfo]> table-columns;
     in-out property <int> table-content-width-px: 0;
     in-out property <length> table-scroll-y: 0px;
+    in-out property <length> table-scroll-x: 0px;
+    in-out property <int> table-current-highlight-row: -1;
+    // Table detail pane data (selected diff row's cells)
+    in property <[TableDetailCellData]> table-detail-cells: [];
     callback table-sheet-changed(string);
     callback table-copy-to-right(int);
     callback table-copy-to-left(int);
@@ -484,6 +488,13 @@ export component MainWindow inherits Window {
     callback table-copy-left-and-next();
     callback table-copy-all-right();
     callback table-copy-all-left();
+    // 3-way table resolve callbacks (copy to base)
+    callback table-use-left(int);
+    callback table-use-right(int);
+    callback table-use-left-and-next();
+    callback table-use-right-and-next();
+    callback table-use-all-left();
+    callback table-use-all-right();
 
     // Diff comments
     in-out property <string> current-diff-comment: "";
@@ -504,6 +515,7 @@ export component MainWindow inherits Window {
     // Clipboard paste path callbacks
     callback paste-left-path();
     callback paste-right-path();
+    callback paste-base-path();
 
     // Folder preview
     in-out property <string> folder-preview-name: "";
@@ -920,19 +932,19 @@ export component MainWindow inherits Window {
 
                 ToolSep {}
 
-                tb-first := ToolBtn { icon: @image-url("icons/first.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { root.first-diff(); } }
-                tb-prev := ToolBtn { icon: @image-url("icons/prev.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 3 { root.prev-conflict(); } else { root.prev-diff(); } } }
-                tb-next := ToolBtn { icon: @image-url("icons/next.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 3 { root.next-conflict(); } else { root.next-diff(); } } }
-                tb-last := ToolBtn { icon: @image-url("icons/last.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { root.last-diff(); } }
+                tb-first := ToolBtn { icon: @image-url("icons/first.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6 || root.view-mode == 8; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { root.first-diff(); } }
+                tb-prev := ToolBtn { icon: @image-url("icons/prev.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6 || root.view-mode == 8; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 3 { root.prev-conflict(); } else { root.prev-diff(); } } }
+                tb-next := ToolBtn { icon: @image-url("icons/next.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6 || root.view-mode == 8; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 3 { root.next-conflict(); } else { root.next-diff(); } } }
+                tb-last := ToolBtn { icon: @image-url("icons/last.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6 || root.view-mode == 8; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { root.last-diff(); } }
 
-                sep-nav := ToolSep { visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; }
+                sep-nav := ToolSep { visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6 || root.view-mode == 8; }
 
-                tb-copy-r := ToolBtn { icon: @image-url("icons/copy-right.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-to-right(root.current-diff-index); } else if root.view-mode == 3 { root.use-left(root.current-conflict-index); } else { root.copy-to-right(root.current-diff-index); } } }
-                tb-copy-l := ToolBtn { icon: @image-url("icons/copy-left.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-to-left(root.current-diff-index); } else if root.view-mode == 3 { root.use-right(root.current-conflict-index); } else { root.copy-to-left(root.current-diff-index); } } }
-                tb-copy-r-next := ToolBtn { icon: @image-url("icons/copy-right-next.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-right-and-next(); } else if root.view-mode == 3 { root.use-left-and-next(); } else { root.copy-right-and-next(); } } }
-                tb-copy-l-next := ToolBtn { icon: @image-url("icons/copy-left-next.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-left-and-next(); } else if root.view-mode == 3 { root.use-right-and-next(); } else { root.copy-left-and-next(); } } }
-                tb-all-r := ToolBtn { icon: @image-url("icons/copy-all-right.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-all-right(); } else if root.view-mode == 3 { root.use-all-left(); } else { root.copy-all-diffs-right(); } } }
-                tb-all-l := ToolBtn { icon: @image-url("icons/copy-all-left.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-all-left(); } else if root.view-mode == 3 { root.use-all-right(); } else { root.copy-all-diffs-left(); } } }
+                tb-copy-r := ToolBtn { icon: @image-url("icons/copy-right.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6 || root.view-mode == 8; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 8 { root.table-use-left(root.current-diff-index); } else if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-to-right(root.current-diff-index); } else if root.view-mode == 3 { root.use-left(root.current-conflict-index); } else { root.copy-to-right(root.current-diff-index); } } }
+                tb-copy-l := ToolBtn { icon: @image-url("icons/copy-left.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6 || root.view-mode == 8; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 8 { root.table-use-right(root.current-diff-index); } else if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-to-left(root.current-diff-index); } else if root.view-mode == 3 { root.use-right(root.current-conflict-index); } else { root.copy-to-left(root.current-diff-index); } } }
+                tb-copy-r-next := ToolBtn { icon: @image-url("icons/copy-right-next.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6 || root.view-mode == 8; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 8 { root.table-use-left-and-next(); } else if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-right-and-next(); } else if root.view-mode == 3 { root.use-left-and-next(); } else { root.copy-right-and-next(); } } }
+                tb-copy-l-next := ToolBtn { icon: @image-url("icons/copy-left-next.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6 || root.view-mode == 8; btn-enabled: root.view-mode == 3 ? root.current-conflict-index >= 0 : root.current-diff-index >= 0; clicked => { if root.view-mode == 8 { root.table-use-right-and-next(); } else if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-left-and-next(); } else if root.view-mode == 3 { root.use-right-and-next(); } else { root.copy-left-and-next(); } } }
+                tb-all-r := ToolBtn { icon: @image-url("icons/copy-all-right.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6 || root.view-mode == 8; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 8 { root.table-use-all-left(); } else if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-all-right(); } else if root.view-mode == 3 { root.use-all-left(); } else { root.copy-all-diffs-right(); } } }
+                tb-all-l := ToolBtn { icon: @image-url("icons/copy-all-left.svg"); visible: root.view-mode == 0 || root.view-mode == 3 || root.view-mode == 4 || root.view-mode == 6 || root.view-mode == 8; btn-enabled: root.view-mode == 3 ? root.conflict-count > 0 : root.diff-count > 0; clicked => { if root.view-mode == 8 { root.table-use-all-right(); } else if root.view-mode == 4 || root.view-mode == 6 { root.table-copy-all-left(); } else if root.view-mode == 3 { root.use-all-right(); } else { root.copy-all-diffs-left(); } } }
 
                 ToolSep {}
 
@@ -1238,6 +1250,8 @@ export component MainWindow inherits Window {
             columns: root.table-columns;
             content-width-px: root.table-content-width-px;
             scroll-y <=> root.table-scroll-y;
+            h-scroll-offset <=> root.table-scroll-x;
+            current-highlight-row: root.table-current-highlight-row;
             has-sheets: true;
             sheet-names: root.excel-sheet-names;
             active-sheet <=> root.excel-active-sheet;
@@ -1253,6 +1267,24 @@ export component MainWindow inherits Window {
             columns: root.table-columns;
             content-width-px: root.table-content-width-px;
             scroll-y <=> root.table-scroll-y;
+            h-scroll-offset <=> root.table-scroll-x;
+            current-highlight-row: root.table-current-highlight-row;
+            has-sheets: false;
+            vertical-stretch: 1;
+        }
+
+        // 3-way CSV/TSV table comparison
+        if root.view-mode == 8 : TableGridView {
+            left-title: root.left-path;
+            right-title: root.right-path;
+            base-title: root.base-path;
+            has-base: true;
+            rows: root.table-rows;
+            columns: root.table-columns;
+            content-width-px: root.table-content-width-px;
+            scroll-y <=> root.table-scroll-y;
+            h-scroll-offset <=> root.table-scroll-x;
+            current-highlight-row: root.table-current-highlight-row;
             has-sheets: false;
             vertical-stretch: 1;
         }
@@ -1652,6 +1684,220 @@ export component MainWindow inherits Window {
             }
         }
 
+        // Table diff detail pane (view-mode 4/6)
+        if root.show-detail-pane && (root.view-mode == 4 || root.view-mode == 6 || root.view-mode == 8) && root.current-diff-index >= 0 : Rectangle {
+            height: 5px;
+            background: transparent;
+
+            Rectangle {
+                x: 0;
+                y: 2px;
+                width: 100%;
+                height: 1px;
+                background: Palette.border;
+            }
+
+            TouchArea {
+                mouse-cursor: row-resize;
+                moved => {
+                    root.detail-pane-height = Math.clamp(root.detail-pane-height - self.mouse-y, 60px, 400px);
+                }
+            }
+        }
+        if root.show-detail-pane && (root.view-mode == 4 || root.view-mode == 6 || root.view-mode == 8) && root.current-diff-index >= 0 : Rectangle {
+            height: root.detail-pane-height;
+            border-color: Palette.border;
+            border-width: 1px;
+
+            property <int> detail-row-count: root.view-mode == 8 ? 3 : 2;
+            property <length> detail-row-h: 22px;
+            property <length> detail-label-w: 48px;
+
+            HorizontalLayout {
+                // Fixed label column (row labels: column headers, Left, Base, Right)
+                VerticalLayout {
+                    width: detail-label-w;
+                    // Column header row label
+                    Rectangle {
+                        height: detail-row-h;
+                        background: Palette.background.darker(0.08);
+                        border-color: Palette.border;
+                        border-width: 1px;
+                    }
+                    // Left row label
+                    Rectangle {
+                        height: detail-row-h;
+                        background: Palette.background.darker(0.02);
+                        border-color: Palette.border;
+                        border-width: 1px;
+                        Text {
+                            x: 4px;
+                            text: "Left";
+                            font-size: 10px;
+                            font-weight: 600;
+                            vertical-alignment: center;
+                            color: ThemeColors.removed-fg;
+                        }
+                    }
+                    // Base row label (3-way only)
+                    if root.view-mode == 8 : Rectangle {
+                        height: detail-row-h;
+                        background: Palette.background.darker(0.02);
+                        border-color: Palette.border;
+                        border-width: 1px;
+                        Text {
+                            x: 4px;
+                            text: "Base";
+                            font-size: 10px;
+                            font-weight: 600;
+                            vertical-alignment: center;
+                            color: ThemeColors.modified-fg;
+                        }
+                    }
+                    // Right row label
+                    Rectangle {
+                        height: detail-row-h;
+                        background: Palette.background.darker(0.02);
+                        border-color: Palette.border;
+                        border-width: 1px;
+                        Text {
+                            x: 4px;
+                            text: "Right";
+                            font-size: 10px;
+                            font-weight: 600;
+                            vertical-alignment: center;
+                            color: ThemeColors.added-fg;
+                        }
+                    }
+                }
+
+                // Scrollable data area (clipped, scroll offset synced with main grid)
+                VerticalLayout {
+                    horizontal-stretch: 1;
+
+                    Rectangle {
+                        vertical-stretch: 1;
+                        clip: true;
+
+                        property <length> detail-scroll-x: root.table-scroll-x;
+
+                        // Row 0: Column headers
+                        for cell in root.table-detail-cells: Rectangle {
+                            x: cell.col-x-px * 1px - detail-scroll-x;
+                            y: 0;
+                            width: cell.col-width-px * 1px;
+                            height: detail-row-h;
+                            background: Palette.background.darker(0.08);
+                            border-color: Palette.border;
+                            border-width: 1px;
+
+                            Rectangle {
+                                x: 0;
+                                y: 3px;
+                                width: 6px;
+                                height: parent.height - 6px;
+                                background: cell.status == 0 ? transparent
+                                          : cell.status == 1 ? ThemeColors.modified-fg
+                                          : cell.status == 2 ? ThemeColors.removed-fg
+                                          : cell.status == 3 ? ThemeColors.added-fg
+                                          : cell.status == 5 ? ThemeColors.conflict-bg
+                                          : transparent;
+                            }
+
+                            Text {
+                                x: 8px;
+                                text: cell.col-name;
+                                font-size: 10px;
+                                font-weight: 600;
+                                font-family: "monospace";
+                                vertical-alignment: center;
+                                overflow: elide;
+                            }
+                        }
+
+                        // Row 1: Left values (use left-status)
+                        for cell in root.table-detail-cells: Rectangle {
+                            x: cell.col-x-px * 1px - detail-scroll-x;
+                            y: detail-row-h;
+                            width: cell.col-width-px * 1px;
+                            height: detail-row-h;
+                            background: cell.left-status == 0 ? Palette.background
+                                      : cell.left-status == 1 ? ThemeColors.modified-bg
+                                      : cell.left-status == 2 ? ThemeColors.removed-bg
+                                      : cell.left-status == 3 ? ThemeColors.added-bg
+                                      : cell.left-status == 4 ? Palette.background.darker(0.04)
+                                      : cell.left-status == 5 ? ThemeColors.conflict-bg
+                                      : Palette.background;
+                            border-color: Palette.border;
+                            border-width: 1px;
+
+                            Text {
+                                x: 4px;
+                                text: cell.left-value;
+                                font-size: 11px;
+                                font-family: "monospace";
+                                vertical-alignment: center;
+                                overflow: elide;
+                                color: cell.left-status != 0 ? ThemeColors.modified-fg : Palette.foreground;
+                            }
+                        }
+
+                        // Row 2 (3-way): Base values (use base-status)
+                        for cell in root.table-detail-cells: Rectangle {
+                            x: cell.col-x-px * 1px - detail-scroll-x;
+                            y: root.view-mode == 8 ? 2 * detail-row-h : -1000px;
+                            width: cell.col-width-px * 1px;
+                            height: detail-row-h;
+                            visible: root.view-mode == 8;
+                            background: cell.base-status == 0 ? Palette.background
+                                      : cell.base-status == 2 ? ThemeColors.removed-bg
+                                      : cell.base-status == 4 ? Palette.background.darker(0.04)
+                                      : Palette.background;
+                            border-color: Palette.border;
+                            border-width: 1px;
+
+                            Text {
+                                x: 4px;
+                                text: cell.base-value;
+                                font-size: 11px;
+                                font-family: "monospace";
+                                vertical-alignment: center;
+                                overflow: elide;
+                            }
+                        }
+
+                        // Last Row: Right values (use right-status)
+                        for cell in root.table-detail-cells: Rectangle {
+                            x: cell.col-x-px * 1px - detail-scroll-x;
+                            y: detail-row-count * detail-row-h;
+                            width: cell.col-width-px * 1px;
+                            height: detail-row-h;
+                            background: cell.right-status == 0 ? Palette.background
+                                      : cell.right-status == 1 ? ThemeColors.modified-bg
+                                      : cell.right-status == 2 ? ThemeColors.removed-bg
+                                      : cell.right-status == 3 ? ThemeColors.added-bg
+                                      : cell.right-status == 4 ? Palette.background.darker(0.04)
+                                      : cell.right-status == 5 ? ThemeColors.conflict-bg
+                                      : Palette.background;
+                            border-color: Palette.border;
+                            border-width: 1px;
+
+                            Text {
+                                x: 4px;
+                                text: cell.right-value;
+                                font-size: 11px;
+                                font-family: "monospace";
+                                vertical-alignment: center;
+                                overflow: elide;
+                                color: cell.right-status != 0 ? ThemeColors.modified-fg : Palette.foreground;
+                            }
+                        }
+                    }
+
+                }
+            }
+        }
+
         // Status bar
         Rectangle {
             height: 24px;
@@ -1923,6 +2169,7 @@ export component MainWindow inherits Window {
         }
         paste-left => { root.paste-left-path(); }
         paste-right => { root.paste-right-path(); }
+        paste-base => { root.paste-base-path(); }
     }
 
     // Go to Line dialog

--- a/ui/widgets/table-grid-view.slint
+++ b/ui/widgets/table-grid-view.slint
@@ -9,7 +9,7 @@ export struct TableColumnInfo {
 
 export struct TableCellData {
     text: string,
-    // 0=identical, 1=different, 2=left-only, 3=right-only, 4=empty-padding
+    // 0=identical, 1=different, 2=left-only, 3=right-only, 4=empty-padding, 5=conflict
     status: int,
     col-x-px: int,     // same as column's x-px
     col-width-px: int,  // same as column's width-px
@@ -19,8 +19,27 @@ export struct TableRowData {
     row-number: int,
     left-cells: [TableCellData],
     right-cells: [TableCellData],
+    base-cells: [TableCellData],
     // 0=identical, 1=has-diffs, 2=left-only, 3=right-only
+    // 3-way extra: 4=conflict, 5=base-only, 6=left-only-3way, 7=right-only-3way
     row-status: int,
+}
+
+// Detail pane data: one entry per column in the selected diff row
+export struct TableDetailCellData {
+    col-name: string,
+    left-value: string,
+    base-value: string,
+    right-value: string,
+    // Combined status for column header indicator
+    // 0=identical, 1=different, 2=left-only, 3=right-only, 5=conflict
+    status: int,
+    // Per-pane status (same codes as TableCellData.status)
+    left-status: int,
+    right-status: int,
+    base-status: int,
+    col-x-px: int,
+    col-width-px: int,
 }
 
 // Minimap showing row-level diff positions
@@ -41,6 +60,10 @@ component TableLocationPane inherits Rectangle {
                   : row.row-status == 1 ? ThemeColors.modified-fg
                   : row.row-status == 2 ? ThemeColors.removed-fg
                   : row.row-status == 3 ? ThemeColors.added-fg
+                  : row.row-status == 4 ? ThemeColors.removed-fg
+                  : row.row-status == 5 ? ThemeColors.removed-fg
+                  : row.row-status == 6 ? ThemeColors.added-fg
+                  : row.row-status == 7 ? ThemeColors.added-fg
                   : transparent;
     }
 }
@@ -48,9 +71,13 @@ component TableLocationPane inherits Rectangle {
 export component TableGridView inherits Rectangle {
     in property <string> left-title: "Left";
     in property <string> right-title: "Right";
+    in property <string> base-title: "Base";
+    in property <bool> has-base: false;
     in property <[TableRowData]> rows;
     in property <[TableColumnInfo]> columns;
     in property <int> content-width-px: 0;
+    // Row index to highlight as current diff (-1 = none)
+    in property <int> current-highlight-row: -1;
 
     // Sheet selector (for Excel)
     in property <bool> has-sheets: false;
@@ -61,6 +88,7 @@ export component TableGridView inherits Rectangle {
     // Scroll sync
     in-out property <length> scroll-y <=> left-list.viewport-y;
     in-out property <length> right-scroll-y <=> right-list.viewport-y;
+    in-out property <length> base-scroll-y: 0px;
 
     // Horizontal scroll offset (shared between left and right panes)
     in-out property <length> h-scroll-offset: 0px;
@@ -68,16 +96,18 @@ export component TableGridView inherits Rectangle {
     property <length> total-content-width: root.row-num-width + root.content-width-px * 1px;
     property <length> col-header-h: 24px;
 
-    // Bidirectional vertical sync
+    // Bidirectional vertical sync (left ↔ right)
     changed scroll-y => {
         if right-list.viewport-y != scroll-y {
             right-list.viewport-y = scroll-y;
         }
+        root.base-scroll-y = scroll-y;
     }
     changed right-scroll-y => {
         if left-list.viewport-y != right-scroll-y {
             left-list.viewport-y = right-scroll-y;
         }
+        root.base-scroll-y = right-scroll-y;
     }
 
     border-color: Palette.border;
@@ -129,6 +159,25 @@ export component TableGridView inherits Rectangle {
                     padding-left: 8px;
                     Text {
                         text: root.left-title;
+                        font-size: 12px;
+                        font-weight: 600;
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
+                }
+            }
+
+            // Base header (3-way only, shown between left and right)
+            if root.has-base : Rectangle {
+                horizontal-stretch: 1;
+                min-width: 80px;
+                background: Palette.background.darker(0.05);
+                border-color: Palette.border;
+                border-width: 1px;
+                HorizontalLayout {
+                    padding-left: 8px;
+                    Text {
+                        text: root.base-title;
                         font-size: 12px;
                         font-weight: 600;
                         vertical-alignment: center;
@@ -228,6 +277,8 @@ export component TableGridView inherits Rectangle {
                     for row[row-idx] in root.rows: Rectangle {
                         height: 22px;
                         clip: true;
+                        border-color: row-idx == root.current-highlight-row ? ThemeColors.modified-fg : transparent;
+                        border-width: row-idx == root.current-highlight-row ? 2px : 0;
 
                         // Row number cell
                         Rectangle {
@@ -260,6 +311,119 @@ export component TableGridView inherits Rectangle {
                                       : cell.status == 1 ? ThemeColors.modified-bg
                                       : cell.status == 2 ? ThemeColors.removed-bg
                                       : cell.status == 3 ? ThemeColors.added-bg
+                                      : cell.status == 5 ? ThemeColors.conflict-bg
+                                      : Palette.background;
+
+                            Text {
+                                text: cell.text;
+                                font-size: 11px;
+                                font-family: "monospace";
+                                vertical-alignment: center;
+                                overflow: elide;
+                                x: 4px;
+                                width: parent.width - 8px;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Base grid pane (3-way only)
+            if root.has-base : Rectangle {
+                horizontal-stretch: 1;
+                min-width: 80px;
+                clip: true;
+
+                // Column header
+                Rectangle {
+                    x: 0;
+                    y: 0;
+                    width: 100%;
+                    height: root.col-header-h;
+                    background: Palette.background.darker(0.08);
+
+                    // "#" header cell
+                    Rectangle {
+                        x: -root.h-scroll-offset;
+                        y: 0;
+                        width: root.row-num-width;
+                        height: 100%;
+                        border-color: Palette.border;
+                        border-width: 0.5px;
+                        Text {
+                            text: "#";
+                            font-size: 11px;
+                            font-weight: 600;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                            color: Palette.foreground.transparentize(0.3);
+                        }
+                    }
+
+                    // Column name cells
+                    for col[idx] in root.columns: Rectangle {
+                        x: root.row-num-width + col.x-px * 1px - root.h-scroll-offset;
+                        y: 0;
+                        width: col.width-px * 1px;
+                        height: 100%;
+                        border-color: Palette.border;
+                        border-width: 0.5px;
+                        Text {
+                            text: col.name;
+                            font-size: 11px;
+                            font-weight: 600;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+
+                // Data rows
+                base-list := ListView {
+                    x: 0;
+                    y: root.col-header-h;
+                    width: 100%;
+                    height: parent.height - root.col-header-h;
+                    viewport-y: root.base-scroll-y;
+
+                    for row[row-idx] in root.rows: Rectangle {
+                        height: 22px;
+                        clip: true;
+                        border-color: row-idx == root.current-highlight-row ? ThemeColors.modified-fg : transparent;
+                        border-width: row-idx == root.current-highlight-row ? 2px : 0;
+
+                        // Row number cell
+                        Rectangle {
+                            x: -root.h-scroll-offset;
+                            y: 0;
+                            width: root.row-num-width;
+                            height: 100%;
+                            background: Palette.background.darker(0.03);
+                            border-color: Palette.border;
+                            border-width: 0.5px;
+                            Text {
+                                text: row.row-number > 0 ? "\{row.row-number}" : "";
+                                font-size: 11px;
+                                font-family: "monospace";
+                                horizontal-alignment: right;
+                                vertical-alignment: center;
+                                color: Palette.foreground.transparentize(0.4);
+                            }
+                        }
+
+                        // Data cells
+                        for cell[idx] in row.base-cells: Rectangle {
+                            x: root.row-num-width + cell.col-x-px * 1px - root.h-scroll-offset;
+                            y: 0;
+                            width: cell.col-width-px * 1px;
+                            height: 100%;
+                            border-color: Palette.border;
+                            border-width: 0.5px;
+                            background: cell.status == 0 ? Palette.background
+                                      : cell.status == 1 ? ThemeColors.modified-bg
+                                      : cell.status == 2 ? ThemeColors.removed-bg
+                                      : cell.status == 3 ? ThemeColors.added-bg
+                                      : cell.status == 5 ? ThemeColors.conflict-bg
                                       : Palette.background;
 
                             Text {
@@ -336,6 +500,8 @@ export component TableGridView inherits Rectangle {
                     for row[row-idx] in root.rows: Rectangle {
                         height: 22px;
                         clip: true;
+                        border-color: row-idx == root.current-highlight-row ? ThemeColors.modified-fg : transparent;
+                        border-width: row-idx == root.current-highlight-row ? 2px : 0;
 
                         // Row number cell
                         Rectangle {
@@ -368,6 +534,7 @@ export component TableGridView inherits Rectangle {
                                       : cell.status == 1 ? ThemeColors.modified-bg
                                       : cell.status == 2 ? ThemeColors.removed-bg
                                       : cell.status == 3 ? ThemeColors.added-bg
+                                      : cell.status == 5 ? ThemeColors.conflict-bg
                                       : Palette.background;
 
                             Text {

--- a/ui/widgets/table-grid-view.slint
+++ b/ui/widgets/table-grid-view.slint
@@ -1,0 +1,415 @@
+import { ListView, ComboBox, Palette, Slider } from "std-widgets.slint";
+import { ThemeColors } from "../theme.slint";
+
+export struct TableColumnInfo {
+    name: string,
+    width-px: int,   // column width in pixels
+    x-px: int,       // cumulative x offset (0 for first column)
+}
+
+export struct TableCellData {
+    text: string,
+    // 0=identical, 1=different, 2=left-only, 3=right-only, 4=empty-padding
+    status: int,
+    col-x-px: int,     // same as column's x-px
+    col-width-px: int,  // same as column's width-px
+}
+
+export struct TableRowData {
+    row-number: int,
+    left-cells: [TableCellData],
+    right-cells: [TableCellData],
+    // 0=identical, 1=has-diffs, 2=left-only, 3=right-only
+    row-status: int,
+}
+
+// Minimap showing row-level diff positions
+component TableLocationPane inherits Rectangle {
+    in property <[TableRowData]> rows;
+
+    width: 12px;
+    background: Palette.background.darker(0.02);
+    border-color: Palette.border;
+    border-width: 1px;
+
+    for row[idx] in rows: Rectangle {
+        y: rows.length > 0 ? (idx * (parent.height - 2px) / rows.length) : 0;
+        height: rows.length > 0 ? Math.max(2px, (parent.height - 2px) / rows.length) : 0;
+        x: 1px;
+        width: parent.width - 2px;
+        background: row.row-status == 0 ? transparent
+                  : row.row-status == 1 ? ThemeColors.modified-fg
+                  : row.row-status == 2 ? ThemeColors.removed-fg
+                  : row.row-status == 3 ? ThemeColors.added-fg
+                  : transparent;
+    }
+}
+
+export component TableGridView inherits Rectangle {
+    in property <string> left-title: "Left";
+    in property <string> right-title: "Right";
+    in property <[TableRowData]> rows;
+    in property <[TableColumnInfo]> columns;
+    in property <int> content-width-px: 0;
+
+    // Sheet selector (for Excel)
+    in property <bool> has-sheets: false;
+    in property <[string]> sheet-names;
+    in-out property <string> active-sheet: "";
+    callback sheet-changed(string);
+
+    // Scroll sync
+    in-out property <length> scroll-y <=> left-list.viewport-y;
+    in-out property <length> right-scroll-y <=> right-list.viewport-y;
+
+    // Horizontal scroll offset (shared between left and right panes)
+    in-out property <length> h-scroll-offset: 0px;
+    property <length> row-num-width: 40px;
+    property <length> total-content-width: root.row-num-width + root.content-width-px * 1px;
+    property <length> col-header-h: 24px;
+
+    // Bidirectional vertical sync
+    changed scroll-y => {
+        if right-list.viewport-y != scroll-y {
+            right-list.viewport-y = scroll-y;
+        }
+    }
+    changed right-scroll-y => {
+        if left-list.viewport-y != right-scroll-y {
+            left-list.viewport-y = right-scroll-y;
+        }
+    }
+
+    border-color: Palette.border;
+    border-width: 1px;
+
+    VerticalLayout {
+        // Sheet selector bar (Excel only)
+        if root.has-sheets : Rectangle {
+            height: 36px;
+            background: Palette.background.darker(0.04);
+            border-color: Palette.border;
+            border-width: 1px;
+
+            HorizontalLayout {
+                padding-left: 8px;
+                padding-right: 8px;
+                spacing: 8px;
+                alignment: start;
+
+                Text {
+                    text: "Sheet:";
+                    font-size: 12px;
+                    vertical-alignment: center;
+                }
+
+                ComboBox {
+                    width: 200px;
+                    model: root.sheet-names;
+                    current-value: root.active-sheet;
+                    selected(val) => {
+                        root.active-sheet = val;
+                        root.sheet-changed(val);
+                    }
+                }
+            }
+        }
+
+        // File path headers
+        HorizontalLayout {
+            height: 28px;
+
+            Rectangle {
+                horizontal-stretch: 1;
+                min-width: 80px;
+                background: Palette.background.darker(0.05);
+                border-color: Palette.border;
+                border-width: 1px;
+                HorizontalLayout {
+                    padding-left: 8px;
+                    Text {
+                        text: root.left-title;
+                        font-size: 12px;
+                        font-weight: 600;
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
+                }
+            }
+
+            Rectangle {
+                horizontal-stretch: 1;
+                min-width: 80px;
+                background: Palette.background.darker(0.05);
+                border-color: Palette.border;
+                border-width: 1px;
+                HorizontalLayout {
+                    padding-left: 8px;
+                    Text {
+                        text: root.right-title;
+                        font-size: 12px;
+                        font-weight: 600;
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
+                }
+            }
+
+            // Spacer for location pane
+            if root.rows.length > 0 : Rectangle {
+                width: 12px;
+                background: Palette.background.darker(0.05);
+                border-color: Palette.border;
+                border-width: 1px;
+            }
+        }
+
+        // Grid content (column headers + data rows inside each pane)
+        HorizontalLayout {
+            vertical-stretch: 1;
+
+            // Left grid pane
+            Rectangle {
+                horizontal-stretch: 1;
+                min-width: 80px;
+                clip: true;
+
+                // Column header
+                Rectangle {
+                    x: 0;
+                    y: 0;
+                    width: 100%;
+                    height: root.col-header-h;
+                    background: Palette.background.darker(0.08);
+
+                    // "#" header cell
+                    Rectangle {
+                        x: -root.h-scroll-offset;
+                        y: 0;
+                        width: root.row-num-width;
+                        height: 100%;
+                        border-color: Palette.border;
+                        border-width: 0.5px;
+                        Text {
+                            text: "#";
+                            font-size: 11px;
+                            font-weight: 600;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                            color: Palette.foreground.transparentize(0.3);
+                        }
+                    }
+
+                    // Column name cells
+                    for col[idx] in root.columns: Rectangle {
+                        x: root.row-num-width + col.x-px * 1px - root.h-scroll-offset;
+                        y: 0;
+                        width: col.width-px * 1px;
+                        height: 100%;
+                        border-color: Palette.border;
+                        border-width: 0.5px;
+                        Text {
+                            text: col.name;
+                            font-size: 11px;
+                            font-weight: 600;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+
+                // Data rows
+                left-list := ListView {
+                    x: 0;
+                    y: root.col-header-h;
+                    width: 100%;
+                    height: parent.height - root.col-header-h;
+
+                    for row[row-idx] in root.rows: Rectangle {
+                        height: 22px;
+                        clip: true;
+
+                        // Row number cell
+                        Rectangle {
+                            x: -root.h-scroll-offset;
+                            y: 0;
+                            width: root.row-num-width;
+                            height: 100%;
+                            background: Palette.background.darker(0.03);
+                            border-color: Palette.border;
+                            border-width: 0.5px;
+                            Text {
+                                text: row.row-number > 0 ? "\{row.row-number}" : "";
+                                font-size: 11px;
+                                font-family: "monospace";
+                                horizontal-alignment: right;
+                                vertical-alignment: center;
+                                color: Palette.foreground.transparentize(0.4);
+                            }
+                        }
+
+                        // Data cells
+                        for cell[idx] in row.left-cells: Rectangle {
+                            x: root.row-num-width + cell.col-x-px * 1px - root.h-scroll-offset;
+                            y: 0;
+                            width: cell.col-width-px * 1px;
+                            height: 100%;
+                            border-color: Palette.border;
+                            border-width: 0.5px;
+                            background: cell.status == 0 ? Palette.background
+                                      : cell.status == 1 ? ThemeColors.modified-bg
+                                      : cell.status == 2 ? ThemeColors.removed-bg
+                                      : cell.status == 3 ? ThemeColors.added-bg
+                                      : Palette.background;
+
+                            Text {
+                                text: cell.text;
+                                font-size: 11px;
+                                font-family: "monospace";
+                                vertical-alignment: center;
+                                overflow: elide;
+                                x: 4px;
+                                width: parent.width - 8px;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Right grid pane
+            Rectangle {
+                horizontal-stretch: 1;
+                min-width: 80px;
+                clip: true;
+
+                // Column header
+                Rectangle {
+                    x: 0;
+                    y: 0;
+                    width: 100%;
+                    height: root.col-header-h;
+                    background: Palette.background.darker(0.08);
+
+                    // "#" header cell
+                    Rectangle {
+                        x: -root.h-scroll-offset;
+                        y: 0;
+                        width: root.row-num-width;
+                        height: 100%;
+                        border-color: Palette.border;
+                        border-width: 0.5px;
+                        Text {
+                            text: "#";
+                            font-size: 11px;
+                            font-weight: 600;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                            color: Palette.foreground.transparentize(0.3);
+                        }
+                    }
+
+                    // Column name cells
+                    for col[idx] in root.columns: Rectangle {
+                        x: root.row-num-width + col.x-px * 1px - root.h-scroll-offset;
+                        y: 0;
+                        width: col.width-px * 1px;
+                        height: 100%;
+                        border-color: Palette.border;
+                        border-width: 0.5px;
+                        Text {
+                            text: col.name;
+                            font-size: 11px;
+                            font-weight: 600;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+                }
+
+                // Data rows
+                right-list := ListView {
+                    x: 0;
+                    y: root.col-header-h;
+                    width: 100%;
+                    height: parent.height - root.col-header-h;
+
+                    for row[row-idx] in root.rows: Rectangle {
+                        height: 22px;
+                        clip: true;
+
+                        // Row number cell
+                        Rectangle {
+                            x: -root.h-scroll-offset;
+                            y: 0;
+                            width: root.row-num-width;
+                            height: 100%;
+                            background: Palette.background.darker(0.03);
+                            border-color: Palette.border;
+                            border-width: 0.5px;
+                            Text {
+                                text: row.row-number > 0 ? "\{row.row-number}" : "";
+                                font-size: 11px;
+                                font-family: "monospace";
+                                horizontal-alignment: right;
+                                vertical-alignment: center;
+                                color: Palette.foreground.transparentize(0.4);
+                            }
+                        }
+
+                        // Data cells
+                        for cell[idx] in row.right-cells: Rectangle {
+                            x: root.row-num-width + cell.col-x-px * 1px - root.h-scroll-offset;
+                            y: 0;
+                            width: cell.col-width-px * 1px;
+                            height: 100%;
+                            border-color: Palette.border;
+                            border-width: 0.5px;
+                            background: cell.status == 0 ? Palette.background
+                                      : cell.status == 1 ? ThemeColors.modified-bg
+                                      : cell.status == 2 ? ThemeColors.removed-bg
+                                      : cell.status == 3 ? ThemeColors.added-bg
+                                      : Palette.background;
+
+                            Text {
+                                text: cell.text;
+                                font-size: 11px;
+                                font-family: "monospace";
+                                vertical-alignment: center;
+                                overflow: elide;
+                                x: 4px;
+                                width: parent.width - 8px;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Location pane
+            if root.rows.length > 0 : TableLocationPane {
+                rows: root.rows;
+            }
+        }
+
+        // Horizontal scrollbar
+        if root.columns.length > 0 : Rectangle {
+            height: 20px;
+            background: Palette.background.darker(0.03);
+            border-color: Palette.border;
+            border-width: 1px;
+
+            HorizontalLayout {
+                padding-left: 4px;
+                padding-right: 4px;
+
+                Slider {
+                    minimum: 0;
+                    maximum: Math.max(0, root.total-content-width / 1px);
+                    value: root.h-scroll-offset / 1px;
+                    changed(val) => {
+                        root.h-scroll-offset = val * 1px;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **3-way CSV table comparison** (view-mode 8): Left/Base/Right 3-pane grid with per-cell diff status
- **Detail pane redesign**: BeyondCompare-style horizontal layout — column headers on top, Left/Base/Right as rows with per-pane diff coloring
- **IPC 3-file support**: Receiver now detects 3 files and opens as 3-way comparison
- **3-way table resolve**: Copy buttons follow text 3-way spec (use-left/use-right copies to Base)
- **Open dialog**: Paste-base button added for 3-way mode
- **Bug fix**: Detail pane now shows diff for right-only changes

## Test plan
- [ ] `cargo test --features desktop` passes
- [ ] 2-way CSV compare: toolbar nav, copy L→R / R→L, detail pane
- [ ] 3-way CSV compare (`base.csv left.csv right.csv`): 3 panes, diff colors, use-left/use-right resolves to base
- [ ] Detail pane horizontal scroll syncs with main grid
- [ ] IPC: launching 3 files sends to running instance as 3-way
- [ ] Open dialog paste-base button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)