### PR TITLE
v0.37.0: macOS Finder Sync Extension — right-click compare

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,46 @@
 {
+  "permissions": {
+    "allow": [
+      "Edit(*)",
+      "Write(*)",
+      "Bash(cargo *)",
+      "Bash(git *)",
+      "Bash(gh *)",
+      "Bash(ls *)",
+      "Bash(mkdir *)",
+      "Bash(cp *)",
+      "Bash(echo *)",
+      "Bash(asdf *)",
+      "Bash(python3 *)",
+      "Bash(iconutil *)",
+      "Bash(codesign *)",
+      "Bash(which *)",
+      "Bash(./target/release/winxmerge *)",
+      "Bash(./build_app.sh *)",
+      "WebSearch",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:api.github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:slint.dev)",
+      "WebFetch(domain:docs.slint.dev)",
+      "WebFetch(domain:docs.rs)",
+      "WebFetch(domain:crates.io)",
+      "WebFetch(domain:manual.winmerge.org)",
+      "WebFetch(domain:winmerge.org)"
+    ],
+    "ask": [
+      "Bash(rm *)",
+      "Bash(kill *)",
+      "Bash(killall *)",
+      "Bash(pkill *)",
+      "Bash(sudo *)",
+      "Bash(git push --force *)"
+    ],
+    "deny": [
+      "Read(.devcontainer/.env)"
+    ],
+    "additionalDirectories": ["/tmp"]
+  },
   "hooks": {
     "PostToolUse": [
       {
@@ -11,5 +53,9 @@
         ]
       }
     ]
-  }
+  },
+  "env": {
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "80"
+  },
+  "respectGitignore": true
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winxmerge"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2024"
 
 [lib]
@@ -76,7 +76,7 @@ identifier = "io.github.masak1yu.winxmerge"
 icon = ["assets/icons/app-icon-32.png", "assets/icons/app-icon-64.png",
         "assets/icons/app-icon-128.png", "assets/icons/app-icon-256.png",
         "assets/icons/app-icon-512.png", "assets/icons/app-icon.icns"]
-version = "0.36.0"
+version = "0.37.0"
 copyright = "WinXMerge contributors"
 category = "Developer Tool"
 short_description = "Cross-platform file diff and merge tool"

--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ A cross-platform file diff comparison and merge tool inspired by WinMerge, built
 - Multiple file pairs (2+) displayed as a virtual folder comparison view
 - Double-click a file in the folder view to open detailed diff in a new tab
 
+### macOS Finder Integration
+- Finder Sync Extension: right-click files in Finder to compare with WinXMerge
+- Select 2 files → "Compare with WinXMerge" (2-way diff)
+- Select 3 files → "Compare with WinXMerge" (3-way merge)
+- Select 1 file → "Mark for Compare" / "Compare with [marked file]" workflow
+- Works with existing running instance (adds new tab) or launches the app
+- Enabled via System Settings > General > Login Items & Extensions
+
 ### Other
 - WinMerge-style initial file selection dialog (with recent files list)
 - WinMerge-style options dialog (Edit → Options...)
@@ -413,6 +421,12 @@ winxmerge/
 │   └── models/
 │       ├── diff_line.rs        # Diff line data model
 │       └── folder_item.rs      # Folder comparison item model
+├── macos/
+│   ├── Info.plist              # macOS app bundle metadata
+│   ├── WinXMerge.entitlements  # App entitlements (App Group)
+│   └── FinderSync/             # Finder Sync Extension (right-click compare)
+├── scripts/
+│   └── build-macos-bundle.sh   # Build .app bundle with Finder extension
 ├── translations/               # Translation files (gettext .po)
 │   └── ja/LC_MESSAGES/         # Japanese translations
 └── testdata/                   # Test sample files

--- a/macos/FinderSync/FinderSync.entitlements
+++ b/macos/FinderSync/FinderSync.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.io.github.masak1yu.winxmerge</string>
+	</array>
+</dict>
+</plist>

--- a/macos/FinderSync/FinderSync.xcodeproj/project.pbxproj
+++ b/macos/FinderSync/FinderSync.xcodeproj/project.pbxproj
@@ -1,0 +1,225 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A1000001 /* FinderSyncExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000002 /* FinderSyncExtension.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		A1000002 /* FinderSyncExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderSyncExtension.swift; sourceTree = "<group>"; };
+		A1000003 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A1000004 /* FinderSync.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = FinderSync.entitlements; sourceTree = "<group>"; };
+		A1000005 /* WinXMergeFinderSync.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WinXMergeFinderSync.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A1000010 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A1000020 /* Root */ = {
+			isa = PBXGroup;
+			children = (
+				A1000021 /* FinderSync */,
+				A1000022 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A1000021 /* FinderSync */ = {
+			isa = PBXGroup;
+			children = (
+				A1000002 /* FinderSyncExtension.swift */,
+				A1000003 /* Info.plist */,
+				A1000004 /* FinderSync.entitlements */,
+			);
+			path = .;
+			sourceTree = "<group>";
+		};
+		A1000022 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A1000005 /* WinXMergeFinderSync.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A1000030 /* WinXMergeFinderSync */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A1000040 /* Build configuration list for PBXNativeTarget "WinXMergeFinderSync" */;
+			buildPhases = (
+				A1000031 /* Sources */,
+				A1000010 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = WinXMergeFinderSync;
+			productName = WinXMergeFinderSync;
+			productReference = A1000005 /* WinXMergeFinderSync.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A1000050 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1630;
+				LastUpgradeCheck = 1630;
+			};
+			buildConfigurationList = A1000060 /* Build configuration list for PBXProject "FinderSync" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A1000020 /* Root */;
+			productRefGroup = A1000022 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A1000030 /* WinXMergeFinderSync */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A1000031 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1000001 /* FinderSyncExtension.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A1000061 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		A1000062 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		A1000041 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = FinderSync.entitlements;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 3D5V7PNTDJ;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MARKETING_VERSION = 0.37.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.masak1yu.winxmerge.FinderSync;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+			};
+			name = Debug;
+		};
+		A1000042 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = FinderSync.entitlements;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 3D5V7PNTDJ;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MARKETING_VERSION = 0.37.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.masak1yu.winxmerge.FinderSync;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A1000060 /* Build configuration list for PBXProject "FinderSync" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1000061 /* Debug */,
+				A1000062 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A1000040 /* Build configuration list for PBXNativeTarget "WinXMergeFinderSync" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1000041 /* Debug */,
+				A1000042 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+	};
+	rootObject = A1000050 /* Project object */;
+}

--- a/macos/FinderSync/FinderSyncExtension.swift
+++ b/macos/FinderSync/FinderSyncExtension.swift
@@ -1,0 +1,121 @@
+import Cocoa
+import FinderSync
+
+class FinderSyncExtension: FIFinderSync {
+
+    let sharedDefaults = UserDefaults(suiteName: "group.io.github.masak1yu.winxmerge")
+
+    override init() {
+        super.init()
+        NSLog("WinXMergeFinderSync: init() called")
+        // Monitor all volumes so the context menu appears everywhere
+        FIFinderSyncController.default().directoryURLs = [URL(fileURLWithPath: "/")]
+        NSLog("WinXMergeFinderSync: directoryURLs set to /")
+    }
+
+    // MARK: - Context Menu
+
+    override func menu(for menuKind: FIMenuKind) -> NSMenu? {
+        NSLog("WinXMergeFinderSync: menu(for:) called, menuKind=%d", menuKind.rawValue)
+        guard menuKind == .contextualMenuForItems else { return nil }
+
+        let menu = NSMenu(title: "WinXMerge")
+        let selectedItems = FIFinderSyncController.default().selectedItemURLs() ?? []
+
+        if selectedItems.count >= 2 {
+            // 2+ items selected: offer direct comparison
+            let compareItem = NSMenuItem(
+                title: "Compare with WinXMerge",
+                action: #selector(compareSelected(_:)),
+                keyEquivalent: ""
+            )
+            compareItem.image = NSImage(named: "winxmerge-icon")
+            menu.addItem(compareItem)
+        }
+
+        if selectedItems.count == 1 {
+            // 1 item selected: offer mark or compare-with-marked
+            let markItem = NSMenuItem(
+                title: "Mark for Compare (WinXMerge)",
+                action: #selector(markForCompare(_:)),
+                keyEquivalent: ""
+            )
+            menu.addItem(markItem)
+
+            if let markedPath = sharedDefaults?.string(forKey: "markedFilePath"),
+               FileManager.default.fileExists(atPath: markedPath) {
+                let markedName = (markedPath as NSString).lastPathComponent
+                let compareItem = NSMenuItem(
+                    title: "Compare with \"\(markedName)\" (WinXMerge)",
+                    action: #selector(compareWithMarked(_:)),
+                    keyEquivalent: ""
+                )
+                menu.addItem(compareItem)
+            }
+        }
+
+        return menu.items.isEmpty ? nil : menu
+    }
+
+    // MARK: - Actions
+
+    @objc func compareSelected(_ sender: AnyObject?) {
+        guard let selectedItems = FIFinderSyncController.default().selectedItemURLs(),
+              selectedItems.count >= 2 else { return }
+
+        // Take first 2 (or 3 for 3-way) items
+        let paths = Array(selectedItems.prefix(3)).map { $0.path }
+        launchWinXMerge(with: paths)
+    }
+
+    @objc func markForCompare(_ sender: AnyObject?) {
+        guard let selectedItems = FIFinderSyncController.default().selectedItemURLs(),
+              let firstItem = selectedItems.first else { return }
+
+        sharedDefaults?.set(firstItem.path, forKey: "markedFilePath")
+        sharedDefaults?.synchronize()
+    }
+
+    @objc func compareWithMarked(_ sender: AnyObject?) {
+        guard let selectedItems = FIFinderSyncController.default().selectedItemURLs(),
+              let selectedItem = selectedItems.first,
+              let markedPath = sharedDefaults?.string(forKey: "markedFilePath") else { return }
+
+        launchWinXMerge(with: [markedPath, selectedItem.path])
+
+        // Clear the marked file after comparison
+        sharedDefaults?.removeObject(forKey: "markedFilePath")
+        sharedDefaults?.synchronize()
+    }
+
+    // MARK: - Launch Helper
+
+    private func launchWinXMerge(with paths: [String]) {
+        // Navigate from .appex to the main app binary:
+        // .../WinXMerge.app/Contents/PlugIns/WinXMergeFinderSync.appex
+        //  -> .../WinXMerge.app/Contents/MacOS/winxmerge
+        let appexURL = URL(fileURLWithPath: Bundle.main.bundlePath)
+        let contentsURL = appexURL
+            .deletingLastPathComponent()  // PlugIns/
+            .deletingLastPathComponent()  // Contents/
+        let binaryPath = contentsURL
+            .appendingPathComponent("MacOS/winxmerge").path
+
+        let binaryURL = URL(fileURLWithPath: binaryPath)
+
+        guard FileManager.default.fileExists(atPath: binaryPath) else {
+            NSLog("WinXMerge binary not found at: %@", binaryPath)
+            return
+        }
+
+        do {
+            let process = Process()
+            process.executableURL = binaryURL
+            process.arguments = paths
+            NSLog("WinXMergeFinderSync: launching %@ with args: %@", binaryPath, paths.joined(separator: ", "))
+            try process.run()
+        } catch {
+            NSLog("Failed to launch WinXMerge: %@", error.localizedDescription)
+        }
+    }
+}

--- a/macos/FinderSync/FinderSyncExtension.swift
+++ b/macos/FinderSync/FinderSyncExtension.swift
@@ -91,29 +91,45 @@ class FinderSyncExtension: FIFinderSync {
     // MARK: - Launch Helper
 
     private func launchWinXMerge(with paths: [String]) {
-        // Navigate from .appex to the main app binary:
+        // Navigate from .appex to the main .app bundle:
         // .../WinXMerge.app/Contents/PlugIns/WinXMergeFinderSync.appex
-        //  -> .../WinXMerge.app/Contents/MacOS/winxmerge
+        //  -> .../WinXMerge.app/
         let appexURL = URL(fileURLWithPath: Bundle.main.bundlePath)
-        let contentsURL = appexURL
+        let appURL = appexURL
             .deletingLastPathComponent()  // PlugIns/
             .deletingLastPathComponent()  // Contents/
-        let binaryPath = contentsURL
-            .appendingPathComponent("MacOS/winxmerge").path
+            .deletingLastPathComponent()  // WinXMerge.app/
 
-        let binaryURL = URL(fileURLWithPath: binaryPath)
-
-        guard FileManager.default.fileExists(atPath: binaryPath) else {
-            NSLog("WinXMerge binary not found at: %@", binaryPath)
+        guard FileManager.default.fileExists(atPath: appURL.path) else {
+            NSLog("WinXMerge.app not found at: %@", appURL.path)
             return
         }
 
+        NSLog("WinXMergeFinderSync: launching %@ with args: %@",
+              appURL.path, paths.joined(separator: ", "))
+
+        // Write file paths to the shared App Group container.
+        // CLI args and `open --args` do NOT work from sandboxed Finder Sync extensions.
+        // The main app polls this file and picks up the request.
+        if let containerURL = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: "group.io.github.masak1yu.winxmerge"
+        ) {
+            let pendingFile = containerURL.appendingPathComponent("pending-compare.txt")
+            let content = paths.joined(separator: "\n")
+            do {
+                try content.write(to: pendingFile, atomically: true, encoding: .utf8)
+            } catch {
+                NSLog("WinXMergeFinderSync: failed to write pending file: %@",
+                      error.localizedDescription)
+            }
+        }
+
+        // Launch/activate the app through Launch Services
         do {
-            let process = Process()
-            process.executableURL = binaryURL
-            process.arguments = paths
-            NSLog("WinXMergeFinderSync: launching %@ with args: %@", binaryPath, paths.joined(separator: ", "))
-            try process.run()
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+            task.arguments = ["-a", appURL.path]
+            try task.run()
         } catch {
             NSLog("Failed to launch WinXMerge: %@", error.localizedDescription)
         }

--- a/macos/FinderSync/Info.plist
+++ b/macos/FinderSync/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>WinXMerge Finder Sync</string>
+	<key>CFBundleExecutable</key>
+	<string>WinXMergeFinderSync</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.github.masak1yu.winxmerge.FinderSync</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>WinXMergeFinderSync</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.37.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict/>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.FinderSync</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>WinXMergeFinderSync.FinderSyncExtension</string>
+	</dict>
+</dict>
+</plist>

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>WinXMerge</string>
+	<key>CFBundleExecutable</key>
+	<string>winxmerge</string>
+	<key>CFBundleIconFile</key>
+	<string>app-icon</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.github.masak1yu.winxmerge</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>WinXMerge</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.37.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+</dict>
+</plist>

--- a/macos/WinXMerge.entitlements
+++ b/macos/WinXMerge.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.io.github.masak1yu.winxmerge</string>
+	</array>
+</dict>
+</plist>

--- a/scripts/build-macos-bundle.sh
+++ b/scripts/build-macos-bundle.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build WinXMerge.app with embedded Finder Sync Extension
+# Usage: ./scripts/build-macos-bundle.sh [--debug]
+#
+# Environment variables:
+#   CODESIGN_IDENTITY  - Code signing identity (default: "Developer ID Application: Masayuki Uchida (3D5V7PNTDJ)")
+#   DEVELOPER_DIR      - Xcode path (default: /Applications/Xcode.app/Contents/Developer)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CODESIGN_IDENTITY="${CODESIGN_IDENTITY:-Developer ID Application: Masayuki Uchida (3D5V7PNTDJ)}"
+
+# Always use real Xcode — Nix may override DEVELOPER_DIR with its SDK path
+if [[ -d "/Applications/Xcode.app/Contents/Developer" ]]; then
+    export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
+else
+    export DEVELOPER_DIR="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}"
+fi
+
+BUILD_CONFIG="release"
+CARGO_PROFILE="--release"
+SWIFT_OPT="-O"
+if [[ "${1:-}" == "--debug" ]]; then
+    BUILD_CONFIG="debug"
+    CARGO_PROFILE=""
+    SWIFT_OPT="-Onone -g"
+fi
+
+APP_NAME="WinXMerge"
+APP_BUNDLE="$PROJECT_ROOT/target/${APP_NAME}.app"
+APPEX_NAME="WinXMergeFinderSync"
+FINDER_SYNC_DIR="$PROJECT_ROOT/macos/FinderSync"
+
+echo "==> Building Rust binary ($BUILD_CONFIG)..."
+cd "$PROJECT_ROOT"
+cargo build $CARGO_PROFILE --features desktop
+
+RUST_BINARY="$PROJECT_ROOT/target/${BUILD_CONFIG}/winxmerge"
+
+echo "==> Building Finder Sync Extension ($BUILD_CONFIG)..."
+
+# Use xcodebuild with clean PATH (nix ld conflicts with Xcode linker flags)
+XCODE_CONFIG="Debug"
+if [[ "$BUILD_CONFIG" == "release" ]]; then
+    XCODE_CONFIG="Release"
+fi
+
+env -i \
+    HOME="$HOME" \
+    PATH="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:${DEVELOPER_DIR}/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    DEVELOPER_DIR="$DEVELOPER_DIR" \
+"${DEVELOPER_DIR}/usr/bin/xcodebuild" \
+    -project "$FINDER_SYNC_DIR/FinderSync.xcodeproj" \
+    -target "$APPEX_NAME" \
+    -configuration "$XCODE_CONFIG" \
+    -arch arm64 \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGNING_ALLOWED=NO \
+    SYMROOT="$PROJECT_ROOT/target/xcode-build" \
+    build 2>&1 | tail -3
+
+APPEX_BUNDLE="$PROJECT_ROOT/target/xcode-build/${XCODE_CONFIG}/${APPEX_NAME}.appex"
+if [[ ! -d "$APPEX_BUNDLE" ]]; then
+    echo "ERROR: appex not found at $APPEX_BUNDLE"
+    exit 1
+fi
+echo "    Built: $APPEX_BUNDLE"
+
+echo "==> Assembling ${APP_NAME}.app bundle..."
+rm -rf "$APP_BUNDLE"
+mkdir -p "$APP_BUNDLE/Contents/MacOS"
+mkdir -p "$APP_BUNDLE/Contents/PlugIns"
+mkdir -p "$APP_BUNDLE/Contents/Resources"
+mkdir -p "$APP_BUNDLE/Contents/Frameworks"
+
+# Copy binary
+cp "$RUST_BINARY" "$APP_BUNDLE/Contents/MacOS/winxmerge"
+chmod +x "$APP_BUNDLE/Contents/MacOS/winxmerge"
+
+# Bundle Nix store dylibs into the app and rewrite references.
+# macOS 11+ removed many /usr/lib dylibs from disk (they live in the shared
+# cache), so pointing at /usr/lib is unreliable. Bundling is the standard
+# approach for app distribution.
+FRAMEWORKS_DIR="$APP_BUNDLE/Contents/Frameworks"
+
+# Phase 1: Copy Nix dylibs and rewrite references in the main binary
+nix_libs=$(otool -L "$APP_BUNDLE/Contents/MacOS/winxmerge" | grep '/nix/store/' | awk '{print $1}')
+for nix_lib in $nix_libs; do
+    lib_name=$(basename "$nix_lib")
+    echo "  Bundling $lib_name"
+    cp "$nix_lib" "$FRAMEWORKS_DIR/$lib_name"
+    chmod 644 "$FRAMEWORKS_DIR/$lib_name"
+    install_name_tool -change "$nix_lib" "@executable_path/../Frameworks/$lib_name" "$APP_BUNDLE/Contents/MacOS/winxmerge"
+done
+
+# Phase 2: Fix references inside the bundled dylibs themselves
+for dylib in "$FRAMEWORKS_DIR"/*.dylib; do
+    [ -f "$dylib" ] || continue
+    lib_name=$(basename "$dylib")
+    # Fix the dylib's own install name
+    install_name_tool -id "@executable_path/../Frameworks/$lib_name" "$dylib"
+    # Rewrite any Nix store references within this dylib
+    for dep in $(otool -L "$dylib" | grep '/nix/store/' | awk '{print $1}'); do
+        dep_name=$(basename "$dep")
+        if [ -f "$FRAMEWORKS_DIR/$dep_name" ]; then
+            install_name_tool -change "$dep" "@executable_path/../Frameworks/$dep_name" "$dylib"
+        else
+            # Dependency not yet bundled — copy it too
+            echo "  Bundling transitive dep $dep_name"
+            cp "$dep" "$FRAMEWORKS_DIR/$dep_name"
+            chmod 644 "$FRAMEWORKS_DIR/$dep_name"
+            install_name_tool -id "@executable_path/../Frameworks/$dep_name" "$FRAMEWORKS_DIR/$dep_name"
+            install_name_tool -change "$dep" "@executable_path/../Frameworks/$dep_name" "$dylib"
+        fi
+    done
+done
+
+# Copy Info.plist
+cp "$PROJECT_ROOT/macos/Info.plist" "$APP_BUNDLE/Contents/Info.plist"
+
+# Copy icon
+cp "$PROJECT_ROOT/assets/icons/app-icon.icns" "$APP_BUNDLE/Contents/Resources/app-icon.icns"
+
+# Copy Finder Sync extension
+cp -R "$APPEX_BUNDLE" "$APP_BUNDLE/Contents/PlugIns/"
+
+echo "==> Code signing..."
+# Sign bundled frameworks first (inside-out signing order)
+for dylib in "$FRAMEWORKS_DIR"/*.dylib; do
+    [ -f "$dylib" ] || continue
+    codesign --force --sign "$CODESIGN_IDENTITY" --options runtime "$dylib"
+done
+
+# Sign the extension
+codesign --force --options runtime \
+    --entitlements "$FINDER_SYNC_DIR/FinderSync.entitlements" \
+    --sign "$CODESIGN_IDENTITY" \
+    "$APP_BUNDLE/Contents/PlugIns/${APPEX_NAME}.appex"
+
+# Sign the main app
+codesign --force --options runtime \
+    --entitlements "$PROJECT_ROOT/macos/WinXMerge.entitlements" \
+    --sign "$CODESIGN_IDENTITY" \
+    "$APP_BUNDLE"
+
+echo "==> Verifying signature..."
+codesign --verify --deep --strict "$APP_BUNDLE"
+
+echo ""
+echo "SUCCESS: $APP_BUNDLE"
+echo ""
+echo "To install:"
+echo "  cp -R \"$APP_BUNDLE\" /Applications/"
+echo ""
+echo "To enable Finder extension:"
+echo "  System Settings > Privacy & Security > Extensions > Added Extensions > WinXMerge"

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -29,17 +29,6 @@ pub fn try_send(pairs: &[(String, String)]) -> Result<(), ()> {
     }
 }
 
-/// Try to send with retries (waiting for server to start).
-pub fn try_send_with_retry(pairs: &[(String, String)], retries: u32) -> Result<(), ()> {
-    for _ in 0..retries {
-        if try_send(pairs).is_ok() {
-            return Ok(());
-        }
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
-    Err(())
-}
-
 /// Copy files to a temp directory so git difftool can clean up originals.
 /// Returns pairs of (original_path, temp_path).
 pub fn copy_to_temp(paths: &[String]) -> Vec<(String, String)> {
@@ -65,17 +54,6 @@ pub fn copy_to_temp(paths: &[String]) -> Vec<(String, String)> {
             (p.clone(), dest.to_string_lossy().to_string())
         })
         .collect()
-}
-
-/// Spawn a new winxmerge server process in the background.
-pub fn spawn_server() {
-    let exe = std::env::current_exe().unwrap_or_else(|_| "winxmerge".into());
-    let _ = std::process::Command::new(exe)
-        .arg("--server")
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn();
 }
 
 /// Start listening for incoming file path pairs from other instances.
@@ -120,4 +98,31 @@ pub fn start_listener(tx: Sender<Vec<(String, String)>>) {
 /// Clean up the socket file (call on app exit).
 pub fn cleanup() {
     let _ = std::fs::remove_file(socket_path());
+}
+
+/// Path to the Finder Sync pending-compare request file in the shared App Group container.
+fn finder_request_path() -> Option<std::path::PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    Some(
+        std::path::PathBuf::from(home).join(
+            "Library/Group Containers/group.io.github.masak1yu.winxmerge/pending-compare.txt",
+        ),
+    )
+}
+
+/// Check for a pending compare request from the Finder Sync extension.
+/// Returns file paths if a request is found, and removes the request file.
+pub fn check_finder_request() -> Option<Vec<String>> {
+    let path = finder_request_path()?;
+    if !path.exists() {
+        return None;
+    }
+    let content = std::fs::read_to_string(&path).ok()?;
+    let _ = std::fs::remove_file(&path);
+    let paths: Vec<String> = content
+        .lines()
+        .map(|l| l.to_string())
+        .filter(|l| !l.is_empty())
+        .collect();
+    if paths.is_empty() { None } else { Some(paths) }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,48 @@ fn main() {
         return;
     }
 
+    // Parse CLI flags and positional arguments early (before creating any UI)
+    // so IPC client mode can exit without creating a MainWindow.
+    let mut positional: Vec<String> = Vec::new();
+    let mut cli_ignore_whitespace = false;
+    let mut cli_ignore_case = false;
+    let mut cli_ignore_blank_lines = false;
+    {
+        let mut i = 1;
+        while i < args.len() {
+            match args[i].as_str() {
+                "--ignore-whitespace" | "-w" => cli_ignore_whitespace = true,
+                "--ignore-case" | "-i" => cli_ignore_case = true,
+                "--ignore-blank-lines" | "-B" => cli_ignore_blank_lines = true,
+                "--server" | "--clear-history" => {}
+                _ => positional.push(args[i].clone()),
+            }
+            i += 1;
+        }
+    }
+
+    // Check for pending Finder Sync request (shared App Group container file).
+    // If no CLI positional args, pick up paths from Finder extension.
+    #[cfg(unix)]
+    if positional.is_empty() {
+        if let Some(finder_paths) = ipc::check_finder_request() {
+            positional = finder_paths;
+        }
+    }
+
+    // IPC client mode (Unix only): if we have file args and are NOT the server,
+    // try to send to a running instance. If no server is running, fall through
+    // to become the server ourselves and open the files directly.
+    #[cfg(unix)]
+    if !is_server_mode && positional.len() >= 2 {
+        let copied = ipc::copy_to_temp(&positional);
+        if ipc::try_send(&copied).is_ok() {
+            return;
+        }
+        // No running instance — fall through to become the server with these files.
+        // The positional args will be opened directly below.
+    }
+
     let window = MainWindow::new().unwrap();
     let state = Rc::new(RefCell::new(AppState::new()));
     let settings = Rc::new(RefCell::new(settings::AppSettings::load()));
@@ -179,25 +221,6 @@ fn main() {
     // Initialize tab list
     app::sync_tab_list(&window, &state.borrow());
 
-    // Parse CLI flags and positional arguments
-    let mut positional: Vec<String> = Vec::new();
-    let mut cli_ignore_whitespace = false;
-    let mut cli_ignore_case = false;
-    let mut cli_ignore_blank_lines = false;
-    {
-        let mut i = 1;
-        while i < args.len() {
-            match args[i].as_str() {
-                "--ignore-whitespace" | "-w" => cli_ignore_whitespace = true,
-                "--ignore-case" | "-i" => cli_ignore_case = true,
-                "--ignore-blank-lines" | "-B" => cli_ignore_blank_lines = true,
-                "--server" | "--clear-history" => {}
-                _ => positional.push(args[i].clone()),
-            }
-            i += 1;
-        }
-    }
-
     // Apply CLI flags to initial tab's diff options
     if cli_ignore_whitespace || cli_ignore_case || cli_ignore_blank_lines {
         let mut s = state.borrow_mut();
@@ -219,23 +242,6 @@ fn main() {
         if cli_ignore_case {
             window.set_ignore_case(true);
         }
-    }
-
-    // IPC client mode (Unix only): if we have file args and are NOT the server,
-    // copy files, send to running instance (or spawn one), then exit immediately.
-    #[cfg(unix)]
-    if !is_server_mode && positional.len() >= 2 {
-        let copied = ipc::copy_to_temp(&positional);
-        if ipc::try_send(&copied).is_ok() {
-            return;
-        }
-        // No running instance — spawn a server and send via IPC
-        ipc::spawn_server();
-        if ipc::try_send_with_retry(&copied, 30).is_ok() {
-            return;
-        }
-        eprintln!("[winxmerge] failed to connect to server");
-        return;
     }
 
     // Server mode (--server) or no-args launch: start IPC listener (Unix only)
@@ -1761,6 +1767,33 @@ fn main() {
                     // IPC: accumulate file pairs, then flush as virtual folder or single diff
                     #[cfg(unix)]
                     {
+                        // Check for Finder Sync extension requests (shared file)
+                        if let Some(finder_paths) = ipc::check_finder_request() {
+                            let mut s = state.borrow_mut();
+                            add_tab(&window, &mut s);
+                            if finder_paths.len() >= 3 {
+                                start_three_way_compare(
+                                    &window,
+                                    &mut s,
+                                    &finder_paths[0],
+                                    &finder_paths[1],
+                                    &finder_paths[2],
+                                );
+                            } else if finder_paths.len() >= 2 {
+                                {
+                                    let tab = s.current_tab_mut();
+                                    tab.left_path =
+                                        Some(std::path::PathBuf::from(&finder_paths[0]));
+                                    tab.right_path =
+                                        Some(std::path::PathBuf::from(&finder_paths[1]));
+                                    tab.view_mode = 0;
+                                }
+                                window.set_view_mode(0);
+                                run_diff(&window, &mut s);
+                            }
+                            app::sync_tab_list(&window, &s);
+                        }
+
                         // Phase 1: Drain incoming IPC messages into buffer
                         while let Ok(pairs) = ipc_rx.try_recv() {
                             if pairs.len() == 3 {


### PR DESCRIPTION
## Summary
- **Finder Sync Extension**: right-click files in Finder to compare with WinXMerge (2-way, 3-way, mark-and-compare)
- **App Group IPC**: FinderSync writes paths to shared container (`~/Library/Group Containers/`), app polls on 100ms timer
- **Build script**: `scripts/build-macos-bundle.sh` — Rust + Xcode appex + Nix dylib bundling + codesign
- **IPC optimization**: arg parsing & IPC client check moved before `MainWindow::new()` for faster early exit

### Key files
- `macos/FinderSync/FinderSyncExtension.swift` — FIFinderSync context menu + shared file launch
- `src/ipc.rs` — `check_finder_request()` for App Group container polling
- `src/main.rs` — startup + timer integration for Finder requests
- `scripts/build-macos-bundle.sh` — full .app bundle build pipeline

### Technical notes
- `NSWorkspace.OpenConfiguration.arguments` and `open --args` do NOT pass CLI args from sandboxed Finder Sync extensions — shared App Group file is the reliable IPC mechanism
- `spawn_server()` / `try_send_with_retry()` removed; IPC client falls through to become server when no instance running

## Test plan
- [ ] Finder: select 2 files → right-click → "Compare with WinXMerge" → diff opens
- [ ] Finder: select 3 files → right-click → "Compare with WinXMerge" → 3-way merge opens
- [ ] Finder: select 1 file → "Mark for Compare" → select another → "Compare with [name]"
- [ ] App already running: Finder compare adds new tab to existing window
- [ ] `cargo run --features desktop -- file1 file2` still works (CLI path)
- [ ] `git difftool` still works (Unix socket IPC path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)