### PR TITLE
v0.43.0: Remove DiffLineData — unify on PaneLineData across desktop & WASM

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -45,57 +45,68 @@ fn paste_from_clipboard(callback: impl Fn(String) + 'static) {
     });
 }
 
-fn build_diff_line_data(result: &crate::models::diff_line::DiffResult) -> Vec<crate::DiffLineData> {
-    result
-        .lines
-        .iter()
-        .enumerate()
-        .map(|(i, line)| {
-            let status = match line.status {
-                LineStatus::Equal => 0,
-                LineStatus::Added => 1,
-                LineStatus::Removed => 2,
-                LineStatus::Modified => 3,
-                LineStatus::Moved => 4,
-            };
+/// Build per-pane PaneLineData from a DiffResult.
+fn build_pane_line_data(
+    result: &crate::models::diff_line::DiffResult,
+) -> (Vec<crate::PaneLineData>, Vec<crate::PaneLineData>) {
+    let mut left_lines = Vec::with_capacity(result.lines.len());
+    let mut right_lines = Vec::with_capacity(result.lines.len());
+    for (i, line) in result.lines.iter().enumerate() {
+        let status = match line.status {
+            LineStatus::Equal => 0,
+            LineStatus::Added => 1,
+            LineStatus::Removed => 2,
+            LineStatus::Modified => 3,
+            LineStatus::Moved => 4,
+        };
 
-            let diff_index = if result.diff_positions.contains(&i) {
-                result
-                    .diff_positions
-                    .iter()
-                    .position(|&p| p == i)
-                    .map(|p| p as i32)
-                    .unwrap_or(-1)
-            } else {
-                -1
-            };
+        let diff_index = if result.diff_positions.contains(&i) {
+            result
+                .diff_positions
+                .iter()
+                .position(|&p| p == i)
+                .map(|p| p as i32)
+                .unwrap_or(-1)
+        } else {
+            -1
+        };
 
-            let left_word_diff = encode_word_diff(&line.left_word_segments);
-            let right_word_diff = encode_word_diff(&line.right_word_segments);
+        let left_word_diff = encode_word_diff(&line.left_word_segments);
+        let right_word_diff = encode_word_diff(&line.right_word_segments);
 
-            crate::DiffLineData {
-                left_line_no: SharedString::from(
-                    line.left_line_no.map(|n| n.to_string()).unwrap_or_default(),
-                ),
-                right_line_no: SharedString::from(
-                    line.right_line_no
-                        .map(|n| n.to_string())
-                        .unwrap_or_default(),
-                ),
-                left_text: SharedString::from(&line.left_text),
-                right_text: SharedString::from(&line.right_text),
-                status,
-                is_current_diff: false,
-                diff_index,
-                left_highlight: -1,
-                right_highlight: -1,
-                left_word_diff: SharedString::from(left_word_diff),
-                right_word_diff: SharedString::from(right_word_diff),
-                is_search_match: false,
-                is_selected: false,
-            }
-        })
-        .collect()
+        left_lines.push(crate::PaneLineData {
+            line_no: SharedString::from(
+                line.left_line_no.map(|n| n.to_string()).unwrap_or_default(),
+            ),
+            text: SharedString::from(&line.left_text),
+            is_ghost: line.left_line_no.is_none(),
+            status,
+            diff_index,
+            word_diff: SharedString::from(left_word_diff),
+            is_current_diff: false,
+            is_search_match: false,
+            is_selected: false,
+            highlight: -1,
+        });
+
+        right_lines.push(crate::PaneLineData {
+            line_no: SharedString::from(
+                line.right_line_no
+                    .map(|n| n.to_string())
+                    .unwrap_or_default(),
+            ),
+            text: SharedString::from(&line.right_text),
+            is_ghost: line.right_line_no.is_none(),
+            status,
+            diff_index,
+            word_diff: SharedString::from(right_word_diff),
+            is_current_diff: false,
+            is_search_match: false,
+            is_selected: false,
+            highlight: -1,
+        });
+    }
+    (left_lines, right_lines)
 }
 
 fn encode_word_diff(segments: &[crate::models::diff_line::WordDiffSegment]) -> String {
@@ -116,16 +127,23 @@ fn encode_word_diff(segments: &[crate::models::diff_line::WordDiffSegment]) -> S
 
 /// Update `is_current_diff` flags and scroll to the diff at `diff_idx`.
 fn navigate_to_diff(window: &crate::WasmApp, diff_positions: &[usize], diff_idx: i32) {
-    let lines_model = window.get_diff_lines();
-    let mut lines: Vec<crate::DiffLineData> = (0..lines_model.row_count())
-        .map(|i| lines_model.row_data(i).unwrap())
-        .collect();
-
-    for line in &mut lines {
-        line.is_current_diff = line.diff_index == diff_idx;
+    // Update is_current_diff on both pane models
+    for model_rc in [window.get_left_lines(), window.get_right_lines()] {
+        if let Some(vec_model) = model_rc
+            .as_any()
+            .downcast_ref::<VecModel<crate::PaneLineData>>()
+        {
+            for i in 0..vec_model.row_count() {
+                if let Some(mut row) = vec_model.row_data(i) {
+                    let should = row.diff_index == diff_idx;
+                    if row.is_current_diff != should {
+                        row.is_current_diff = should;
+                        vec_model.set_row_data(i, row);
+                    }
+                }
+            }
+        }
     }
-
-    window.set_diff_lines(ModelRc::new(VecModel::from(lines)));
     window.set_current_diff_index(diff_idx);
 
     // Scroll to the line: row height = (font_size + 2)px (matches DiffView ListView row height)
@@ -252,8 +270,9 @@ pub fn run() {
             *diff_positions.borrow_mut() = result.diff_positions.clone();
             current_diff_idx.set(-1);
 
-            let lines = build_diff_line_data(&result);
-            window.set_diff_lines(ModelRc::new(VecModel::from(lines)));
+            let (left_lines, right_lines) = build_pane_line_data(&result);
+            window.set_left_lines(ModelRc::new(VecModel::from(left_lines)));
+            window.set_right_lines(ModelRc::new(VecModel::from(right_lines)));
             window.set_diff_count(diff_count as i32);
             window.set_current_diff_index(-1);
             window.set_diff_scroll_y(0.0);

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -1,5 +1,5 @@
 import { Button, HorizontalBox, VerticalBox, Palette, CheckBox, LineEdit, ScrollView, ListView, Slider } from "std-widgets.slint";
-import { DiffView, DiffLineData, PaneLineData, WordSegment } from "widgets/diff-view.slint";
+import { DiffView, PaneLineData, WordSegment } from "widgets/diff-view.slint";
 import { DiffView3Way } from "widgets/diff-view-3way.slint";
 import { FolderView, FolderItemData } from "widgets/folder-view.slint";
 import { TabBar, TabData } from "widgets/tab-bar.slint";
@@ -26,7 +26,7 @@ export struct DetailLineData {
     status: int,  // 1=added, 2=removed, 3=modified, 4=moved
 }
 
-export { DiffLineData, PaneLineData, WordSegment, ExcelCellData, FolderItemData, TabData, RecentEntryData, ThemeColors, FileEntryData, TableRowData, TableCellData, TableColumnInfo, TableDetailCellData }
+export { PaneLineData, WordSegment, ExcelCellData, FolderItemData, TabData, RecentEntryData, ThemeColors, FileEntryData, TableRowData, TableCellData, TableColumnInfo, TableDetailCellData }
 
 // Toolbar icon button: fixed 32x32 with image icon + optional overlay text
 component ToolBtn inherits Rectangle {
@@ -156,9 +156,7 @@ export component MainWindow inherits Window {
     min-width: 600px;
     min-height: 400px;
 
-    // File diff properties
-    in-out property <[DiffLineData]> diff-lines;
-    // Per-pane independent buffer properties (Phase 0+)
+    // Per-pane independent buffer properties
     in-out property <[PaneLineData]> left-lines;
     in-out property <[PaneLineData]> right-lines;
     in-out property <[PaneLineData]> middle-lines;
@@ -1110,7 +1108,6 @@ export component MainWindow inherits Window {
         }
 
         if root.view-mode == 0 : DiffView {
-            diff-lines: root.diff-lines;
             left-lines: root.left-lines;
             right-lines: root.right-lines;
             current-diff-index: root.current-diff-index;

--- a/ui/wasm-app.slint
+++ b/ui/wasm-app.slint
@@ -1,5 +1,5 @@
 import { Button, TextEdit, Palette, ScrollView } from "std-widgets.slint";
-import { DiffView, DiffLineData } from "widgets/diff-view.slint";
+import { DiffView, PaneLineData } from "widgets/diff-view.slint";
 import { ThemeColors } from "theme.slint";
 
 export component WasmApp inherits Window {
@@ -13,7 +13,8 @@ export component WasmApp inherits Window {
     in-out property <string> right-text: "";
     in-out property <string> left-title: "Left";
     in-out property <string> right-title: "Right";
-    in-out property <[DiffLineData]> diff-lines;
+    in-out property <[PaneLineData]> left-lines;
+    in-out property <[PaneLineData]> right-lines;
     in-out property <int> diff-count: 0;
     in-out property <int> opt-font-size: 13;
     in-out property <int> current-diff-index: -1;
@@ -70,7 +71,7 @@ export component WasmApp inherits Window {
                     spacing: 8px;
                     alignment: end;
 
-                    if root.diff-lines.length == 0: Button {
+                    if root.left-lines.length == 0: Button {
                         text: "Compare";
                         clicked => { root.compare(); }
                     }
@@ -84,7 +85,7 @@ export component WasmApp inherits Window {
             background: #2a2a3e;
         }
 
-        if diff-lines.length == 0: HorizontalLayout {
+        if left-lines.length == 0: HorizontalLayout {
             vertical-stretch: 1;
             spacing: 0px;
             padding: 0px;
@@ -208,7 +209,7 @@ export component WasmApp inherits Window {
             }
         }
 
-        if diff-lines.length > 0: VerticalLayout {
+        if left-lines.length > 0: VerticalLayout {
             vertical-stretch: 1;
 
             // Navigation bar
@@ -236,7 +237,8 @@ export component WasmApp inherits Window {
                             TouchArea {
                                 mouse-cursor: pointer;
                                 clicked => {
-                                    root.diff-lines = [];
+                                    root.left-lines = [];
+                                    root.right-lines = [];
                                     root.current-diff-index = -1;
                                     root.diff-scroll-y = 0px;
                                 }
@@ -312,7 +314,8 @@ export component WasmApp inherits Window {
 
             diff-view := DiffView {
                 vertical-stretch: 1;
-                diff-lines: root.diff-lines;
+                left-lines: root.left-lines;
+                right-lines: root.right-lines;
                 current-diff-index: root.current-diff-index;
                 left-title: root.left-title;
                 right-title: root.right-title;

--- a/ui/widgets/diff-view.slint
+++ b/ui/widgets/diff-view.slint
@@ -22,28 +22,6 @@ export struct PaneLineData {
     highlight: int,
 }
 
-export struct DiffLineData {
-    left-line-no: string,
-    right-line-no: string,
-    left-text: string,
-    right-text: string,
-    // 0=Equal, 1=Added, 2=Removed, 3=Modified, 4=Moved
-    status: int,
-    is-current-diff: bool,
-    diff-index: int, // -1 if not a diff, otherwise the diff block index
-    // Syntax highlight: -1=none, 0=keyword, 1=string, 2=comment, 3=number, 4=function, etc.
-    left-highlight: int,
-    right-highlight: int,
-    // Word-level diff: text with changed portions marked (for Modified lines)
-    // Format: "unchanged|CHANGED|unchanged|CHANGED" where CHANGED segments are the differing parts
-    left-word-diff: string,
-    right-word-diff: string,
-    // True when this row matches the current search query
-    is-search-match: bool,
-    // True when this row is part of a multi-line selection
-    is-selected: bool,
-}
-
 component DiffLineRow inherits Rectangle {
     in property <string> line-no;
     in-out property <string> text;
@@ -230,7 +208,6 @@ component LocationPane inherits Rectangle {
 export component DiffView inherits Rectangle {
     in property <string> left-title: "Left";
     in property <string> right-title: "Right";
-    in property <[DiffLineData]> diff-lines;  // legacy (kept for bridge; unused by ListViews)
     in property <[PaneLineData]> left-lines;
     in property <[PaneLineData]> right-lines;
     in property <int> current-diff-index: -1;


### PR DESCRIPTION
## Summary
- WASM パスを `DiffLineData` から per-pane `PaneLineData`（left-lines / right-lines）モデルに移行
- `diff-view.slint` から `DiffLineData` struct、`MainWindow`/`DiffView` から `diff-lines` プロパティを削除
- 関連する import/export を整理し、`PaneLineData` をデスクトップ・WASM 双方で唯一の行データ構造に統一

## Test plan
- [ ] `cargo build --features desktop` がグリーン
- [ ] `cargo test --features desktop` がグリーン
- [ ] WASM ビルド（`dist/`）でブラウザ上の 2-way diff 表示が従来どおり動作
- [ ] デスクトップで 2-way / 3-way diff の表示・編集・save/rescan にリグレッションなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)