### PR TITLE
v0.41.0: fix copy scroll, 3-way table blank, 3-way text data loss

### DIFF
--- a/src/app/save_export.rs
+++ b/src/app/save_export.rs
@@ -49,6 +49,28 @@ pub fn collect_pending_saves(
                 }
             }
         }
+    } else if current_view_mode == ViewMode::ThreeWayText {
+        // Rebuild internal arrays from VecModel (authoritative source) to avoid desync
+        let model = window.get_three_way_lines();
+        if let Some(vec_model) = model.as_any().downcast_ref::<VecModel<ThreeWayLineData>>() {
+            let tab = state.current_tab_mut();
+            tab.left_lines = Vec::new();
+            tab.base_lines = Vec::new();
+            tab.right_lines = Vec::new();
+            for i in 0..vec_model.row_count() {
+                if let Some(row) = vec_model.row_data(i) {
+                    if !row.left_line_no.is_empty() {
+                        tab.left_lines.push(row.left_text.to_string());
+                    }
+                    if !row.base_line_no.is_empty() {
+                        tab.base_lines.push(row.base_text.to_string());
+                    }
+                    if !row.right_line_no.is_empty() {
+                        tab.right_lines.push(row.right_text.to_string());
+                    }
+                }
+            }
+        }
     }
 
     let mut queue = Vec::new();

--- a/src/app/table.rs
+++ b/src/app/table.rs
@@ -302,10 +302,12 @@ pub fn table_copy_to_right(window: &MainWindow, state: &mut AppState, diff_index
     apply_table_rows_to_window(window, state);
     rebuild_table_diff_positions(window, state);
 
-    let tab = state.current_tab();
+    // Update diff index without scrolling — copy-only should not move the view
+    let tab = state.current_tab_mut();
     if !tab.diff_positions.is_empty() {
-        let new_idx = (diff_index as usize).min(tab.diff_positions.len() - 1);
-        update_current_diff(window, state, new_idx as i32);
+        let new_idx = (diff_index as usize).min(tab.diff_positions.len() - 1) as i32;
+        tab.current_diff = new_idx;
+        window.set_current_diff_index(new_idx);
     }
 }
 
@@ -323,23 +325,33 @@ pub fn table_copy_to_left(window: &MainWindow, state: &mut AppState, diff_index:
     apply_table_rows_to_window(window, state);
     rebuild_table_diff_positions(window, state);
 
-    let tab = state.current_tab();
+    // Update diff index without scrolling
+    let tab = state.current_tab_mut();
     if !tab.diff_positions.is_empty() {
-        let new_idx = (diff_index as usize).min(tab.diff_positions.len() - 1);
-        update_current_diff(window, state, new_idx as i32);
+        let new_idx = (diff_index as usize).min(tab.diff_positions.len() - 1) as i32;
+        tab.current_diff = new_idx;
+        window.set_current_diff_index(new_idx);
     }
 }
 
 pub fn table_copy_right_and_next(window: &MainWindow, state: &mut AppState) {
     let diff_index = state.current_tab().current_diff;
     table_copy_to_right(window, state, diff_index);
-    navigate_diff(window, state, true);
+    let tab = state.current_tab();
+    if !tab.diff_positions.is_empty() {
+        let idx = tab.current_diff.min(tab.diff_positions.len() as i32 - 1);
+        update_current_diff(window, state, idx);
+    }
 }
 
 pub fn table_copy_left_and_next(window: &MainWindow, state: &mut AppState) {
     let diff_index = state.current_tab().current_diff;
     table_copy_to_left(window, state, diff_index);
-    navigate_diff(window, state, true);
+    let tab = state.current_tab();
+    if !tab.diff_positions.is_empty() {
+        let idx = tab.current_diff.min(tab.diff_positions.len() as i32 - 1);
+        update_current_diff(window, state, idx);
+    }
 }
 
 /// 3-way table: copy left cells to base cells for a single diff row (use-left).
@@ -355,13 +367,21 @@ pub fn table_use_right(window: &MainWindow, state: &mut AppState, diff_index: i3
 pub fn table_use_left_and_next(window: &MainWindow, state: &mut AppState) {
     let diff_index = state.current_tab().current_diff;
     table_use_left(window, state, diff_index);
-    navigate_diff(window, state, true);
+    let tab = state.current_tab();
+    if !tab.diff_positions.is_empty() {
+        let idx = tab.current_diff.min(tab.diff_positions.len() as i32 - 1);
+        update_current_diff(window, state, idx);
+    }
 }
 
 pub fn table_use_right_and_next(window: &MainWindow, state: &mut AppState) {
     let diff_index = state.current_tab().current_diff;
     table_use_right(window, state, diff_index);
-    navigate_diff(window, state, true);
+    let tab = state.current_tab();
+    if !tab.diff_positions.is_empty() {
+        let idx = tab.current_diff.min(tab.diff_positions.len() as i32 - 1);
+        update_current_diff(window, state, idx);
+    }
 }
 
 pub fn table_use_all_left(window: &MainWindow, state: &mut AppState) {
@@ -400,10 +420,12 @@ fn table_resolve_to_base(
     apply_table_rows_to_window(window, state);
     rebuild_table_diff_positions(window, state);
 
-    let tab = state.current_tab();
+    // Update diff index without scrolling
+    let tab = state.current_tab_mut();
     if !tab.diff_positions.is_empty() {
-        let new_idx = (diff_index as usize).min(tab.diff_positions.len() - 1);
-        update_current_diff(window, state, new_idx as i32);
+        let new_idx = (diff_index as usize).min(tab.diff_positions.len() - 1) as i32;
+        tab.current_diff = new_idx;
+        window.set_current_diff_index(new_idx);
     }
     window.set_status_text(SharedString::from(if use_left {
         "Left → Base copied"
@@ -580,21 +602,72 @@ pub(super) fn table_redo(window: &MainWindow, state: &mut AppState) {
 pub fn new_blank_table_3way(
     window: &MainWindow,
     state: &mut AppState,
-    file_type: i32,
+    _file_type: i32,
     delimiter: &str,
-    newline_in_quotes: bool,
-    quote_char: &str,
+    _newline_in_quotes: bool,
+    _quote_char: &str,
 ) {
-    // 3-way table: base + left + right — reuse new_blank_table logic but with view_mode awareness
-    // For now, open as a 2-pane table view since 3-way table merge is the same as 2-pane in WinMerge
-    new_blank_table(
-        window,
-        state,
-        file_type,
-        delimiter,
-        newline_in_quotes,
-        quote_char,
+    let delim_str = if delimiter == "TAB" { "\t" } else { delimiter };
+    let delim_byte = delim_str.as_bytes().first().copied().unwrap_or(b',');
+    let current_is_blank = {
+        let tab = state.current_tab();
+        tab.view_mode == ViewMode::Blank && tab.left_path.is_none() && tab.right_path.is_none()
+    };
+    if !current_is_blank {
+        add_tab(window, state);
+    }
+
+    let initial_rows = 10;
+    let initial_cols = 5;
+    let (columns, content_width_px) = build_columns(initial_cols, DEFAULT_COL_WIDTH_PX);
+    let empty_grid: Vec<Vec<String>> = (0..initial_rows)
+        .map(|_| vec![String::new(); initial_cols])
+        .collect();
+    let cell_status: Vec<Vec<i32>> = (0..initial_rows)
+        .map(|_| vec![0i32; initial_cols])
+        .collect();
+    let table_rows = build_table_rows_3way(
+        &empty_grid,
+        &empty_grid,
+        &empty_grid,
+        &cell_status,
+        initial_rows,
+        initial_cols,
+        &columns,
     );
+
+    {
+        let tab = state.current_tab_mut();
+        tab.view_mode = ViewMode::CsvThreeWay;
+        tab.left_path = None;
+        tab.right_path = None;
+        tab.base_path = None;
+        tab.title = "Untitled".to_string();
+        tab.excel_cells = Vec::new();
+        tab.table_rows = table_rows.clone();
+        tab.table_columns = columns.clone();
+        tab.table_content_width_px = content_width_px;
+        tab.csv_delimiter = delim_byte;
+        tab.excel_sheet_data.clear();
+        tab.diff_positions.clear();
+        tab.diff_stats = String::new();
+        tab.has_unsaved_changes = false;
+        tab.left_encoding = "UTF-8".to_string();
+        tab.right_encoding = "UTF-8".to_string();
+        tab.base_encoding = "UTF-8".to_string();
+    }
+
+    window.set_view_mode(ViewMode::CsvThreeWay.as_i32());
+    window.set_table_rows(ModelRc::new(VecModel::from(table_rows)));
+    window.set_table_columns(ModelRc::new(VecModel::from(columns)));
+    window.set_table_content_width_px(content_width_px);
+    window.set_diff_count(0);
+    window.set_left_path(SharedString::from(""));
+    window.set_right_path(SharedString::from(""));
+    window.set_base_path(SharedString::from(""));
+    window.set_has_unsaved_changes(false);
+    window.set_status_text(SharedString::from("New blank 3-way table document"));
+    sync_tab_list(window, state);
 }
 
 pub fn new_blank_table(

--- a/src/app/text_edit.rs
+++ b/src/app/text_edit.rs
@@ -132,10 +132,18 @@ pub fn copy_to_right(window: &MainWindow, state: &mut AppState, diff_index: i32)
 
     recompute_diff_from_text(window, state, &left_text, &right_text);
 
-    let tab = state.current_tab();
+    // Update diff index without scrolling — copy-only should not move the view
+    let tab = state.current_tab_mut();
     if !tab.diff_positions.is_empty() {
-        let new_idx = (diff_index as usize).min(tab.diff_positions.len() - 1);
-        update_current_diff(window, state, new_idx as i32);
+        let new_idx = (diff_index as usize).min(tab.diff_positions.len() - 1) as i32;
+        tab.current_diff = new_idx;
+        window.set_current_diff_index(new_idx);
+        window.set_status_text(SharedString::from(format!(
+            "Difference {} of {} [{}]",
+            new_idx + 1,
+            tab.diff_positions.len(),
+            tab.diff_stats
+        )));
     }
     window.set_can_undo(true);
     window.set_can_redo(false);
@@ -145,13 +153,23 @@ pub fn copy_to_right(window: &MainWindow, state: &mut AppState, diff_index: i32)
 pub fn copy_right_and_next(window: &MainWindow, state: &mut AppState) {
     let diff_index = state.current_tab().current_diff;
     copy_to_right(window, state, diff_index);
-    navigate_diff(window, state, true);
+    // After copy, current_diff already points to the next diff (shifted),
+    // so use update_current_diff to scroll to it
+    let tab = state.current_tab();
+    if !tab.diff_positions.is_empty() {
+        let idx = tab.current_diff.min(tab.diff_positions.len() as i32 - 1);
+        update_current_diff(window, state, idx);
+    }
 }
 
 pub fn copy_left_and_next(window: &MainWindow, state: &mut AppState) {
     let diff_index = state.current_tab().current_diff;
     copy_to_left(window, state, diff_index);
-    navigate_diff(window, state, true);
+    let tab = state.current_tab();
+    if !tab.diff_positions.is_empty() {
+        let idx = tab.current_diff.min(tab.diff_positions.len() as i32 - 1);
+        update_current_diff(window, state, idx);
+    }
 }
 
 pub fn copy_to_left(window: &MainWindow, state: &mut AppState, diff_index: i32) {
@@ -171,10 +189,18 @@ pub fn copy_to_left(window: &MainWindow, state: &mut AppState, diff_index: i32) 
 
     recompute_diff_from_text(window, state, &left_text, &right_text);
 
-    let tab = state.current_tab();
+    // Update diff index without scrolling
+    let tab = state.current_tab_mut();
     if !tab.diff_positions.is_empty() {
-        let new_idx = (diff_index as usize).min(tab.diff_positions.len() - 1);
-        update_current_diff(window, state, new_idx as i32);
+        let new_idx = (diff_index as usize).min(tab.diff_positions.len() - 1) as i32;
+        tab.current_diff = new_idx;
+        window.set_current_diff_index(new_idx);
+        window.set_status_text(SharedString::from(format!(
+            "Difference {} of {} [{}]",
+            new_idx + 1,
+            tab.diff_positions.len(),
+            tab.diff_stats
+        )));
     }
     window.set_can_undo(true);
     window.set_can_redo(false);

--- a/src/app/three_way.rs
+++ b/src/app/three_way.rs
@@ -572,30 +572,42 @@ pub fn three_way_insert_line_after(
         return;
     }
 
-    // Sync internal line arrays
-    let current_row = match vec_model.row_data(row_index as usize) {
-        Some(r) => r,
-        None => return,
-    };
-    {
-        let tab = state.current_tab_mut();
+    // Find the correct insertion position in the internal line array.
+    // If the current row is a ghost for this pane (empty line_no), scan backwards
+    // to find the last real line number for this pane.
+    let parse_pane_line_no = |r: &ThreeWayLineData| -> Option<usize> {
         match pane {
-            0 => {
-                let line_no = current_row.left_line_no.parse::<usize>().unwrap_or(1);
-                let pos = line_no.min(tab.left_lines.len());
-                tab.left_lines.insert(pos, String::new());
-            }
-            1 => {
-                let line_no = current_row.base_line_no.parse::<usize>().unwrap_or(1);
-                let pos = line_no.min(tab.base_lines.len());
-                tab.base_lines.insert(pos, String::new());
-            }
-            _ => {
-                let line_no = current_row.right_line_no.parse::<usize>().unwrap_or(1);
-                let pos = line_no.min(tab.right_lines.len());
-                tab.right_lines.insert(pos, String::new());
+            0 => r.left_line_no.parse::<usize>().ok(),
+            1 => r.base_line_no.parse::<usize>().ok(),
+            _ => r.right_line_no.parse::<usize>().ok(),
+        }
+    };
+    let mut insert_pos = 0usize;
+    // First try the current row
+    if let Some(r) = vec_model.row_data(row_index as usize) {
+        if let Some(n) = parse_pane_line_no(&r) {
+            insert_pos = n;
+        } else {
+            // Ghost row: scan backwards for the nearest real line in this pane
+            for i in (0..row_index as usize).rev() {
+                if let Some(r) = vec_model.row_data(i) {
+                    if let Some(n) = parse_pane_line_no(&r) {
+                        insert_pos = n;
+                        break;
+                    }
+                }
             }
         }
+    }
+    {
+        let tab = state.current_tab_mut();
+        let lines = match pane {
+            0 => &mut tab.left_lines,
+            1 => &mut tab.base_lines,
+            _ => &mut tab.right_lines,
+        };
+        let pos = insert_pos.min(lines.len());
+        lines.insert(pos, String::new());
     }
 
     // Build new row: only the edited pane gets a placeholder line number, others empty
@@ -747,7 +759,7 @@ pub fn three_way_delete_line(window: &MainWindow, state: &mut AppState, row_inde
                 vec_model.set_row_data(i, r);
             }
         }
-        mark_dirty(window, state);
+        mark_dirty_editing(window, state);
     }
     let prev = if row_index > 0 { row_index - 1 } else { 0 };
     match pane {


### PR DESCRIPTION
## Summary

- **Copy (←/→) no longer auto-scrolls** to the next diff. Only copy-and-advance (←▼/→▼) scrolls. Fixes incorrect behavior where copy acted identically to copy-and-advance.
- **New blank 3-way table** now opens correctly as `CsvThreeWay` (view-mode 8) with 3 panes (left/base/right), instead of falling back to 2-way `CsvCompare`.
- **Fix 3-way text save data loss**: `collect_pending_saves` rebuilds internal line arrays from VecModel (authoritative source) before save, preventing desync when ghost-row edits corrupt the secondary cache.
- **Fix ghost-row insert position**: `three_way_insert_line_after` scans backwards to find the correct insertion point instead of defaulting to position 1 (`unwrap_or(1)`).
- **Fix dirty flag inconsistency**: `three_way_delete_line` now calls `mark_dirty_editing` instead of `mark_dirty`.

## Files changed

| File | Change |
|------|--------|
| `src/app/text_edit.rs` | Copy functions: no-scroll for copy, scroll for copy-and-next |
| `src/app/table.rs` | Same copy fix for table/3-way table + `new_blank_table_3way` rewrite |
| `src/app/three_way.rs` | Ghost-row insert fix + delete dirty flag fix |
| `src/app/save_export.rs` | VecModel rebuild before 3-way save |

## Test plan

- [x] `cargo build --features desktop` — zero warnings
- [x] `cargo test --features desktop` — 29/29 pass
- [ ] Text diff: copy (←/→) stays in place, copy-and-advance (←▼/→▼) scrolls to next diff
- [ ] New blank 3-way table: 3 panes (left/base/right) visible with column headers
- [ ] 3-way text: insert lines on ghost rows, edit, save — content preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)