### PR TITLE
v0.38.0: macOS code signing and notarization in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,6 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact: winxmerge-linux-x86_64
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            artifact: winxmerge-macos-aarch64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: winxmerge-windows-x86_64
@@ -83,8 +80,98 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}.*
 
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94.0"
+          targets: aarch64-apple-darwin
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: macos-aarch64-apple-darwin-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            macos-aarch64-apple-darwin-cargo-release-
+
+      - name: Import code signing certificate
+        env:
+          MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          CERT_FILE=$(mktemp /tmp/cert.XXXXXX.p12)
+          KEYCHAIN_FILE=$(mktemp /tmp/keychain.XXXXXX.keychain-db)
+          KEYCHAIN_PASSWORD=$(openssl rand -hex 16)
+
+          echo "$MACOS_CERTIFICATE_P12" | base64 --decode > "$CERT_FILE"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_FILE"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
+          security import "$CERT_FILE" -k "$KEYCHAIN_FILE" -P "$MACOS_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productsign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
+          security list-keychains -d user -s "$KEYCHAIN_FILE" $(security list-keychains -d user | tr -d '"')
+
+          echo "KEYCHAIN_FILE=$KEYCHAIN_FILE" >> "$GITHUB_ENV"
+
+          rm -f "$CERT_FILE"
+
+      - name: Build .app bundle
+        env:
+          CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
+        run: |
+          chmod +x scripts/build-macos-bundle.sh
+          scripts/build-macos-bundle.sh
+
+      - name: Notarize .app bundle
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          APP_BUNDLE="target/WinXMerge.app"
+
+          ditto -c -k --keepParent "$APP_BUNDLE" target/WinXMerge-notarize.zip
+
+          xcrun notarytool submit target/WinXMerge-notarize.zip \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+
+          xcrun stapler staple "$APP_BUNDLE"
+
+          rm -f target/WinXMerge-notarize.zip
+
+      - name: Package as .zip
+        run: |
+          cd target
+          ditto -c -k --keepParent WinXMerge.app ../winxmerge-macos-aarch64.zip
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          if [ -n "${KEYCHAIN_FILE:-}" ]; then
+            security delete-keychain "$KEYCHAIN_FILE" || true
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: winxmerge-macos-aarch64
+          path: winxmerge-macos-aarch64.zip
+
   release:
-    needs: build
+    needs: [build, build-macos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -97,5 +184,5 @@ jobs:
           generate_release_notes: true
           files: |
             winxmerge-linux-x86_64.tar.gz
-            winxmerge-macos-aarch64.tar.gz
+            winxmerge-macos-aarch64.zip
             winxmerge-windows-x86_64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,12 @@ jobs:
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_FILE"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
+
+          # Import Apple intermediate certificates (required for chain validation)
+          curl -sL https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer -o "$RUNNER_TEMP/DeveloperIDG2CA.cer"
+          security import "$RUNNER_TEMP/DeveloperIDG2CA.cer" -k "$KEYCHAIN_FILE" -T /usr/bin/codesign
+
+          # Import developer certificate
           security import "$CERT_FILE" -k "$KEYCHAIN_FILE" -P "$MACOS_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
           security default-keychain -s "$KEYCHAIN_FILE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,7 @@ jobs:
           security find-identity -v -p codesigning "$KEYCHAIN_FILE"
 
           echo "KEYCHAIN_FILE=$KEYCHAIN_FILE" >> "$GITHUB_ENV"
+          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> "$GITHUB_ENV"
 
           rm -f "$CERT_FILE"
 
@@ -133,6 +134,14 @@ jobs:
         env:
           CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
         run: |
+          # Debug: verify keychain state before build
+          echo "==> Keychain search list:"
+          security list-keychains -d user
+          echo "==> Available signing identities:"
+          security find-identity -v -p codesigning
+          echo "==> Unlocking keychain..."
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
+
           chmod +x scripts/build-macos-bundle.sh
           scripts/build-macos-bundle.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,9 +117,13 @@ jobs:
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_FILE"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
-          security import "$CERT_FILE" -k "$KEYCHAIN_FILE" -P "$MACOS_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productsign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
+          security import "$CERT_FILE" -k "$KEYCHAIN_FILE" -P "$MACOS_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
+          security default-keychain -s "$KEYCHAIN_FILE"
           security list-keychains -d user -s "$KEYCHAIN_FILE" $(security list-keychains -d user | tr -d '"')
+
+          # Verify certificate is accessible
+          security find-identity -v -p codesigning "$KEYCHAIN_FILE"
 
           echo "KEYCHAIN_FILE=$KEYCHAIN_FILE" >> "$GITHUB_ENV"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,9 +128,6 @@ jobs:
           security default-keychain -s "$KEYCHAIN_FILE"
           security list-keychains -d user -s "$KEYCHAIN_FILE" $(security list-keychains -d user | tr -d '"')
 
-          # Verify certificate is accessible
-          security find-identity -v -p codesigning "$KEYCHAIN_FILE"
-
           echo "KEYCHAIN_FILE=$KEYCHAIN_FILE" >> "$GITHUB_ENV"
           echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> "$GITHUB_ENV"
 
@@ -140,14 +137,7 @@ jobs:
         env:
           CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
         run: |
-          # Debug: verify keychain state before build
-          echo "==> Keychain search list:"
-          security list-keychains -d user
-          echo "==> Available signing identities:"
-          security find-identity -v -p codesigning
-          echo "==> Unlocking keychain..."
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
-
           chmod +x scripts/build-macos-bundle.sh
           scripts/build-macos-bundle.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,8 +108,8 @@ jobs:
           MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
         run: |
-          CERT_FILE=$(mktemp /tmp/cert.XXXXXX.p12)
-          KEYCHAIN_FILE=$(mktemp /tmp/keychain.XXXXXX.keychain-db)
+          CERT_FILE="$RUNNER_TEMP/certificate.p12"
+          KEYCHAIN_FILE="$RUNNER_TEMP/app-signing.keychain-db"
           KEYCHAIN_PASSWORD=$(openssl rand -hex 16)
 
           echo "$MACOS_CERTIFICATE_P12" | base64 --decode > "$CERT_FILE"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6356,7 +6356,7 @@ dependencies = [
 
 [[package]]
 name = "winxmerge"
-version = "0.36.0"
+version = "0.38.0"
 dependencies = [
  "arboard",
  "calamine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winxmerge"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2024"
 
 [lib]
@@ -76,7 +76,7 @@ identifier = "io.github.masak1yu.winxmerge"
 icon = ["assets/icons/app-icon-32.png", "assets/icons/app-icon-64.png",
         "assets/icons/app-icon-128.png", "assets/icons/app-icon-256.png",
         "assets/icons/app-icon-512.png", "assets/icons/app-icon.icns"]
-version = "0.37.0"
+version = "0.38.0"
 copyright = "WinXMerge contributors"
 category = "Developer Tool"
 short_description = "Cross-platform file diff and merge tool"

--- a/macos/FinderSync/FinderSync.xcodeproj/project.pbxproj
+++ b/macos/FinderSync/FinderSync.xcodeproj/project.pbxproj
@@ -165,7 +165,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 0.37.0;
+				MARKETING_VERSION = 0.38.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.masak1yu.winxmerge.FinderSync;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -189,7 +189,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 0.37.0;
+				MARKETING_VERSION = 0.38.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.masak1yu.winxmerge.FinderSync;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/macos/FinderSync/Info.plist
+++ b/macos/FinderSync/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.37.0</string>
+	<string>0.38.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleSupportedPlatforms</key>

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.37.0</string>
+	<string>0.38.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CFBundleSupportedPlatforms</key>

--- a/scripts/build-macos-bundle.sh
+++ b/scripts/build-macos-bundle.sh
@@ -81,42 +81,45 @@ cp "$RUST_BINARY" "$APP_BUNDLE/Contents/MacOS/winxmerge"
 chmod +x "$APP_BUNDLE/Contents/MacOS/winxmerge"
 
 # Bundle Nix store dylibs into the app and rewrite references.
-# macOS 11+ removed many /usr/lib dylibs from disk (they live in the shared
-# cache), so pointing at /usr/lib is unreliable. Bundling is the standard
-# approach for app distribution.
+# This section is only relevant for Nix-based development environments.
+# On standard macOS toolchains (including GitHub Actions runners), the binary
+# will not reference /nix/store/ paths, so this block is a no-op.
 FRAMEWORKS_DIR="$APP_BUNDLE/Contents/Frameworks"
 
-# Phase 1: Copy Nix dylibs and rewrite references in the main binary
-nix_libs=$(otool -L "$APP_BUNDLE/Contents/MacOS/winxmerge" | grep '/nix/store/' | awk '{print $1}')
-for nix_lib in $nix_libs; do
-    lib_name=$(basename "$nix_lib")
-    echo "  Bundling $lib_name"
-    cp "$nix_lib" "$FRAMEWORKS_DIR/$lib_name"
-    chmod 644 "$FRAMEWORKS_DIR/$lib_name"
-    install_name_tool -change "$nix_lib" "@executable_path/../Frameworks/$lib_name" "$APP_BUNDLE/Contents/MacOS/winxmerge"
-done
+nix_libs=$(otool -L "$APP_BUNDLE/Contents/MacOS/winxmerge" | grep '/nix/store/' | awk '{print $1}' || true)
+if [[ -n "$nix_libs" ]]; then
+    echo "  Detected Nix store dylib references, bundling..."
 
-# Phase 2: Fix references inside the bundled dylibs themselves
-for dylib in "$FRAMEWORKS_DIR"/*.dylib; do
-    [ -f "$dylib" ] || continue
-    lib_name=$(basename "$dylib")
-    # Fix the dylib's own install name
-    install_name_tool -id "@executable_path/../Frameworks/$lib_name" "$dylib"
-    # Rewrite any Nix store references within this dylib
-    for dep in $(otool -L "$dylib" | grep '/nix/store/' | awk '{print $1}'); do
-        dep_name=$(basename "$dep")
-        if [ -f "$FRAMEWORKS_DIR/$dep_name" ]; then
-            install_name_tool -change "$dep" "@executable_path/../Frameworks/$dep_name" "$dylib"
-        else
-            # Dependency not yet bundled — copy it too
-            echo "  Bundling transitive dep $dep_name"
-            cp "$dep" "$FRAMEWORKS_DIR/$dep_name"
-            chmod 644 "$FRAMEWORKS_DIR/$dep_name"
-            install_name_tool -id "@executable_path/../Frameworks/$dep_name" "$FRAMEWORKS_DIR/$dep_name"
-            install_name_tool -change "$dep" "@executable_path/../Frameworks/$dep_name" "$dylib"
-        fi
+    # Phase 1: Copy Nix dylibs and rewrite references in the main binary
+    for nix_lib in $nix_libs; do
+        lib_name=$(basename "$nix_lib")
+        echo "  Bundling $lib_name"
+        cp "$nix_lib" "$FRAMEWORKS_DIR/$lib_name"
+        chmod 644 "$FRAMEWORKS_DIR/$lib_name"
+        install_name_tool -change "$nix_lib" "@executable_path/../Frameworks/$lib_name" "$APP_BUNDLE/Contents/MacOS/winxmerge"
     done
-done
+
+    # Phase 2: Fix references inside the bundled dylibs themselves
+    for dylib in "$FRAMEWORKS_DIR"/*.dylib; do
+        [ -f "$dylib" ] || continue
+        lib_name=$(basename "$dylib")
+        install_name_tool -id "@executable_path/../Frameworks/$lib_name" "$dylib"
+        for dep in $(otool -L "$dylib" | grep '/nix/store/' | awk '{print $1}'); do
+            dep_name=$(basename "$dep")
+            if [ -f "$FRAMEWORKS_DIR/$dep_name" ]; then
+                install_name_tool -change "$dep" "@executable_path/../Frameworks/$dep_name" "$dylib"
+            else
+                echo "  Bundling transitive dep $dep_name"
+                cp "$dep" "$FRAMEWORKS_DIR/$dep_name"
+                chmod 644 "$FRAMEWORKS_DIR/$dep_name"
+                install_name_tool -id "@executable_path/../Frameworks/$dep_name" "$FRAMEWORKS_DIR/$dep_name"
+                install_name_tool -change "$dep" "@executable_path/../Frameworks/$dep_name" "$dylib"
+            fi
+        done
+    done
+else
+    echo "  No Nix store dylib references found, skipping bundling."
+fi
 
 # Copy Info.plist
 cp "$PROJECT_ROOT/macos/Info.plist" "$APP_BUNDLE/Contents/Info.plist"


### PR DESCRIPTION
## Summary
- macOS ビルドをマトリクスから分離し、署名・公証・.app バンドル作成の専用ジョブを追加
- `scripts/build-macos-bundle.sh` の Nix dylib bundling を明示的条件分岐に変更（CI では自動スキップ）
- リリースに署名済み・公証済みの `WinXMerge.app` を `.zip` で添付（Gatekeeper 警告なしで起動可能）

## Test plan
- [x] `v0.38.0-rc1` タグで CI 全ジョブ（Linux, macOS, Windows）成功確認
- [x] macOS: codesign 署名成功、notarytool `Accepted`、stapler staple 成功
- [x] 生成された `.zip` をダウンロードし、`WinXMerge.app` が Gatekeeper 警告なしで起動確認
- [x] FinderSync 拡張が認識されること確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)