### PR TITLE
v0.40.0: code quality — dedup helpers, named constants, enum methods

### DIFF
--- a/src/app/diff_text.rs
+++ b/src/app/diff_text.rs
@@ -284,13 +284,7 @@ pub(super) fn apply_diff_result(
         .iter()
         .enumerate()
         .map(|(i, line)| {
-            let status: i32 = match line.status {
-                LineStatus::Equal => 0,
-                LineStatus::Added => 1,
-                LineStatus::Removed => 2,
-                LineStatus::Modified => 3,
-                LineStatus::Moved => 4,
-            };
+            let status: i32 = line.status.as_i32();
             let diff_index = line_block_idx[i];
 
             // Map line numbers to highlight indices

--- a/src/app/diff_text.rs
+++ b/src/app/diff_text.rs
@@ -107,14 +107,8 @@ pub fn run_diff(window: &MainWindow, state: &mut AppState) {
         .and_then(|m| m.modified().ok());
 
     // Generate title from filenames
-    let left_name = left_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
-    let right_name = right_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
+    let left_name = path_file_name(&left_path);
+    let right_name = path_file_name(&right_path);
     tab.title = format!("{} ↔ {}", left_name, right_name);
 
     // Compute syntax highlights (if enabled)

--- a/src/app/diff_text.rs
+++ b/src/app/diff_text.rs
@@ -257,6 +257,56 @@ pub(super) fn apply_diff_result(
         0
     };
 
+    let diff_line_data =
+        build_diff_line_data(&result, left_highlights, right_highlights, tab_width);
+    let stats = compute_diff_stats(&result);
+
+    tab.diff_positions = result.diff_positions;
+    tab.current_diff = current_diff;
+    let model = ModelRc::new(VecModel::from(diff_line_data.clone()));
+    tab.diff_line_data = diff_line_data;
+    window.set_diff_lines(model);
+    window.set_diff_count(result.diff_count as i32);
+    window.set_current_diff_index(tab.current_diff);
+    window.set_left_path(SharedString::from(
+        tab.left_path
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default(),
+    ));
+    window.set_right_path(SharedString::from(
+        tab.right_path
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default(),
+    ));
+
+    let tab = state.current_tab_mut();
+    tab.diff_stats = stats.clone();
+    sync_diff_stats(window, &stats);
+
+    let status = if result.diff_count == 0 {
+        "Files are identical".to_string()
+    } else if tab.current_diff >= 0 {
+        format!("Difference 1 of {} [{}]", result.diff_count, stats)
+    } else {
+        format!("{} differences found [{}]", result.diff_count, stats)
+    };
+    window.set_status_text(SharedString::from(status));
+
+    // Update detail pane
+    let model = window.get_diff_lines();
+    let tab = state.current_tab();
+    update_detail_pane(window, &model, tab.current_diff, tab);
+}
+
+/// Build `DiffLineData` vec from a `DiffResult`, applying highlights and tab expansion.
+fn build_diff_line_data(
+    result: &DiffResult,
+    left_highlights: &[i32],
+    right_highlights: &[i32],
+    tab_width: usize,
+) -> Vec<DiffLineData> {
     // Build per-line diff block index: all lines in the same contiguous block share one index
     let mut line_block_idx: Vec<i32> = vec![-1; result.lines.len()];
     let mut current_block = -1i32;
@@ -273,7 +323,7 @@ pub(super) fn apply_diff_result(
         }
     }
 
-    let diff_line_data: Vec<DiffLineData> = result
+    result
         .lines
         .iter()
         .enumerate()
@@ -281,7 +331,6 @@ pub(super) fn apply_diff_result(
             let status: i32 = line.status.as_i32();
             let diff_index = line_block_idx[i];
 
-            // Map line numbers to highlight indices
             let left_hl = line
                 .left_line_no
                 .and_then(|n| left_highlights.get((n - 1) as usize).copied())
@@ -291,10 +340,6 @@ pub(super) fn apply_diff_result(
                 .and_then(|n| right_highlights.get((n - 1) as usize).copied())
                 .unwrap_or(-1);
 
-            // Build word-diff segment strings for the detail pane.
-            // Format: \x01-separated list of ALL segments (changed and unchanged),
-            // where even indices (0,2,4,...) = unchanged, odd indices (1,3,5,...) = changed.
-            // If the first segment is changed, an empty unchanged prefix is prepended.
             let left_word_diff = build_word_diff_string(&line.left_word_segments);
             let right_word_diff = build_word_diff_string(&line.right_word_segments);
 
@@ -320,29 +365,11 @@ pub(super) fn apply_diff_result(
                 is_selected: false,
             }
         })
-        .collect();
+        .collect()
+}
 
-    tab.diff_positions = result.diff_positions;
-    tab.current_diff = current_diff;
-    let model = ModelRc::new(VecModel::from(diff_line_data.clone()));
-    tab.diff_line_data = diff_line_data;
-    window.set_diff_lines(model);
-    window.set_diff_count(result.diff_count as i32);
-    window.set_current_diff_index(tab.current_diff);
-    window.set_left_path(SharedString::from(
-        tab.left_path
-            .as_ref()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_default(),
-    ));
-    window.set_right_path(SharedString::from(
-        tab.right_path
-            .as_ref()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_default(),
-    ));
-
-    // Compute diff statistics once and cache them
+/// Compute diff statistics string (e.g. "+3 -1 ~2") from a DiffResult.
+fn compute_diff_stats(result: &DiffResult) -> String {
     let mut added = 0u32;
     let mut removed = 0u32;
     let mut modified = 0u32;
@@ -354,24 +381,7 @@ pub(super) fn apply_diff_result(
             _ => {}
         }
     }
-    let tab = state.current_tab_mut();
-    tab.diff_stats = format!("+{} -{} ~{}", added, removed, modified);
-    let stats = tab.diff_stats.clone();
-    sync_diff_stats(window, &stats);
-
-    let status = if result.diff_count == 0 {
-        "Files are identical".to_string()
-    } else if tab.current_diff >= 0 {
-        format!("Difference 1 of {} [{}]", result.diff_count, stats)
-    } else {
-        format!("{} differences found [{}]", result.diff_count, stats)
-    };
-    window.set_status_text(SharedString::from(status));
-
-    // Update detail pane
-    let model = window.get_diff_lines();
-    let tab = state.current_tab();
-    update_detail_pane(window, &model, tab.current_diff, tab);
+    format!("+{} -{} ~{}", added, removed, modified)
 }
 
 /// Poll the shared result slot and apply if a background diff has finished.

--- a/src/app/folder.rs
+++ b/src/app/folder.rs
@@ -22,14 +22,8 @@ pub fn run_folder_compare(window: &MainWindow, state: &mut AppState) {
     let items = compare_folders_with_options(&left_folder, &right_folder, &options);
     let (folder_item_data, summary) = build_folder_item_data(&items);
 
-    let left_name = left_folder
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
-    let right_name = right_folder
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
+    let left_name = path_file_name(&left_folder);
+    let right_name = path_file_name(&right_folder);
 
     let tab = state.current_tab_mut();
     tab.folder_items = items;
@@ -284,14 +278,8 @@ pub(super) fn run_zip_compare(
     let items = compare_zip_archives(left_bytes, right_bytes, &left_str, &right_str);
     let (folder_item_data, summary) = build_folder_item_data(&items);
 
-    let left_name = left_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
-    let right_name = right_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
+    let left_name = path_file_name(left_path);
+    let right_name = path_file_name(right_path);
 
     let tab = state.current_tab_mut();
     tab.folder_items = items;
@@ -327,14 +315,8 @@ pub(super) fn run_image_compare(
     left_path: &std::path::Path,
     right_path: &std::path::Path,
 ) {
-    let left_name = left_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
-    let right_name = right_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
+    let left_name = path_file_name(left_path);
+    let right_name = path_file_name(right_path);
 
     match compare_images(left_bytes, right_bytes) {
         Err(e) => {

--- a/src/app/folder.rs
+++ b/src/app/folder.rs
@@ -56,12 +56,7 @@ pub(super) fn build_folder_item_data(
     let folder_item_data: Vec<FolderItemData> = items
         .iter()
         .map(|item| {
-            let status: i32 = match item.status {
-                FileCompareStatus::Identical => 0,
-                FileCompareStatus::Different => 1,
-                FileCompareStatus::LeftOnly => 2,
-                FileCompareStatus::RightOnly => 3,
-            };
+            let status: i32 = item.status.as_i32();
             let depth = item
                 .relative_path
                 .chars()
@@ -419,8 +414,6 @@ fn format_size(bytes: u64) -> String {
 // --- Feature: Folder sort ---
 
 pub fn sort_folder(window: &MainWindow, state: &mut AppState, column: i32) {
-    use crate::models::folder_item::FileCompareStatus;
-
     let tab = state.current_tab_mut();
     if tab.view_mode != ViewMode::FolderCompare || tab.folder_items.is_empty() {
         return;
@@ -442,15 +435,7 @@ pub fn sort_folder(window: &MainWindow, state: &mut AppState, column: i32) {
                 .relative_path
                 .to_lowercase()
                 .cmp(&b.relative_path.to_lowercase()),
-            1 => {
-                let status_ord = |s: &FileCompareStatus| match s {
-                    FileCompareStatus::Identical => 0,
-                    FileCompareStatus::Different => 1,
-                    FileCompareStatus::LeftOnly => 2,
-                    FileCompareStatus::RightOnly => 3,
-                };
-                status_ord(&a.status).cmp(&status_ord(&b.status))
-            }
+            1 => a.status.as_i32().cmp(&b.status.as_i32()),
             2 => a.left_size.unwrap_or(0).cmp(&b.left_size.unwrap_or(0)),
             3 => a.right_size.unwrap_or(0).cmp(&b.right_size.unwrap_or(0)),
             4 => a

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -15,10 +15,33 @@ macro_rules! let_diff_vec_model {
 }
 pub(super) use let_diff_vec_model;
 
+/// Downcast the window's three_way_lines model to `&VecModel<ThreeWayLineData>`.
+/// Usage: `let_three_way_vec_model!(model, vec_model, window);`
+macro_rules! let_three_way_vec_model {
+    ($model:ident, $vec:ident, $window:expr) => {
+        let $model = $window.get_three_way_lines();
+        let Some($vec) = $model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() else {
+            return;
+        };
+    };
+}
+pub(super) use let_three_way_vec_model;
+
 /// Mark the current tab as having unsaved changes and sync to the window.
 pub(super) fn mark_dirty(window: &MainWindow, state: &mut AppState) {
     state.current_tab_mut().has_unsaved_changes = true;
     window.set_has_unsaved_changes(true);
+}
+
+/// Mark dirty and enter editing mode (shows "press F5 to compare" hint).
+pub(super) fn mark_dirty_editing(window: &MainWindow, state: &mut AppState) {
+    let tab = state.current_tab_mut();
+    tab.has_unsaved_changes = true;
+    window.set_has_unsaved_changes(true);
+    if !tab.editing_dirty {
+        tab.editing_dirty = true;
+        window.set_status_text(SharedString::from("Editing — press F5 to compare"));
+    }
 }
 
 // --- Native dialog helpers ---

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -44,6 +44,14 @@ pub(super) fn mark_dirty_editing(window: &MainWindow, state: &mut AppState) {
     }
 }
 
+/// Extract the file name from a path as a `String`.
+pub(super) fn path_file_name(p: impl AsRef<std::path::Path>) -> String {
+    p.as_ref()
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default()
+}
+
 // --- Native dialog helpers ---
 
 /// Returns true if the platform supports native file dialogs.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -168,7 +168,7 @@ pub struct TabState {
     pub excel_cells: Vec<ExcelCellData>,
     /// Excel sheet names for the selector
     pub excel_sheet_names: Vec<String>,
-    /// Image comparison cached images and stats (view_mode == 5)
+    /// Image comparison cached images and stats (ViewMode::ImageCompare)
     pub left_image: Option<slint::Image>,
     pub right_image: Option<slint::Image>,
     pub diff_image: Option<slint::Image>,

--- a/src/app/save_export.rs
+++ b/src/app/save_export.rs
@@ -524,11 +524,7 @@ pub fn save_file(window: &MainWindow, state: &mut AppState, save_left: bool) {
 
 /// Save a pane of 3-way diff.  pane: 0=left, 1=base(middle), 2=right.
 pub fn save_three_way_pane(window: &MainWindow, state: &mut AppState, pane: i32) {
-    let model = window.get_three_way_lines();
-    let vec_model = match model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() {
-        Some(m) => m,
-        None => return,
-    };
+    let_three_way_vec_model!(model, vec_model, window);
 
     let text = rebuild_three_way_text(vec_model, pane);
     let tab = state.current_tab();

--- a/src/app/save_export.rs
+++ b/src/app/save_export.rs
@@ -65,45 +65,36 @@ pub fn collect_pending_saves(
             let right_text = state.tabs[i].right_lines.join("\n") + "\n";
             let left_enc = state.tabs[i].left_encoding.clone();
             let right_enc = state.tabs[i].right_encoding.clone();
-            let base_enc = "UTF-8".to_string(); // base uses UTF-8 by default
+            let base_enc = "UTF-8".to_string();
 
-            if let Some(path) = state.tabs[i].left_path.clone() {
-                let bytes = encode_text(&left_text, &left_enc);
-                if let Err(e) = fs::write(&path, bytes) {
-                    window.set_status_text(SharedString::from(format!(
-                        "Error saving {}: {}",
-                        path.display(),
-                        e
-                    )));
-                }
-            } else if !left_text.trim().is_empty() {
-                queue.push((i, 0, left_text, left_enc));
-            }
-            if let Some(path) = state.tabs[i].base_path.clone() {
-                let bytes = encode_text(&base_text, &base_enc);
-                if let Err(e) = fs::write(&path, bytes) {
-                    window.set_status_text(SharedString::from(format!(
-                        "Error saving {}: {}",
-                        path.display(),
-                        e
-                    )));
-                }
-            } else if !base_text.trim().is_empty() {
-                queue.push((i, 2, base_text, base_enc));
-            }
-            if let Some(path) = state.tabs[i].right_path.clone() {
-                let bytes = encode_text(&right_text, &right_enc);
-                if let Err(e) = fs::write(&path, bytes) {
-                    window.set_status_text(SharedString::from(format!(
-                        "Error saving {}: {}",
-                        path.display(),
-                        e
-                    )));
-                }
-            } else if !right_text.trim().is_empty() {
-                queue.push((i, 1, right_text, right_enc));
-            }
-            // Clear unsaved flag if all three sides have paths
+            save_or_queue(
+                window,
+                &mut queue,
+                i,
+                0,
+                &state.tabs[i].left_path,
+                left_text,
+                left_enc,
+            );
+            save_or_queue(
+                window,
+                &mut queue,
+                i,
+                2,
+                &state.tabs[i].base_path,
+                base_text,
+                base_enc,
+            );
+            save_or_queue(
+                window,
+                &mut queue,
+                i,
+                1,
+                &state.tabs[i].right_path,
+                right_text,
+                right_enc,
+            );
+
             if state.tabs[i].left_path.is_some()
                 && state.tabs[i].base_path.is_some()
                 && state.tabs[i].right_path.is_some()
@@ -112,42 +103,60 @@ pub fn collect_pending_saves(
             }
         } else {
             // 2-way tab
-            let left_path = state.tabs[i].left_path.clone();
             let left_enc = state.tabs[i].left_encoding.clone();
             let left_text = rebuild_left_from_data(&state.tabs[i].diff_line_data);
-            if let Some(path) = left_path {
-                let bytes = encode_text(&left_text, &left_enc);
-                if let Err(e) = fs::write(&path, bytes) {
-                    window.set_status_text(SharedString::from(format!(
-                        "Error saving {}: {}",
-                        path.display(),
-                        e
-                    )));
-                }
-            } else if !left_text.trim().is_empty() {
-                queue.push((i, 0, left_text, left_enc));
-            }
-            let right_path = state.tabs[i].right_path.clone();
+            save_or_queue(
+                window,
+                &mut queue,
+                i,
+                0,
+                &state.tabs[i].left_path,
+                left_text,
+                left_enc,
+            );
+
             let right_enc = state.tabs[i].right_encoding.clone();
             let right_text = rebuild_right_from_data(&state.tabs[i].diff_line_data);
-            if let Some(path) = right_path {
-                let bytes = encode_text(&right_text, &right_enc);
-                if let Err(e) = fs::write(&path, bytes) {
-                    window.set_status_text(SharedString::from(format!(
-                        "Error saving {}: {}",
-                        path.display(),
-                        e
-                    )));
-                }
-            } else if !right_text.trim().is_empty() {
-                queue.push((i, 1, right_text, right_enc));
-            }
+            save_or_queue(
+                window,
+                &mut queue,
+                i,
+                1,
+                &state.tabs[i].right_path,
+                right_text,
+                right_enc,
+            );
+
             if state.tabs[i].left_path.is_some() && state.tabs[i].right_path.is_some() {
                 state.tabs[i].has_unsaved_changes = false;
             }
         }
     }
     queue
+}
+
+/// Save text to path if available, otherwise queue for Save-As dialog.
+fn save_or_queue(
+    window: &MainWindow,
+    queue: &mut Vec<(usize, i32, String, String)>,
+    tab_idx: usize,
+    pane: i32,
+    path: &Option<std::path::PathBuf>,
+    text: String,
+    encoding: String,
+) {
+    if let Some(path) = path {
+        let bytes = encode_text(&text, &encoding);
+        if let Err(e) = fs::write(path, bytes) {
+            window.set_status_text(SharedString::from(format!(
+                "Error saving {}: {}",
+                path.display(),
+                e
+            )));
+        }
+    } else if !text.trim().is_empty() {
+        queue.push((tab_idx, pane, text, encoding));
+    }
 }
 
 pub fn export_html_report(window: &MainWindow, state: &AppState) {

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -145,11 +145,7 @@ pub fn replace_text(window: &MainWindow, state: &mut AppState, search: &str, rep
     let search_lower = search.to_lowercase();
 
     if tab.view_mode == ViewMode::ThreeWayText {
-        let model = window.get_three_way_lines();
-        let vec_model = match model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() {
-            Some(m) => m,
-            None => return,
-        };
+        let_three_way_vec_model!(model, vec_model, window);
         let match_idx = tab.search_matches[tab.current_search_match as usize];
         let Some(mut row) = vec_model.row_data(match_idx) else {
             return;
@@ -210,11 +206,7 @@ pub fn replace_all_text(
     let matches = tab.search_matches.clone();
 
     if tab.view_mode == ViewMode::ThreeWayText {
-        let model = window.get_three_way_lines();
-        let vec_model = match model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() {
-            Some(m) => m,
-            None => return,
-        };
+        let_three_way_vec_model!(model, vec_model, window);
         for &match_idx in &matches {
             if let Some(mut row) = vec_model.row_data(match_idx) {
                 row.left_text = SharedString::from(case_insensitive_replace(

--- a/src/app/tab.rs
+++ b/src/app/tab.rs
@@ -90,7 +90,45 @@ pub(super) fn restore_tab(window: &MainWindow, state: &AppState) {
     window.set_view_mode(tab.view_mode.as_i32());
     window.set_active_tab_index(state.active_tab as i32);
 
-    // Restore diff data
+    restore_tab_common(window, tab);
+    restore_tab_diff_options(window, tab);
+
+    // Update detail pane
+    let model = window.get_diff_lines();
+    update_detail_pane(window, &model, tab.current_diff, tab);
+
+    // Restore folder data
+    let folder_model = ModelRc::new(VecModel::from(tab.folder_item_data.clone()));
+    window.set_folder_items(folder_model);
+
+    match tab.view_mode {
+        ViewMode::FolderCompare => {
+            window.set_folder_summary_text(SharedString::from(&tab.folder_summary));
+        }
+        ViewMode::ImageCompare => restore_tab_image(window, tab),
+        ViewMode::Blank => {
+            window.set_status_text(SharedString::from(""));
+        }
+        _ => {}
+    }
+
+    if tab.view_mode.is_table_mode() {
+        restore_tab_table(window, tab);
+    }
+
+    // Restore diff comment for current diff block
+    let comment = tab
+        .diff_comments
+        .get(&(tab.current_diff.max(0) as usize))
+        .cloned()
+        .unwrap_or_default();
+    window.set_current_diff_comment(SharedString::from(comment));
+
+    // Restore status filter
+    window.set_diff_status_filter(tab.diff_status_filter);
+}
+
+fn restore_tab_common(window: &MainWindow, tab: &TabState) {
     let model = ModelRc::new(VecModel::from(tab.diff_line_data.clone()));
     window.set_diff_lines(model);
     window.set_diff_count(tab.diff_positions.len() as i32);
@@ -99,29 +137,6 @@ pub(super) fn restore_tab(window: &MainWindow, state: &AppState) {
     if tab.editing_dirty {
         window.set_status_text(SharedString::from("Editing — press F5 to compare"));
     }
-    window.set_ignore_whitespace(tab.diff_options.ignore_whitespace);
-    window.set_ignore_case(tab.diff_options.ignore_case);
-
-    // Restore per-tab diff options
-    window.set_opt_ignore_blank_lines(tab.diff_options.ignore_blank_lines);
-    window.set_opt_ignore_eol(tab.diff_options.ignore_eol);
-    window.set_opt_detect_moved_lines(tab.diff_options.detect_moved_lines);
-    let filters_str = tab.diff_options.line_filters.join("|");
-    window.set_opt_line_filters(SharedString::from(filters_str));
-    let sub_pats: Vec<&str> = tab
-        .diff_options
-        .substitution_filters
-        .iter()
-        .map(|(p, _)| p.as_str())
-        .collect();
-    let sub_reps: Vec<&str> = tab
-        .diff_options
-        .substitution_filters
-        .iter()
-        .map(|(_, r)| r.as_str())
-        .collect();
-    window.set_opt_substitution_patterns(SharedString::from(sub_pats.join("|")));
-    window.set_opt_substitution_replacements(SharedString::from(sub_reps.join("|")));
 
     sync_diff_stats(window, &tab.diff_stats.clone());
     window.set_left_encoding_display(SharedString::from(&tab.left_encoding));
@@ -141,81 +156,77 @@ pub(super) fn restore_tab(window: &MainWindow, state: &AppState) {
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_default(),
     ));
+}
 
-    // Update detail pane
-    let model = window.get_diff_lines();
-    update_detail_pane(window, &model, tab.current_diff, tab);
+fn restore_tab_diff_options(window: &MainWindow, tab: &TabState) {
+    window.set_ignore_whitespace(tab.diff_options.ignore_whitespace);
+    window.set_ignore_case(tab.diff_options.ignore_case);
+    window.set_opt_ignore_blank_lines(tab.diff_options.ignore_blank_lines);
+    window.set_opt_ignore_eol(tab.diff_options.ignore_eol);
+    window.set_opt_detect_moved_lines(tab.diff_options.detect_moved_lines);
+    let filters_str = tab.diff_options.line_filters.join("|");
+    window.set_opt_line_filters(SharedString::from(filters_str));
+    let sub_pats: Vec<&str> = tab
+        .diff_options
+        .substitution_filters
+        .iter()
+        .map(|(p, _)| p.as_str())
+        .collect();
+    let sub_reps: Vec<&str> = tab
+        .diff_options
+        .substitution_filters
+        .iter()
+        .map(|(_, r)| r.as_str())
+        .collect();
+    window.set_opt_substitution_patterns(SharedString::from(sub_pats.join("|")));
+    window.set_opt_substitution_replacements(SharedString::from(sub_reps.join("|")));
+}
 
-    // Restore folder data
-    let folder_model = ModelRc::new(VecModel::from(tab.folder_item_data.clone()));
-    window.set_folder_items(folder_model);
-
-    if tab.view_mode == ViewMode::FolderCompare {
-        window.set_folder_summary_text(SharedString::from(&tab.folder_summary));
+fn restore_tab_image(window: &MainWindow, tab: &TabState) {
+    if let Some(img) = tab.left_image.clone() {
+        window.set_left_image(img);
     }
-
-    if tab.view_mode == ViewMode::ImageCompare {
-        if let Some(img) = tab.left_image.clone() {
-            window.set_left_image(img);
-        }
-        if let Some(img) = tab.right_image.clone() {
-            window.set_right_image(img);
-        }
-        if let Some(img) = tab.diff_image.clone() {
-            window.set_diff_image(img);
-        }
-        window.set_image_stats(SharedString::from(&tab.image_stats));
-        window.set_image_left_width(tab.image_left_w);
-        window.set_image_left_height(tab.image_left_h);
-        window.set_image_right_width(tab.image_right_w);
-        window.set_image_right_height(tab.image_right_h);
+    if let Some(img) = tab.right_image.clone() {
+        window.set_right_image(img);
     }
-
-    if tab.view_mode.is_table_mode() {
-        window.set_table_rows(ModelRc::new(VecModel::from(tab.table_rows.clone())));
-        window.set_table_columns(ModelRc::new(VecModel::from(tab.table_columns.clone())));
-        window.set_table_content_width_px(tab.table_content_width_px);
-        window.set_diff_count(tab.diff_positions.len() as i32);
-        window.set_current_diff_index(tab.current_diff);
-        // Restore highlight row
-        let highlight_row = if tab.current_diff >= 0 {
-            tab.diff_positions
-                .get(tab.current_diff as usize)
-                .map(|&p| p as i32)
-                .unwrap_or(-1)
-        } else {
-            -1
-        };
-        window.set_table_current_highlight_row(highlight_row);
-
-        if tab.view_mode == ViewMode::ExcelCompare {
-            let sheet_model: ModelRc<SharedString> = ModelRc::new(VecModel::from(
-                std::iter::once(SharedString::from(""))
-                    .chain(
-                        tab.excel_sheet_names
-                            .iter()
-                            .map(|s| SharedString::from(s.as_str())),
-                    )
-                    .collect::<Vec<_>>(),
-            ));
-            window.set_excel_sheet_names(sheet_model);
-        }
+    if let Some(img) = tab.diff_image.clone() {
+        window.set_diff_image(img);
     }
+    window.set_image_stats(SharedString::from(&tab.image_stats));
+    window.set_image_left_width(tab.image_left_w);
+    window.set_image_left_height(tab.image_left_h);
+    window.set_image_right_width(tab.image_right_w);
+    window.set_image_right_height(tab.image_right_h);
+}
 
-    if tab.view_mode == ViewMode::Blank {
-        window.set_status_text(SharedString::from(""));
+fn restore_tab_table(window: &MainWindow, tab: &TabState) {
+    window.set_table_rows(ModelRc::new(VecModel::from(tab.table_rows.clone())));
+    window.set_table_columns(ModelRc::new(VecModel::from(tab.table_columns.clone())));
+    window.set_table_content_width_px(tab.table_content_width_px);
+    window.set_diff_count(tab.diff_positions.len() as i32);
+    window.set_current_diff_index(tab.current_diff);
+    let highlight_row = if tab.current_diff >= 0 {
+        tab.diff_positions
+            .get(tab.current_diff as usize)
+            .map(|&p| p as i32)
+            .unwrap_or(-1)
+    } else {
+        -1
+    };
+    window.set_table_current_highlight_row(highlight_row);
+
+    if tab.view_mode == ViewMode::ExcelCompare {
+        let sheet_model: ModelRc<SharedString> = ModelRc::new(VecModel::from(
+            std::iter::once(SharedString::from(""))
+                .chain(
+                    tab.excel_sheet_names
+                        .iter()
+                        .map(|s| SharedString::from(s.as_str())),
+                )
+                .collect::<Vec<_>>(),
+        ));
+        window.set_excel_sheet_names(sheet_model);
     }
-
-    // Restore diff comment for current diff block
-    let comment = tab
-        .diff_comments
-        .get(&(tab.current_diff.max(0) as usize))
-        .cloned()
-        .unwrap_or_default();
-    window.set_current_diff_comment(SharedString::from(comment));
-
-    // Restore status filter
-    window.set_diff_status_filter(tab.diff_status_filter);
 }
 
 pub fn sync_tab_list(window: &MainWindow, state: &AppState) {

--- a/src/app/table.rs
+++ b/src/app/table.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+const DEFAULT_COL_WIDTH_PX: i32 = 100;
+const MIN_COL_WIDTH_PX: i32 = 30;
+
 // --- Table detail pane ---
 
 /// Update the table detail pane with cell-by-cell comparison for the given row.
@@ -55,7 +58,10 @@ pub(super) fn update_table_detail_pane(window: &MainWindow, state: &AppState, ro
             base_status
         };
         let col_x_px = columns.get(i).map(|c| c.x_px).unwrap_or(0);
-        let col_width_px = columns.get(i).map(|c| c.width_px).unwrap_or(100);
+        let col_width_px = columns
+            .get(i)
+            .map(|c| c.width_px)
+            .unwrap_or(DEFAULT_COL_WIDTH_PX);
 
         detail_cells.push(TableDetailCellData {
             col_name: SharedString::from(col_name),
@@ -167,7 +173,7 @@ pub fn resize_table_column(
         return;
     }
 
-    let new_width = new_width.max(30);
+    let new_width = new_width.max(MIN_COL_WIDTH_PX);
     let old_width = tab.table_columns[col_idx].width_px;
     let width_delta = new_width - old_width;
     if width_delta == 0 {
@@ -392,7 +398,7 @@ pub fn table_use_right_and_next(window: &MainWindow, state: &mut AppState) {
 pub fn table_use_all_left(window: &MainWindow, state: &mut AppState) {
     let positions: Vec<usize> = state.current_tab().diff_positions.clone();
     for (i, _) in positions.iter().enumerate() {
-        table_resolve_to_base_inner(state, i);
+        table_resolve_to_base_inner(state, i, true);
     }
     apply_table_rows_to_window(window, state);
     rebuild_table_diff_positions(window, state);
@@ -401,7 +407,7 @@ pub fn table_use_all_left(window: &MainWindow, state: &mut AppState) {
 pub fn table_use_all_right(window: &MainWindow, state: &mut AppState) {
     let positions: Vec<usize> = state.current_tab().diff_positions.clone();
     for (i, _) in positions.iter().enumerate() {
-        table_resolve_to_base_inner_right(state, i);
+        table_resolve_to_base_inner(state, i, false);
     }
     apply_table_rows_to_window(window, state);
     rebuild_table_diff_positions(window, state);
@@ -420,11 +426,7 @@ fn table_resolve_to_base(
             return;
         }
     }
-    if use_left {
-        table_resolve_to_base_inner(state, diff_index as usize);
-    } else {
-        table_resolve_to_base_inner_right(state, diff_index as usize);
-    }
+    table_resolve_to_base_inner(state, diff_index as usize, use_left);
 
     apply_table_rows_to_window(window, state);
     rebuild_table_diff_positions(window, state);
@@ -441,96 +443,56 @@ fn table_resolve_to_base(
     }));
 }
 
-fn table_resolve_to_base_inner(state: &mut AppState, diff_index: usize) {
+/// Copy source pane's cells to base for a single diff row.
+/// When `use_left` is true, left → base; otherwise right → base.
+/// The opposite pane's cells keep their values but get status re-evaluated.
+fn table_resolve_to_base_inner(state: &mut AppState, diff_index: usize, use_left: bool) {
     let tab = state.current_tab();
     if diff_index >= tab.diff_positions.len() {
         return;
     }
     let row_idx = tab.diff_positions[diff_index];
     let row = &tab.table_rows[row_idx];
-    let src_model = &row.left_cells;
-    let cell_count = src_model.row_count();
-    let mut new_base = Vec::with_capacity(cell_count);
-    let mut new_left = Vec::with_capacity(cell_count);
-    let mut new_right = Vec::with_capacity(cell_count);
-    let right_model = &row.right_cells;
-    for i in 0..cell_count {
-        if let Some(lc) = src_model.row_data(i) {
-            new_base.push(TableCellData {
-                text: lc.text.clone(),
-                status: 0,
-                col_x_px: lc.col_x_px,
-                col_width_px: lc.col_width_px,
-            });
-            new_left.push(TableCellData {
-                text: lc.text.clone(),
-                status: 0,
-                col_x_px: lc.col_x_px,
-                col_width_px: lc.col_width_px,
-            });
-            // Right keeps its value; re-evaluate status vs new base (=left)
-            let rc = right_model.row_data(i);
-            let rv = rc.as_ref().map(|c| c.text.clone()).unwrap_or_default();
-            let st = if rv == lc.text { 0 } else { 1 };
-            new_right.push(TableCellData {
-                text: rv,
-                status: st,
-                col_x_px: lc.col_x_px,
-                col_width_px: lc.col_width_px,
-            });
-        }
-    }
-    let has_diff = new_right.iter().any(|c| c.status != 0);
-    let tab = state.current_tab_mut();
-    tab.table_rows[row_idx] = TableRowData {
-        row_number: tab.table_rows[row_idx].row_number,
-        left_cells: ModelRc::new(VecModel::from(new_left)),
-        right_cells: ModelRc::new(VecModel::from(new_right)),
-        base_cells: ModelRc::new(VecModel::from(new_base)),
-        row_status: if has_diff { 1 } else { 0 },
+    let (src_model, other_model) = if use_left {
+        (&row.left_cells, &row.right_cells)
+    } else {
+        (&row.right_cells, &row.left_cells)
     };
-}
-
-fn table_resolve_to_base_inner_right(state: &mut AppState, diff_index: usize) {
-    let tab = state.current_tab();
-    if diff_index >= tab.diff_positions.len() {
-        return;
-    }
-    let row_idx = tab.diff_positions[diff_index];
-    let row = &tab.table_rows[row_idx];
-    let src_model = &row.right_cells;
     let cell_count = src_model.row_count();
     let mut new_base = Vec::with_capacity(cell_count);
-    let mut new_right = Vec::with_capacity(cell_count);
-    let mut new_left = Vec::with_capacity(cell_count);
-    let left_model = &row.left_cells;
+    let mut new_src = Vec::with_capacity(cell_count);
+    let mut new_other = Vec::with_capacity(cell_count);
     for i in 0..cell_count {
-        if let Some(rc) = src_model.row_data(i) {
+        if let Some(sc) = src_model.row_data(i) {
             new_base.push(TableCellData {
-                text: rc.text.clone(),
+                text: sc.text.clone(),
                 status: 0,
-                col_x_px: rc.col_x_px,
-                col_width_px: rc.col_width_px,
+                col_x_px: sc.col_x_px,
+                col_width_px: sc.col_width_px,
             });
-            new_right.push(TableCellData {
-                text: rc.text.clone(),
+            new_src.push(TableCellData {
+                text: sc.text.clone(),
                 status: 0,
-                col_x_px: rc.col_x_px,
-                col_width_px: rc.col_width_px,
+                col_x_px: sc.col_x_px,
+                col_width_px: sc.col_width_px,
             });
-            // Left keeps its value; re-evaluate status vs new base (=right)
-            let lc = left_model.row_data(i);
-            let lv = lc.as_ref().map(|c| c.text.clone()).unwrap_or_default();
-            let st = if lv == rc.text { 0 } else { 1 };
-            new_left.push(TableCellData {
-                text: lv,
+            let oc = other_model.row_data(i);
+            let ov = oc.as_ref().map(|c| c.text.clone()).unwrap_or_default();
+            let st = if ov == sc.text { 0 } else { 1 };
+            new_other.push(TableCellData {
+                text: ov,
                 status: st,
-                col_x_px: rc.col_x_px,
-                col_width_px: rc.col_width_px,
+                col_x_px: sc.col_x_px,
+                col_width_px: sc.col_width_px,
             });
         }
     }
-    let has_diff = new_left.iter().any(|c| c.status != 0);
+    let has_diff = new_other.iter().any(|c| c.status != 0);
+    let (new_left, new_right) = if use_left {
+        (new_src, new_other)
+    } else {
+        (new_other, new_src)
+    };
     let tab = state.current_tab_mut();
     tab.table_rows[row_idx] = TableRowData {
         row_number: tab.table_rows[row_idx].row_number,
@@ -750,7 +712,7 @@ pub fn new_blank_table(
     // Create an initial 10×5 empty grid so the user can start editing immediately
     let initial_rows = 10;
     let initial_cols = 5;
-    let (columns, content_width_px) = build_columns(initial_cols, 100);
+    let (columns, content_width_px) = build_columns(initial_cols, DEFAULT_COL_WIDTH_PX);
     let empty_grid: Vec<Vec<String>> = (0..initial_rows)
         .map(|_| vec![String::new(); initial_cols])
         .collect();
@@ -841,7 +803,10 @@ pub(super) fn build_table_rows(
             }
 
             let col_x_px = columns.get(c).map(|col| col.x_px).unwrap_or(0);
-            let col_width_px = columns.get(c).map(|col| col.width_px).unwrap_or(100);
+            let col_width_px = columns
+                .get(c)
+                .map(|col| col.width_px)
+                .unwrap_or(DEFAULT_COL_WIDTH_PX);
 
             left_cells.push(TableCellData {
                 text: SharedString::from(lv),
@@ -970,7 +935,10 @@ pub(super) fn build_table_rows_3way(
             }
 
             let col_x_px = columns.get(c).map(|col| col.x_px).unwrap_or(0);
-            let col_width_px = columns.get(c).map(|col| col.width_px).unwrap_or(100);
+            let col_width_px = columns
+                .get(c)
+                .map(|col| col.width_px)
+                .unwrap_or(DEFAULT_COL_WIDTH_PX);
 
             base_cells.push(TableCellData {
                 text: SharedString::from(bv),
@@ -1032,7 +1000,7 @@ pub(super) fn recompute_table_from_csv(
     let need_rebuild_cols = result.max_cols != old_cols;
 
     let columns = if need_rebuild_cols {
-        let (cols, width) = build_columns(result.max_cols, 100);
+        let (cols, width) = build_columns(result.max_cols, DEFAULT_COL_WIDTH_PX);
         let tab = state.current_tab_mut();
         tab.table_columns = cols.clone();
         tab.table_content_width_px = width;
@@ -1085,7 +1053,7 @@ pub(super) fn recompute_table_from_csv_3way(
     let need_rebuild_cols = result.max_cols != old_cols;
 
     let columns = if need_rebuild_cols {
-        let (cols, width) = build_columns(result.max_cols, 100);
+        let (cols, width) = build_columns(result.max_cols, DEFAULT_COL_WIDTH_PX);
         let tab = state.current_tab_mut();
         tab.table_columns = cols.clone();
         tab.table_content_width_px = width;
@@ -1135,20 +1103,14 @@ pub(super) fn run_excel_compare(
 ) {
     let result = compare_excel_full(left_bytes, right_bytes);
 
-    let left_name = left_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
-    let right_name = right_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
+    let left_name = path_file_name(left_path);
+    let right_name = path_file_name(right_path);
 
     // Build SheetTableCache for each sheet
     let mut sheet_cache: std::collections::BTreeMap<String, SheetTableCache> =
         std::collections::BTreeMap::new();
     for (sheet_name, data) in &result.sheets {
-        let (columns, content_width_px) = build_columns(data.max_cols, 100);
+        let (columns, content_width_px) = build_columns(data.max_cols, DEFAULT_COL_WIDTH_PX);
         let rows = build_table_rows(
             &data.left_grid,
             &data.right_grid,
@@ -1173,7 +1135,7 @@ pub(super) fn run_excel_compare(
     for data in result.sheets.values() {
         all_max_cols = all_max_cols.max(data.max_cols);
     }
-    let (all_columns, all_content_width_px) = build_columns(all_max_cols, 100);
+    let (all_columns, all_content_width_px) = build_columns(all_max_cols, DEFAULT_COL_WIDTH_PX);
     for data in result.sheets.values() {
         let rows = build_table_rows(
             &data.left_grid,
@@ -1259,7 +1221,7 @@ pub fn switch_excel_sheet(window: &MainWindow, state: &mut AppState, sheet_name:
         for cache in tab.excel_sheet_data.values() {
             all_rows.extend(cache.rows.clone());
         }
-        let (columns, content_width_px) = build_columns(max_cols, 100);
+        let (columns, content_width_px) = build_columns(max_cols, DEFAULT_COL_WIDTH_PX);
         tab.table_rows = all_rows.clone();
         tab.table_columns = columns.clone();
         tab.table_content_width_px = content_width_px;
@@ -1312,7 +1274,7 @@ pub(super) fn run_csv_compare(
 
     let result = compare_csv_full(&left_text, &right_text);
 
-    let (columns, content_width_px) = build_columns(result.max_cols, 100);
+    let (columns, content_width_px) = build_columns(result.max_cols, DEFAULT_COL_WIDTH_PX);
     let table_rows = build_table_rows(
         &result.left_grid,
         &result.right_grid,
@@ -1322,14 +1284,8 @@ pub(super) fn run_csv_compare(
         &columns,
     );
 
-    let left_name = left_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
-    let right_name = right_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
+    let left_name = path_file_name(left_path);
+    let right_name = path_file_name(right_path);
 
     let diff_count = result.diff_count;
     let delimiter_mismatch = result.delimiter_mismatch;
@@ -1409,7 +1365,7 @@ pub(super) fn run_csv_compare_3way(
 
     let result = compare_csv_full_3way(&base_text, &left_text, &right_text);
 
-    let (columns, content_width_px) = build_columns(result.max_cols, 100);
+    let (columns, content_width_px) = build_columns(result.max_cols, DEFAULT_COL_WIDTH_PX);
     let table_rows = build_table_rows_3way(
         &result.base_grid,
         &result.left_grid,
@@ -1420,14 +1376,8 @@ pub(super) fn run_csv_compare_3way(
         &columns,
     );
 
-    let left_name = left_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
-    let right_name = right_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
+    let left_name = path_file_name(left_path);
+    let right_name = path_file_name(right_path);
 
     let diff_count = result.diff_count;
     let conflict_count = result.conflict_count;

--- a/src/app/table.rs
+++ b/src/app/table.rs
@@ -256,6 +256,38 @@ pub(super) fn apply_table_rows_to_window(window: &MainWindow, state: &AppState) 
     window.set_table_rows(ModelRc::new(VecModel::from(tab.table_rows.clone())));
 }
 
+/// Clone all cells from a model with status reset to 0.
+fn clone_cells_equal(model: &ModelRc<TableCellData>) -> Vec<TableCellData> {
+    (0..model.row_count())
+        .filter_map(|i| {
+            model.row_data(i).map(|c| TableCellData {
+                text: c.text.clone(),
+                status: 0,
+                col_x_px: c.col_x_px,
+                col_width_px: c.col_width_px,
+            })
+        })
+        .collect()
+}
+
+/// Equalize a table row by copying source cells to both left and right.
+fn equalize_table_row(tab: &mut TabState, row_idx: usize, copy_left_to_right: bool) {
+    let src = if copy_left_to_right {
+        &tab.table_rows[row_idx].left_cells
+    } else {
+        &tab.table_rows[row_idx].right_cells
+    };
+    let cells = clone_cells_equal(src);
+    let base_cells_clone = tab.table_rows[row_idx].base_cells.clone();
+    tab.table_rows[row_idx] = TableRowData {
+        row_number: tab.table_rows[row_idx].row_number,
+        left_cells: ModelRc::new(VecModel::from(cells.clone())),
+        right_cells: ModelRc::new(VecModel::from(cells)),
+        base_cells: base_cells_clone,
+        row_status: 0,
+    };
+}
+
 /// Copy left cells to right for a single diff row (table view).
 pub fn table_copy_to_right(window: &MainWindow, state: &mut AppState, diff_index: i32) {
     {
@@ -265,39 +297,7 @@ pub fn table_copy_to_right(window: &MainWindow, state: &mut AppState, diff_index
         }
     }
     let row_idx = state.current_tab().diff_positions[diff_index as usize];
-    let tab = state.current_tab_mut();
-    let row = &tab.table_rows[row_idx];
-
-    // Read left cells
-    let left_model = &row.left_cells;
-    let cell_count = left_model.row_count();
-    let mut new_right_cells = Vec::with_capacity(cell_count);
-    let mut new_left_cells = Vec::with_capacity(cell_count);
-    for i in 0..cell_count {
-        if let Some(lc) = left_model.row_data(i) {
-            new_right_cells.push(TableCellData {
-                text: lc.text.clone(),
-                status: 0,
-                col_x_px: lc.col_x_px,
-                col_width_px: lc.col_width_px,
-            });
-            new_left_cells.push(TableCellData {
-                text: lc.text.clone(),
-                status: 0,
-                col_x_px: lc.col_x_px,
-                col_width_px: lc.col_width_px,
-            });
-        }
-    }
-
-    let base_cells_clone = tab.table_rows[row_idx].base_cells.clone();
-    tab.table_rows[row_idx] = TableRowData {
-        row_number: tab.table_rows[row_idx].row_number,
-        left_cells: ModelRc::new(VecModel::from(new_left_cells)),
-        right_cells: ModelRc::new(VecModel::from(new_right_cells)),
-        base_cells: base_cells_clone,
-        row_status: 0,
-    };
+    equalize_table_row(state.current_tab_mut(), row_idx, true);
 
     apply_table_rows_to_window(window, state);
     rebuild_table_diff_positions(window, state);
@@ -318,38 +318,7 @@ pub fn table_copy_to_left(window: &MainWindow, state: &mut AppState, diff_index:
         }
     }
     let row_idx = state.current_tab().diff_positions[diff_index as usize];
-    let tab = state.current_tab_mut();
-    let row = &tab.table_rows[row_idx];
-
-    let right_model = &row.right_cells;
-    let cell_count = right_model.row_count();
-    let mut new_left_cells = Vec::with_capacity(cell_count);
-    let mut new_right_cells = Vec::with_capacity(cell_count);
-    for i in 0..cell_count {
-        if let Some(rc) = right_model.row_data(i) {
-            new_left_cells.push(TableCellData {
-                text: rc.text.clone(),
-                status: 0,
-                col_x_px: rc.col_x_px,
-                col_width_px: rc.col_width_px,
-            });
-            new_right_cells.push(TableCellData {
-                text: rc.text.clone(),
-                status: 0,
-                col_x_px: rc.col_x_px,
-                col_width_px: rc.col_width_px,
-            });
-        }
-    }
-
-    let base_cells_clone = tab.table_rows[row_idx].base_cells.clone();
-    tab.table_rows[row_idx] = TableRowData {
-        row_number: tab.table_rows[row_idx].row_number,
-        left_cells: ModelRc::new(VecModel::from(new_left_cells)),
-        right_cells: ModelRc::new(VecModel::from(new_right_cells)),
-        base_cells: base_cells_clone,
-        row_status: 0,
-    };
+    equalize_table_row(state.current_tab_mut(), row_idx, false);
 
     apply_table_rows_to_window(window, state);
     rebuild_table_diff_positions(window, state);
@@ -505,90 +474,28 @@ fn table_resolve_to_base_inner(state: &mut AppState, diff_index: usize, use_left
 
 /// Copy all left cells to right for all diff rows (table view).
 pub fn table_copy_all_right(window: &MainWindow, state: &mut AppState) {
-    let tab = state.current_tab();
-    if tab.diff_positions.is_empty() {
+    let positions: Vec<usize> = state.current_tab().diff_positions.clone();
+    if positions.is_empty() {
         return;
     }
-    let positions: Vec<usize> = tab.diff_positions.clone();
-
     let tab = state.current_tab_mut();
     for &row_idx in &positions {
-        let row = &tab.table_rows[row_idx];
-        let left_model = &row.left_cells;
-        let cell_count = left_model.row_count();
-        let mut new_right_cells = Vec::with_capacity(cell_count);
-        let mut new_left_cells = Vec::with_capacity(cell_count);
-        for i in 0..cell_count {
-            if let Some(lc) = left_model.row_data(i) {
-                new_right_cells.push(TableCellData {
-                    text: lc.text.clone(),
-                    status: 0,
-                    col_x_px: lc.col_x_px,
-                    col_width_px: lc.col_width_px,
-                });
-                new_left_cells.push(TableCellData {
-                    text: lc.text.clone(),
-                    status: 0,
-                    col_x_px: lc.col_x_px,
-                    col_width_px: lc.col_width_px,
-                });
-            }
-        }
-        let base_cells_clone = tab.table_rows[row_idx].base_cells.clone();
-        tab.table_rows[row_idx] = TableRowData {
-            row_number: tab.table_rows[row_idx].row_number,
-            left_cells: ModelRc::new(VecModel::from(new_left_cells)),
-            right_cells: ModelRc::new(VecModel::from(new_right_cells)),
-            base_cells: base_cells_clone,
-            row_status: 0,
-        };
+        equalize_table_row(tab, row_idx, true);
     }
-
     apply_table_rows_to_window(window, state);
     rebuild_table_diff_positions(window, state);
 }
 
 /// Copy all right cells to left for all diff rows (table view).
 pub fn table_copy_all_left(window: &MainWindow, state: &mut AppState) {
-    let tab = state.current_tab();
-    if tab.diff_positions.is_empty() {
+    let positions: Vec<usize> = state.current_tab().diff_positions.clone();
+    if positions.is_empty() {
         return;
     }
-    let positions: Vec<usize> = tab.diff_positions.clone();
-
     let tab = state.current_tab_mut();
     for &row_idx in &positions {
-        let row = &tab.table_rows[row_idx];
-        let right_model = &row.right_cells;
-        let cell_count = right_model.row_count();
-        let mut new_left_cells = Vec::with_capacity(cell_count);
-        let mut new_right_cells = Vec::with_capacity(cell_count);
-        for i in 0..cell_count {
-            if let Some(rc) = right_model.row_data(i) {
-                new_left_cells.push(TableCellData {
-                    text: rc.text.clone(),
-                    status: 0,
-                    col_x_px: rc.col_x_px,
-                    col_width_px: rc.col_width_px,
-                });
-                new_right_cells.push(TableCellData {
-                    text: rc.text.clone(),
-                    status: 0,
-                    col_x_px: rc.col_x_px,
-                    col_width_px: rc.col_width_px,
-                });
-            }
-        }
-        let base_cells_clone = tab.table_rows[row_idx].base_cells.clone();
-        tab.table_rows[row_idx] = TableRowData {
-            row_number: tab.table_rows[row_idx].row_number,
-            left_cells: ModelRc::new(VecModel::from(new_left_cells)),
-            right_cells: ModelRc::new(VecModel::from(new_right_cells)),
-            base_cells: base_cells_clone,
-            row_status: 0,
-        };
+        equalize_table_row(tab, row_idx, false);
     }
-
     apply_table_rows_to_window(window, state);
     rebuild_table_diff_positions(window, state);
 }

--- a/src/app/text_edit.rs
+++ b/src/app/text_edit.rs
@@ -1,5 +1,47 @@
 use super::*;
 
+/// Renumber left/right line numbers in the diff model starting from `from_row`.
+/// Counts existing line numbers in rows before `from_row`, then sequentially
+/// renumbers all rows from `from_row` onward.
+fn renumber_diff_lines(vec_model: &VecModel<DiffLineData>, from_row: usize) {
+    let mut left_counter = 0usize;
+    let mut right_counter = 0usize;
+    for i in 0..from_row {
+        if let Some(r) = vec_model.row_data(i) {
+            if !r.left_line_no.is_empty() {
+                left_counter += 1;
+            }
+            if !r.right_line_no.is_empty() {
+                right_counter += 1;
+            }
+        }
+    }
+    for i in from_row..vec_model.row_count() {
+        if let Some(mut r) = vec_model.row_data(i) {
+            let mut changed = false;
+            if !r.left_line_no.is_empty() {
+                left_counter += 1;
+                let new_no = SharedString::from(left_counter.to_string());
+                if r.left_line_no != new_no {
+                    r.left_line_no = new_no;
+                    changed = true;
+                }
+            }
+            if !r.right_line_no.is_empty() {
+                right_counter += 1;
+                let new_no = SharedString::from(right_counter.to_string());
+                if r.right_line_no != new_no {
+                    r.right_line_no = new_no;
+                    changed = true;
+                }
+            }
+            if changed {
+                vec_model.set_row_data(i, r);
+            }
+        }
+    }
+}
+
 pub(super) fn push_undo_snapshot(state: &mut AppState, vec_model: &VecModel<DiffLineData>) {
     let left_text = rebuild_left(vec_model);
     let right_text = rebuild_right(vec_model);
@@ -272,43 +314,7 @@ pub fn insert_line_after(
     };
     vec_model.insert(insert_at, new_row);
 
-    // Renumber line numbers — only rows from insert_at onward changed
-    let mut left_counter = 0usize;
-    let mut right_counter = 0usize;
-    for i in 0..insert_at {
-        if let Some(r) = vec_model.row_data(i) {
-            if !r.left_line_no.is_empty() {
-                left_counter += 1;
-            }
-            if !r.right_line_no.is_empty() {
-                right_counter += 1;
-            }
-        }
-    }
-    for i in insert_at..vec_model.row_count() {
-        if let Some(mut r) = vec_model.row_data(i) {
-            let mut changed = false;
-            if !r.left_line_no.is_empty() {
-                left_counter += 1;
-                let new_no = SharedString::from(left_counter.to_string());
-                if r.left_line_no != new_no {
-                    r.left_line_no = new_no;
-                    changed = true;
-                }
-            }
-            if !r.right_line_no.is_empty() {
-                right_counter += 1;
-                let new_no = SharedString::from(right_counter.to_string());
-                if r.right_line_no != new_no {
-                    r.right_line_no = new_no;
-                    changed = true;
-                }
-            }
-            if changed {
-                vec_model.set_row_data(i, r);
-            }
-        }
-    }
+    renumber_diff_lines(vec_model, insert_at);
 
     mark_dirty_editing(window, state);
     window.set_can_undo(true);
@@ -366,43 +372,7 @@ pub fn delete_line(window: &MainWindow, state: &mut AppState, line_index: i32, i
 
         vec_model.remove(idx);
 
-        // Renumber — only rows from idx onward changed
-        let mut left_counter = 0usize;
-        let mut right_counter = 0usize;
-        for i in 0..idx {
-            if let Some(r) = vec_model.row_data(i) {
-                if !r.left_line_no.is_empty() {
-                    left_counter += 1;
-                }
-                if !r.right_line_no.is_empty() {
-                    right_counter += 1;
-                }
-            }
-        }
-        for i in idx..vec_model.row_count() {
-            if let Some(mut r) = vec_model.row_data(i) {
-                let mut changed = false;
-                if !r.left_line_no.is_empty() {
-                    left_counter += 1;
-                    let new_no = SharedString::from(left_counter.to_string());
-                    if r.left_line_no != new_no {
-                        r.left_line_no = new_no;
-                        changed = true;
-                    }
-                }
-                if !r.right_line_no.is_empty() {
-                    right_counter += 1;
-                    let new_no = SharedString::from(right_counter.to_string());
-                    if r.right_line_no != new_no {
-                        r.right_line_no = new_no;
-                        changed = true;
-                    }
-                }
-                if changed {
-                    vec_model.set_row_data(i, r);
-                }
-            }
-        }
+        renumber_diff_lines(vec_model, idx);
 
         mark_dirty_editing(window, state);
         window.set_can_undo(true);

--- a/src/app/text_edit.rs
+++ b/src/app/text_edit.rs
@@ -310,16 +310,7 @@ pub fn insert_line_after(
         }
     }
 
-    // Mark dirty
-    {
-        let tab = state.current_tab_mut();
-        tab.has_unsaved_changes = true;
-        if !tab.editing_dirty {
-            tab.editing_dirty = true;
-            window.set_status_text(SharedString::from("Editing — press F5 to compare"));
-        }
-    }
-    window.set_has_unsaved_changes(true);
+    mark_dirty_editing(window, state);
     window.set_can_undo(true);
 
     // Move focus to the newly inserted row
@@ -413,13 +404,7 @@ pub fn delete_line(window: &MainWindow, state: &mut AppState, line_index: i32, i
             }
         }
 
-        let tab = state.current_tab_mut();
-        tab.has_unsaved_changes = true;
-        if !tab.editing_dirty {
-            tab.editing_dirty = true;
-            window.set_status_text(SharedString::from("Editing — press F5 to compare"));
-        }
-        window.set_has_unsaved_changes(true);
+        mark_dirty_editing(window, state);
         window.set_can_undo(true);
     }
     // Find the nearest previous editable (non-ghost) row
@@ -489,13 +474,8 @@ pub fn edit_line(
         }
     }
 
-    tab.has_unsaved_changes = true;
-    window.set_has_unsaved_changes(true);
+    mark_dirty_editing(window, state);
     window.set_can_undo(true);
-    if !tab.editing_dirty {
-        tab.editing_dirty = true;
-        window.set_status_text(SharedString::from("Editing — press F5 to compare"));
-    }
 }
 
 pub fn copy_current_line_text(window: &MainWindow, state: &AppState, is_left: bool) {

--- a/src/app/three_way.rs
+++ b/src/app/three_way.rs
@@ -367,71 +367,21 @@ pub(super) fn update_three_way_detail_pane(
 
 /// Copy left text to base (middle) pane for the given diff index.
 pub fn resolve_conflict_use_left(window: &MainWindow, state: &mut AppState, conflict_index: i32) {
-    let tab = state.current_tab();
-    if conflict_index < 0 || conflict_index as usize >= tab.three_way_conflict_positions.len() {
-        return;
-    }
-
-    let pos = tab.three_way_conflict_positions[conflict_index as usize];
-    let model = window.get_three_way_lines();
-    if let Some(vec_model) = model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() {
-        // Find all rows in this block (same conflict_index)
-        let block_ci = vec_model
-            .row_data(pos)
-            .map(|r| r.conflict_index)
-            .unwrap_or(-1);
-        if block_ci < 0 {
-            return;
-        }
-        for i in 0..vec_model.row_count() {
-            if let Some(mut row) = vec_model.row_data(i) {
-                if row.conflict_index == block_ci {
-                    if !row.left_line_no.is_empty() {
-                        // Left has a real line — copy it to base
-                        row.base_text = row.left_text.clone();
-                        if row.base_line_no.is_empty() {
-                            row.base_line_no = SharedString::from("+");
-                        }
-                    }
-                    // Don't touch base_text if left is a ghost row
-                    row.status = if row.left_text == row.right_text {
-                        0
-                    } else {
-                        2
-                    };
-                    vec_model.set_row_data(i, row);
-                }
-            }
-        }
-        // Rebuild tab.base_lines from VecModel (authoritative after copy)
-        let tab = state.current_tab_mut();
-        tab.base_lines = Vec::new();
-        for i in 0..vec_model.row_count() {
-            if let Some(row) = vec_model.row_data(i) {
-                if !row.base_line_no.is_empty() {
-                    tab.base_lines.push(row.base_text.to_string());
-                }
-            }
-        }
-    }
-
-    let tab = state.current_tab_mut();
-    tab.has_unsaved_changes = true;
-    tab.editing_dirty = true;
-    window.set_has_unsaved_changes(true);
-    window.set_status_text(SharedString::from("Left → Middle copied"));
-
-    // BUG-3: Clear stale focus state after copy
-    window.set_three_way_edit_focus_left_row(-1);
-    window.set_three_way_edit_focus_base_row(-1);
-    window.set_three_way_edit_focus_right_row(-1);
-
-    let model = window.get_three_way_lines();
-    update_three_way_detail_pane(window, &model, conflict_index);
+    resolve_conflict_copy_to_base(window, state, conflict_index, true);
 }
 
 /// Copy right text to base (middle) pane for the given diff index.
 pub fn resolve_conflict_use_right(window: &MainWindow, state: &mut AppState, conflict_index: i32) {
+    resolve_conflict_copy_to_base(window, state, conflict_index, false);
+}
+
+/// Copy left or right text to base (middle) pane for the given diff index.
+fn resolve_conflict_copy_to_base(
+    window: &MainWindow,
+    state: &mut AppState,
+    conflict_index: i32,
+    use_left: bool,
+) {
     let tab = state.current_tab();
     if conflict_index < 0 || conflict_index as usize >= tab.three_way_conflict_positions.len() {
         return;
@@ -447,21 +397,27 @@ pub fn resolve_conflict_use_right(window: &MainWindow, state: &mut AppState, con
         if block_ci < 0 {
             return;
         }
+        // Status when source matches the other side: Equal(0).
+        // Status when they differ: LeftChanged(1) if right was copied, RightChanged(2) if left was copied.
+        let diff_status = if use_left { 2 } else { 1 };
         for i in 0..vec_model.row_count() {
             if let Some(mut row) = vec_model.row_data(i) {
                 if row.conflict_index == block_ci {
-                    if !row.right_line_no.is_empty() {
-                        // Right has a real line — copy it to base
-                        row.base_text = row.right_text.clone();
+                    let (src_line_no, src_text) = if use_left {
+                        (&row.left_line_no, row.left_text.clone())
+                    } else {
+                        (&row.right_line_no, row.right_text.clone())
+                    };
+                    if !src_line_no.is_empty() {
+                        row.base_text = src_text.clone();
                         if row.base_line_no.is_empty() {
                             row.base_line_no = SharedString::from("+");
                         }
                     }
-                    // Don't touch base_text if right is a ghost row
                     row.status = if row.left_text == row.right_text {
                         0
                     } else {
-                        1
+                        diff_status
                     };
                     vec_model.set_row_data(i, row);
                 }
@@ -483,7 +439,12 @@ pub fn resolve_conflict_use_right(window: &MainWindow, state: &mut AppState, con
     tab.has_unsaved_changes = true;
     tab.editing_dirty = true;
     window.set_has_unsaved_changes(true);
-    window.set_status_text(SharedString::from("Right → Middle copied"));
+    let msg = if use_left {
+        "Left → Middle copied"
+    } else {
+        "Right → Middle copied"
+    };
+    window.set_status_text(SharedString::from(msg));
 
     // BUG-3: Clear stale focus state after copy
     window.set_three_way_edit_focus_left_row(-1);

--- a/src/app/three_way.rs
+++ b/src/app/three_way.rs
@@ -118,14 +118,8 @@ pub fn run_three_way_diff(window: &MainWindow, state: &mut AppState) {
     let result = compute_three_way_diff(&base_text, &left_text, &right_text);
     let line_data = build_three_way_line_data(&result);
 
-    let left_name = left_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
-    let right_name = right_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
+    let left_name = path_file_name(&left_path);
+    let right_name = path_file_name(&right_path);
 
     let tab = state.current_tab_mut();
     tab.three_way_conflict_positions = result.conflict_positions.clone();

--- a/src/app/three_way.rs
+++ b/src/app/three_way.rs
@@ -263,13 +263,7 @@ fn build_three_way_line_data(result: &ThreeWayResult) -> Vec<ThreeWayLineData> {
         .iter()
         .enumerate()
         .map(|(i, line)| {
-            let status: i32 = match line.status {
-                ThreeWayStatus::Equal => 0,
-                ThreeWayStatus::LeftChanged => 1,
-                ThreeWayStatus::RightChanged => 2,
-                ThreeWayStatus::BothChanged => 3,
-                ThreeWayStatus::Conflict => 4,
-            };
+            let status: i32 = line.status.as_i32();
             let conflict_index = block_indices[i];
             ThreeWayLineData {
                 base_line_no: line
@@ -560,11 +554,7 @@ pub fn three_way_edit_line(
     new_text: &str,
     pane: i32,
 ) {
-    let model = window.get_three_way_lines();
-    let vec_model = match model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() {
-        Some(m) => m,
-        None => return,
-    };
+    let_three_way_vec_model!(model, vec_model, window);
     if row_index < 0 || row_index as usize >= vec_model.row_count() {
         return;
     }
@@ -607,12 +597,7 @@ pub fn three_way_edit_line(
             }
         }
     }
-    tab.has_unsaved_changes = true;
-    window.set_has_unsaved_changes(true);
-    if !tab.editing_dirty {
-        tab.editing_dirty = true;
-        window.set_status_text(SharedString::from("Editing — press F5 to compare"));
-    }
+    mark_dirty_editing(window, state);
 }
 
 /// Insert a blank row after `row_index` in the 3-way view. pane: 0=left, 1=base, 2=right.
@@ -625,11 +610,7 @@ pub fn three_way_insert_line_after(
     if row_index < 0 {
         return;
     }
-    let model = window.get_three_way_lines();
-    let vec_model = match model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() {
-        Some(m) => m,
-        None => return,
-    };
+    let_three_way_vec_model!(model, vec_model, window);
     let insert_at = (row_index + 1) as usize;
     let count = vec_model.row_count();
     if insert_at > count {
@@ -720,13 +701,7 @@ pub fn three_way_insert_line_after(
         1 => window.set_three_way_edit_focus_base_row(insert_at as i32),
         _ => window.set_three_way_edit_focus_right_row(insert_at as i32),
     }
-    let tab = state.current_tab_mut();
-    tab.has_unsaved_changes = true;
-    window.set_has_unsaved_changes(true);
-    if !tab.editing_dirty {
-        tab.editing_dirty = true;
-        window.set_status_text(SharedString::from("Editing — press F5 to compare"));
-    }
+    mark_dirty_editing(window, state);
 }
 
 /// Delete the row at `row_index` in the 3-way view if the pane's cell is empty.
@@ -734,11 +709,7 @@ pub fn three_way_delete_line(window: &MainWindow, state: &mut AppState, row_inde
     if row_index < 0 {
         return;
     }
-    let model = window.get_three_way_lines();
-    let vec_model = match model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() {
-        Some(m) => m,
-        None => return,
-    };
+    let_three_way_vec_model!(model, vec_model, window);
     let idx = row_index as usize;
     if idx >= vec_model.row_count() {
         return;

--- a/src/diff/three_way.rs
+++ b/src/diff/three_way.rs
@@ -10,6 +10,18 @@ pub enum ThreeWayStatus {
     Conflict,     // OP_DIFF:     Left!=Right!=Base
 }
 
+impl ThreeWayStatus {
+    pub fn as_i32(&self) -> i32 {
+        match self {
+            Self::Equal => 0,
+            Self::LeftChanged => 1,
+            Self::RightChanged => 2,
+            Self::BothChanged => 3,
+            Self::Conflict => 4,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ThreeWayLine {
     pub base_text: String,

--- a/src/models/diff_line.rs
+++ b/src/models/diff_line.rs
@@ -7,6 +7,18 @@ pub enum LineStatus {
     Moved,
 }
 
+impl LineStatus {
+    pub fn as_i32(&self) -> i32 {
+        match self {
+            Self::Equal => 0,
+            Self::Added => 1,
+            Self::Removed => 2,
+            Self::Modified => 3,
+            Self::Moved => 4,
+        }
+    }
+}
+
 /// A segment of word-level diff within a modified line.
 /// `changed` = true means this segment differs between left and right.
 #[derive(Debug, Clone)]

--- a/src/models/folder_item.rs
+++ b/src/models/folder_item.rs
@@ -8,6 +8,17 @@ pub enum FileCompareStatus {
     RightOnly,
 }
 
+impl FileCompareStatus {
+    pub fn as_i32(&self) -> i32 {
+        match self {
+            Self::Identical => 0,
+            Self::Different => 1,
+            Self::LeftOnly => 2,
+            Self::RightOnly => 3,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct FolderItem {
     pub relative_path: String,


### PR DESCRIPTION
## Summary
- Add `as_i32()` methods to `LineStatus`, `FileCompareStatus`, `ThreeWayStatus` enums, replacing inline match arms at Slint boundary conversions
- Add `let_three_way_vec_model!` macro and `mark_dirty_editing()` helper to deduplicate repeated patterns across modules
- Extract `renumber_diff_lines()` (was duplicated in insert/delete), `path_file_name()` (16 sites), and `resolve_conflict_copy_to_base()` (merged left/right variants)
- Add `DEFAULT_COL_WIDTH_PX` / `MIN_COL_WIDTH_PX` named constants in table.rs (11 magic number sites)
- Net -165 lines across 12 files, zero warnings, 29/29 tests pass

## Test plan
- [ ] `cargo build --features desktop` — zero warnings
- [ ] `cargo test --features desktop` — 29/29 pass
- [ ] Manual: 2-way text diff — insert/delete lines, undo/redo, save
- [ ] Manual: 3-way text diff — resolve conflict left/right, copy all left/right
- [ ] Manual: CSV/Excel compare — column widths, cell navigation
- [ ] Manual: Folder compare — sort by status column
- [ ] Manual: Search & replace in 2-way and 3-way modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)