### PR TITLE
v0.44.0: horizontal scroll for long lines (2-way & 3-way)

### DIFF
--- a/src/app/diff_text.rs
+++ b/src/app/diff_text.rs
@@ -258,6 +258,12 @@ pub(super) fn apply_diff_result(
         build_pane_buffers_2way(&result, left_highlights, right_highlights, tab_width);
     window.set_left_lines(ModelRc::from(left_buf.model.clone()));
     window.set_right_lines(ModelRc::from(right_buf.model.clone()));
+    let font_size = window.get_opt_font_size();
+    let max_w = max_content_width_px(
+        &[left_buf.model.clone(), right_buf.model.clone()],
+        font_size,
+    );
+    window.set_diff_max_content_width_px(max_w);
     tab.left_buffer = Some(left_buf);
     tab.right_buffer = Some(right_buf);
     tab.middle_buffer = None;

--- a/src/app/pane_buffer.rs
+++ b/src/app/pane_buffer.rs
@@ -465,3 +465,22 @@ pub fn renumber_pane_buffer(buffer: &mut PaneBuffer) {
         }
     }
 }
+
+/// Estimate the pixel width needed to display the longest line across all given models.
+/// Used to set `viewport-width` on diff pane ListViews for horizontal scrolling.
+pub fn max_content_width_px(models: &[Rc<VecModel<PaneLineData>>], font_size: i32) -> i32 {
+    let max_len = models
+        .iter()
+        .flat_map(|m| {
+            let count = m.row_count();
+            let m = m.clone();
+            (0..count).map(move |i| m.row_data(i).map(|d| d.text.len()).unwrap_or(0))
+        })
+        .max()
+        .unwrap_or(0);
+    if max_len == 0 {
+        return 0;
+    }
+    // Approximate monospace char width: font_size * 0.62 + line-number column + padding
+    ((max_len as f32) * (font_size as f32) * 0.62) as i32 + 100
+}

--- a/src/app/tab.rs
+++ b/src/app/tab.rs
@@ -135,6 +135,22 @@ fn restore_tab_common(window: &MainWindow, tab: &TabState) {
     } else {
         window.set_right_lines(ModelRc::new(VecModel::from(Vec::<PaneLineData>::new())));
     }
+    // Compute max content width for horizontal scrolling
+    {
+        let font_size = window.get_opt_font_size();
+        let mut models: Vec<std::rc::Rc<slint::VecModel<PaneLineData>>> = Vec::new();
+        if let Some(ref buf) = tab.left_buffer {
+            models.push(buf.model.clone());
+        }
+        if let Some(ref buf) = tab.middle_buffer {
+            models.push(buf.model.clone());
+        }
+        if let Some(ref buf) = tab.right_buffer {
+            models.push(buf.model.clone());
+        }
+        window.set_diff_max_content_width_px(max_content_width_px(&models, font_size));
+    }
+
     window.set_diff_count(tab.diff_positions.len() as i32);
     window.set_current_diff_index(tab.current_diff);
     window.set_has_unsaved_changes(tab.has_unsaved_changes);

--- a/src/app/three_way.rs
+++ b/src/app/three_way.rs
@@ -163,6 +163,15 @@ pub fn run_three_way_diff(window: &MainWindow, state: &mut AppState) {
     window.set_left_lines(ModelRc::from(left_buf.model.clone()));
     window.set_middle_lines(ModelRc::from(middle_buf.model.clone()));
     window.set_right_lines(ModelRc::from(right_buf.model.clone()));
+    let font_size = window.get_opt_font_size();
+    window.set_diff_max_content_width_px(max_content_width_px(
+        &[
+            left_buf.model.clone(),
+            middle_buf.model.clone(),
+            right_buf.model.clone(),
+        ],
+        font_size,
+    ));
     tab.left_buffer = Some(left_buf);
     tab.middle_buffer = Some(middle_buf);
     tab.right_buffer = Some(right_buf);
@@ -207,6 +216,15 @@ pub fn recompute_three_way_from_text(
     window.set_left_lines(ModelRc::from(left_buf.model.clone()));
     window.set_middle_lines(ModelRc::from(middle_buf.model.clone()));
     window.set_right_lines(ModelRc::from(right_buf.model.clone()));
+    let font_size = window.get_opt_font_size();
+    window.set_diff_max_content_width_px(max_content_width_px(
+        &[
+            left_buf.model.clone(),
+            middle_buf.model.clone(),
+            right_buf.model.clone(),
+        ],
+        font_size,
+    ));
     tab.left_buffer = Some(left_buf);
     tab.middle_buffer = Some(middle_buf);
     tab.right_buffer = Some(right_buf);

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -473,6 +473,9 @@ export component MainWindow inherits Window {
     in property <[string]> excel-sheet-names;
     in-out property <string> excel-active-sheet: "";
 
+    // Max content width for horizontal scrolling in text diff views
+    in-out property <int> diff-max-content-width-px: 3000;
+
     // Table grid comparison (view_mode == 4 and 6)
     in-out property <[TableRowData]> table-rows;
     in-out property <[TableColumnInfo]> table-columns;
@@ -1126,6 +1129,7 @@ export component MainWindow inherits Window {
             diff-status-filter: (root.left-path != "" || root.right-path != "") ? root.diff-status-filter : 0;
             editor-font-size: root.opt-font-size;
             editor-tab-width: root.opt-tab-width;
+            max-content-width: root.diff-max-content-width-px * 1px;
             copy-to-right(idx) => { root.copy-to-right(idx); }
             copy-to-left(idx) => { root.copy-to-left(idx); }
             select-diff(idx) => { root.select-diff(idx); }
@@ -1234,6 +1238,7 @@ export component MainWindow inherits Window {
             show-location-pane: root.show-location-pane;
             editor-font-size: root.opt-font-size;
             inline-edit-enabled: root.opt-inline-edit;
+            max-content-width: root.diff-max-content-width-px * 1px;
             edit-focus-left-row <=> root.three-way-edit-focus-left-row;
             edit-focus-base-row <=> root.three-way-edit-focus-base-row;
             edit-focus-right-row <=> root.three-way-edit-focus-right-row;

--- a/ui/widgets/diff-view-3way.slint
+++ b/ui/widgets/diff-view-3way.slint
@@ -84,7 +84,7 @@ component ThreeWayLineRow inherits Rectangle {
                 font-size: root.text-font-size * 1px;
                 font-family: "monospace";
                 vertical-alignment: center;
-                overflow: elide;
+                overflow: clip;
                 color: root.text-color;
             }
         }
@@ -217,6 +217,7 @@ export component DiffView3Way inherits Rectangle {
     in property <int> editor-font-size: 13;
     in property <bool> inline-edit-enabled: false;
     in property <bool> show-location-pane: true;
+    in property <length> max-content-width: 3000px;
 
     // Row index to focus for each pane (-1 = none)
     in-out property <int> edit-focus-left-row: -1;
@@ -318,6 +319,7 @@ export component DiffView3Way inherits Rectangle {
                 border-color: Palette.border;
                 border-width: 1px;
                 left-list := ListView {
+                    viewport-width: Math.max(self.width, root.max-content-width);
                     for line[idx] in left-lines: ThreeWayLineRow {
                         height: (root.editor-font-size + 2) * 1px;
                         line-no: line.line-no;
@@ -347,8 +349,10 @@ export component DiffView3Way inherits Rectangle {
                 min-width: 80px;
                 border-color: Palette.border;
                 border-width: 1px;
-                ListView {
+                base-list := ListView {
                     viewport-y: left-list.viewport-y;
+                    viewport-x: left-list.viewport-x;
+                    viewport-width: Math.max(self.width, root.max-content-width);
                     for line[idx] in middle-lines: ThreeWayLineRow {
                         height: (root.editor-font-size + 2) * 1px;
                         line-no: line.line-no;
@@ -378,8 +382,10 @@ export component DiffView3Way inherits Rectangle {
                 min-width: 80px;
                 border-color: Palette.border;
                 border-width: 1px;
-                ListView {
+                right-list := ListView {
                     viewport-y: left-list.viewport-y;
+                    viewport-x: left-list.viewport-x;
+                    viewport-width: Math.max(self.width, root.max-content-width);
                     for line[idx] in right-lines: ThreeWayLineRow {
                         height: (root.editor-font-size + 2) * 1px;
                         line-no: line.line-no;

--- a/ui/widgets/diff-view.slint
+++ b/ui/widgets/diff-view.slint
@@ -142,7 +142,7 @@ component DiffLineRow inherits Rectangle {
                 font-size: root.text-font-size * 1px;
                 font-family: "monospace";
                 vertical-alignment: center;
-                overflow: root.word-wrap-mode ? clip : elide;
+                overflow: clip;
                 wrap: root.word-wrap-mode ? word-wrap : no-wrap;
                 color: parent.text-color;
             }
@@ -220,6 +220,7 @@ export component DiffView inherits Rectangle {
     in property <bool> show-location-pane: true;
     in property <bool> show-word-diff: true;
     in property <bool> word-wrap-mode: false;
+    in property <length> max-content-width: 3000px;
     in property <bool> diff-only-mode: false;
     // 0=All, 1=Added, 2=Removed, 3=Modified, 4=Moved
     in property <int> diff-status-filter: 0;
@@ -249,6 +250,20 @@ export component DiffView inherits Rectangle {
     changed right-scroll-y => {
         if left-list.viewport-y != right-scroll-y {
             left-list.viewport-y = right-scroll-y;
+        }
+    }
+
+    // Horizontal scroll sync
+    in-out property <length> scroll-x <=> left-list.viewport-x;
+    in-out property <length> right-scroll-x <=> right-list.viewport-x;
+    changed scroll-x => {
+        if right-list.viewport-x != scroll-x {
+            right-list.viewport-x = scroll-x;
+        }
+    }
+    changed right-scroll-x => {
+        if left-list.viewport-x != right-scroll-x {
+            left-list.viewport-x = right-scroll-x;
         }
     }
 
@@ -355,6 +370,7 @@ export component DiffView inherits Rectangle {
                 }
 
                 left-list := ListView {
+                    viewport-width: root.word-wrap-mode ? self.width : Math.max(self.width, root.max-content-width);
                     for line[idx] in left-lines: DiffLineRow {
                         height: (root.diff-only-mode || root.diff-status-filter != 0) && line.status == 0 ? 0px
                               : root.diff-status-filter != 0 && line.status != 0 && line.status != root.diff-status-filter ? 0px
@@ -409,6 +425,7 @@ export component DiffView inherits Rectangle {
                 }
 
                 right-list := ListView {
+                    viewport-width: root.word-wrap-mode ? self.width : Math.max(self.width, root.max-content-width);
                     for line[idx] in right-lines: DiffLineRow {
                         height: (root.diff-only-mode || root.diff-status-filter != 0) && line.status == 0 ? 0px
                               : root.diff-status-filter != 0 && line.status != 0 && line.status != root.diff-status-filter ? 0px


### PR DESCRIPTION
## Summary

- 2-way・3-way差分ビューで行が長い場合、デフォルトで左右スクロールに対応
- `overflow: elide`（末尾 `...` 省略）→ `overflow: clip` + `viewport-width` による横スクロールに変更
- 2-wayは左右ペインの `viewport-x` を双方向同期、3-wayは3ペイン同期

## Changes

- `ui/widgets/diff-view.slint`: `overflow: clip`、`max-content-width` プロパティ、`scroll-x` 双方向同期、ListViewに `viewport-width` バインド
- `ui/widgets/diff-view-3way.slint`: 同様、`base-list`/`right-list` にID付与して `viewport-x` 同期
- `ui/main.slint`: `diff-max-content-width-px` プロパティ追加・バインド
- `src/app/pane_buffer.rs`: `max_content_width_px()` ユーティリティ追加（最長行をフォントサイズから概算）
- `src/app/diff_text.rs` / `three_way.rs` / `tab.rs`: diff計算後・タブ切替時に幅を設定

## Test plan

- [ ] 長い行（200文字超）のファイルを2-wayで開いて横スクロールバーが表示されるか確認
- [ ] 左右ペインが連動してスクロールするか確認
- [ ] 3-wayでも同様に動作するか確認
- [ ] 短い行のファイルではスクロールバーが不要なほど小さいか確認
- [ ] word-wrapモードON時は横スクロールが無効になるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)