### PR TITLE
v0.46.0: Diff エンジンを WinMerge の比較ロジックに寄せる (#50)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6356,7 +6356,7 @@ dependencies = [
 
 [[package]]
 name = "winxmerge"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "arboard",
  "calamine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winxmerge"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2024"
 
 [lib]
@@ -76,7 +76,7 @@ identifier = "io.github.masak1yu.winxmerge"
 icon = ["assets/icons/app-icon-32.png", "assets/icons/app-icon-64.png",
         "assets/icons/app-icon-128.png", "assets/icons/app-icon-256.png",
         "assets/icons/app-icon-512.png", "assets/icons/app-icon.icns"]
-version = "0.45.0"
+version = "0.46.0"
 copyright = "WinXMerge contributors"
 category = "Developer Tool"
 short_description = "Cross-platform file diff and merge tool"

--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ winxmerge [options] <base> <left> <right>   3-way merge
 
 | Option | Effect |
 | --- | --- |
-| `/ignorews[:N]` | Ignore whitespace differences (`:0` disables) |
+| `/ignorews[:N]` | Ignore whitespace differences (`:0` disables, `:1` ignores whitespace changes, `:2` ignores all whitespace) |
 | `/ignorecase[:N]` | Ignore letter case differences |
 | `/ignoreblanklines[:N]` | Ignore blank line differences |
 | `/ignoreeol[:N]` | Ignore line ending differences |

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -10,7 +10,7 @@ use crate::archive::{compare_zip_archives, is_zip_bytes, is_zip_path};
 use crate::csv::{compare_csv_full, compare_csv_full_3way, is_csv_path};
 use crate::diff::engine::{DiffOptions, compute_diff_with_options};
 use crate::diff::folder::{FolderCompareOptions, compare_folders_with_options};
-use crate::diff::three_way::compute_three_way_diff;
+use crate::diff::three_way::compute_three_way_diff_with_options;
 use crate::encoding::{decode_file, detect_eol, encode_text, is_binary};
 use crate::excel::{compare_excel_full, is_excel_path};
 use crate::highlight::{detect_file_type, highlight_lines};

--- a/src/app/options.rs
+++ b/src/app/options.rs
@@ -3,6 +3,7 @@ use super::*;
 pub fn apply_options(window: &MainWindow, state: &mut AppState, settings: &mut AppSettings) {
     // Read options from window
     settings.ignore_whitespace = window.get_ignore_whitespace();
+    settings.ignore_whitespace_all = window.get_opt_ignore_whitespace_all();
     settings.ignore_case = window.get_ignore_case();
     settings.ignore_blank_lines = window.get_opt_ignore_blank_lines();
     settings.ignore_eol = window.get_opt_ignore_eol();
@@ -98,6 +99,7 @@ pub fn apply_options(window: &MainWindow, state: &mut AppState, settings: &mut A
     // Apply diff options to current tab and re-run
     let tab = state.current_tab_mut();
     tab.diff_options.ignore_whitespace = settings.ignore_whitespace;
+    tab.diff_options.ignore_whitespace_all = settings.ignore_whitespace_all;
     tab.diff_options.ignore_case = settings.ignore_case;
     tab.diff_options.ignore_blank_lines = settings.ignore_blank_lines;
     tab.diff_options.ignore_eol = settings.ignore_eol;

--- a/src/app/tab.rs
+++ b/src/app/tab.rs
@@ -53,6 +53,7 @@ pub(super) fn save_current_tab_from_window(window: &MainWindow, state: &mut AppS
     // PaneBuffers are Rc<VecModel> owned by TabState — no snapshot needed.
     // Save per-tab diff options from window state
     tab.diff_options.ignore_whitespace = window.get_ignore_whitespace();
+    tab.diff_options.ignore_whitespace_all = window.get_opt_ignore_whitespace_all();
     tab.diff_options.ignore_case = window.get_ignore_case();
     tab.diff_options.ignore_blank_lines = window.get_opt_ignore_blank_lines();
     tab.diff_options.ignore_eol = window.get_opt_ignore_eol();
@@ -184,6 +185,7 @@ fn restore_tab_common(window: &MainWindow, tab: &TabState) {
 
 fn restore_tab_diff_options(window: &MainWindow, tab: &TabState) {
     window.set_ignore_whitespace(tab.diff_options.ignore_whitespace);
+    window.set_opt_ignore_whitespace_all(tab.diff_options.ignore_whitespace_all);
     window.set_ignore_case(tab.diff_options.ignore_case);
     window.set_opt_ignore_blank_lines(tab.diff_options.ignore_blank_lines);
     window.set_opt_ignore_eol(tab.diff_options.ignore_eol);

--- a/src/app/three_way.rs
+++ b/src/app/three_way.rs
@@ -140,7 +140,9 @@ pub fn run_three_way_diff(window: &MainWindow, state: &mut AppState) {
     let (left_text, left_enc) = decode_file(&left_bytes);
     let (right_text, right_enc) = decode_file(&right_bytes);
 
-    let result = compute_three_way_diff(&base_text, &left_text, &right_text);
+    let diff_options = state.current_tab().diff_options.clone();
+    let result =
+        compute_three_way_diff_with_options(&base_text, &left_text, &right_text, &diff_options);
 
     let left_name = path_file_name(&left_path);
     let right_name = path_file_name(&right_path);
@@ -201,7 +203,9 @@ pub fn recompute_three_way_from_text(
     left_text: &str,
     right_text: &str,
 ) {
-    let result = compute_three_way_diff(base_text, left_text, right_text);
+    let diff_options = state.current_tab().diff_options.clone();
+    let result =
+        compute_three_way_diff_with_options(base_text, left_text, right_text, &diff_options);
 
     let tab = state.current_tab_mut();
     tab.three_way_conflict_positions = result.conflict_positions.clone();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,8 @@ Usage:
   winxmerge [options] <base> <left> <right>   3-way merge
 
 Compare options:
-  /ignorews[:N]          Ignore whitespace differences (:0 disables)
+  /ignorews[:N]          Ignore whitespace differences
+                         (:0 disables, :1 ignores whitespace changes, :2 ignores all whitespace)
   /ignorecase[:N]        Ignore letter case differences
   /ignoreblanklines[:N]  Ignore blank line differences
   /ignoreeol[:N]         Ignore line ending differences
@@ -45,6 +46,7 @@ pub struct CliArgs {
     pub clear_history: bool,
     // None = not specified on the command line (keep the saved setting).
     pub ignore_whitespace: Option<bool>,
+    pub ignore_whitespace_all: Option<bool>,
     pub ignore_case: Option<bool>,
     pub ignore_blank_lines: Option<bool>,
     pub ignore_eol: Option<bool>,
@@ -79,7 +81,8 @@ fn split_option(token: &str) -> Option<(String, Option<&str>)> {
 }
 
 /// WinMerge treats `:0` as "off" and any other value (`:1`, `:2`) as "on".
-/// The engine has a single whitespace mode, so `:1` and `:2` both enable it.
+/// `/ignorews` is the exception — see its match arm below, which distinguishes
+/// `:1` (ignore whitespace change) from `:2` (ignore all whitespace).
 fn flag_value(value: Option<&str>) -> bool {
     value != Some("0")
 }
@@ -110,7 +113,10 @@ pub fn parse(args: &[String]) -> CliArgs {
             "server" => cli.server = true,
             "clear-history" => cli.clear_history = true,
             "ignorews" | "ignore-whitespace" | "w" => {
-                cli.ignore_whitespace = Some(flag_value(value))
+                // WinMerge: :0 = compare, :1 (and bare) = ignore change, :2 = ignore all.
+                let on = value != Some("0");
+                cli.ignore_whitespace = Some(on);
+                cli.ignore_whitespace_all = Some(on && value == Some("2"));
             }
             "ignorecase" | "ignore-case" | "i" => cli.ignore_case = Some(flag_value(value)),
             "ignoreblanklines" | "ignore-blank-lines" | "b" => {
@@ -161,6 +167,26 @@ mod tests {
         let cli = parse_args(&["/ignorews:0", "/ignoreeol:2"]);
         assert_eq!(cli.ignore_whitespace, Some(false));
         assert_eq!(cli.ignore_eol, Some(true));
+    }
+
+    #[test]
+    fn ignorews_levels() {
+        // WinMerge: :0 = off, :1 (and bare) = ignore whitespace change, :2 = ignore all.
+        let cli = parse_args(&["/ignorews"]);
+        assert_eq!(cli.ignore_whitespace, Some(true));
+        assert_eq!(cli.ignore_whitespace_all, Some(false));
+
+        let cli = parse_args(&["/ignorews:1"]);
+        assert_eq!(cli.ignore_whitespace, Some(true));
+        assert_eq!(cli.ignore_whitespace_all, Some(false));
+
+        let cli = parse_args(&["/ignorews:2"]);
+        assert_eq!(cli.ignore_whitespace, Some(true));
+        assert_eq!(cli.ignore_whitespace_all, Some(true));
+
+        let cli = parse_args(&["/ignorews:0"]);
+        assert_eq!(cli.ignore_whitespace, Some(false));
+        assert_eq!(cli.ignore_whitespace_all, Some(false));
     }
 
     #[test]

--- a/src/diff/engine.rs
+++ b/src/diff/engine.rs
@@ -198,27 +198,63 @@ pub fn compute_diff_with_options(
     }
 }
 
+/// Split `s` into identifier / whitespace / punctuation tokens.
+///
+/// Diffing per-token (instead of per-char) keeps a change like `foo` -> `foobar`
+/// from being reported as a split in the middle of the identifier.
+fn tokenize_words(s: &str) -> Vec<&str> {
+    let mut tokens = Vec::new();
+    let mut chars = s.char_indices().peekable();
+    while let Some((start, c)) = chars.next() {
+        let is_word = c.is_alphanumeric() || c == '_';
+        let is_space = c.is_whitespace();
+        let mut end = start + c.len_utf8();
+        if is_word || is_space {
+            while let Some(&(next_idx, next_c)) = chars.peek() {
+                let next_matches = if is_word {
+                    next_c.is_alphanumeric() || next_c == '_'
+                } else {
+                    next_c.is_whitespace()
+                };
+                if !next_matches {
+                    break;
+                }
+                end = next_idx + next_c.len_utf8();
+                chars.next();
+            }
+        }
+        tokens.push(&s[start..end]);
+    }
+    tokens
+}
+
 /// Compute word-level diff between two strings, returning segments for left and right.
 fn compute_word_diff(left: &str, right: &str) -> (Vec<WordDiffSegment>, Vec<WordDiffSegment>) {
+    let left_tokens = tokenize_words(left);
+    let right_tokens = tokenize_words(right);
+
+    // `similar`'s built-in diff_words() doesn't split on punctuation the way we need
+    // (e.g. `foo(bar)` doesn't break at the parens), which is coarser than the plain
+    // char diff this replaces — so we diff our own identifier/whitespace/punct tokens.
     let diff = TextDiff::configure()
         .algorithm(Algorithm::Myers)
-        .diff_chars(left, right);
+        .diff_slices(&left_tokens, &right_tokens);
 
     let mut left_segs: Vec<WordDiffSegment> = Vec::new();
     let mut right_segs: Vec<WordDiffSegment> = Vec::new();
 
     for change in diff.iter_all_changes() {
-        let text = change.value().to_string();
+        let text: &str = change.value();
         match change.tag() {
             ChangeTag::Equal => {
-                push_segment(&mut left_segs, &text, false);
-                push_segment(&mut right_segs, &text, false);
+                push_segment(&mut left_segs, text, false);
+                push_segment(&mut right_segs, text, false);
             }
             ChangeTag::Delete => {
-                push_segment(&mut left_segs, &text, true);
+                push_segment(&mut left_segs, text, true);
             }
             ChangeTag::Insert => {
-                push_segment(&mut right_segs, &text, true);
+                push_segment(&mut right_segs, text, true);
             }
         }
     }
@@ -605,5 +641,24 @@ mod tests {
         assert_eq!(modified.left_line_no, Some(3));
         assert_eq!(modified.right_text, "c");
         assert_eq!(modified.right_line_no, Some(2));
+    }
+
+    #[test]
+    fn test_word_diff_tokenizes_at_word_boundaries() {
+        let (left_segs, right_segs) = compute_word_diff("let foo = 1;", "let foobar = 1;");
+
+        let left_changed: Vec<&str> = left_segs
+            .iter()
+            .filter(|s| s.changed)
+            .map(|s| s.text.as_str())
+            .collect();
+        let right_changed: Vec<&str> = right_segs
+            .iter()
+            .filter(|s| s.changed)
+            .map(|s| s.text.as_str())
+            .collect();
+
+        assert_eq!(left_changed, vec!["foo"]);
+        assert_eq!(right_changed, vec!["foobar"]);
     }
 }

--- a/src/diff/engine.rs
+++ b/src/diff/engine.rs
@@ -306,7 +306,7 @@ fn compile_substitution_filters(filters: &[(String, String)]) -> Vec<(Regex, Str
 /// 0-based line index it came from in `text`.  `ignore_blank_lines` and the line
 /// filters drop lines, so the two numbering schemes diverge and every lookup into
 /// the original text has to go through this map — see `orig_line`.
-fn normalize_text(text: &str, options: &DiffOptions) -> (String, Vec<usize>) {
+pub(super) fn normalize_text(text: &str, options: &DiffOptions) -> (String, Vec<usize>) {
     let line_filters = compile_line_filters(&options.line_filters);
     let sub_filters = compile_substitution_filters(&options.substitution_filters);
 

--- a/src/diff/engine.rs
+++ b/src/diff/engine.rs
@@ -44,8 +44,8 @@ pub fn compute_diff_with_options(
     right_text: &str,
     options: &DiffOptions,
 ) -> DiffResult {
-    let left_normalized = normalize_text(left_text, options);
-    let right_normalized = normalize_text(right_text, options);
+    let (left_normalized, left_map) = normalize_text(left_text, options);
+    let (right_normalized, right_map) = normalize_text(right_text, options);
 
     // Use original lines for display, normalized for comparison
     let left_orig_lines: Vec<&str> = left_text.lines().collect();
@@ -74,19 +74,14 @@ pub fn compute_diff_with_options(
     while i < changes.len() {
         match changes[i].tag() {
             ChangeTag::Equal => {
-                let left_display = left_orig_lines
-                    .get(left_line_no as usize)
-                    .unwrap_or(&"")
-                    .to_string();
-                let right_display = right_orig_lines
-                    .get(right_line_no as usize)
-                    .unwrap_or(&"")
-                    .to_string();
+                let (left_display, left_no) = orig_line(&left_orig_lines, &left_map, left_line_no);
+                let (right_display, right_no) =
+                    orig_line(&right_orig_lines, &right_map, right_line_no);
                 left_line_no += 1;
                 right_line_no += 1;
                 lines.push(DiffLine {
-                    left_line_no: Some(left_line_no),
-                    right_line_no: Some(right_line_no),
+                    left_line_no: Some(left_no),
+                    right_line_no: Some(right_no),
                     left_text: left_display,
                     right_text: right_display,
                     status: LineStatus::Equal,
@@ -118,22 +113,18 @@ pub fn compute_diff_with_options(
                 let word_diff_enabled = line_count <= WORD_DIFF_LINE_LIMIT;
                 let n_pairs = del_indices.len().min(ins_indices.len());
                 for j in 0..n_pairs {
-                    let left_display = left_orig_lines
-                        .get(del_indices[j] as usize)
-                        .unwrap_or(&"")
-                        .to_string();
-                    let right_display = right_orig_lines
-                        .get(ins_indices[j] as usize)
-                        .unwrap_or(&"")
-                        .to_string();
+                    let (left_display, left_no) =
+                        orig_line(&left_orig_lines, &left_map, del_indices[j]);
+                    let (right_display, right_no) =
+                        orig_line(&right_orig_lines, &right_map, ins_indices[j]);
                     let (left_segs, right_segs) = if word_diff_enabled {
                         compute_word_diff(&left_display, &right_display)
                     } else {
                         (Vec::new(), Vec::new())
                     };
                     lines.push(DiffLine {
-                        left_line_no: Some(del_indices[j] + 1),
-                        right_line_no: Some(ins_indices[j] + 1),
+                        left_line_no: Some(left_no),
+                        right_line_no: Some(right_no),
                         left_text: left_display,
                         right_text: right_display,
                         status: LineStatus::Modified,
@@ -143,12 +134,10 @@ pub fn compute_diff_with_options(
                 }
                 // Extra deletions → Removed
                 for j in n_pairs..del_indices.len() {
-                    let left_display = left_orig_lines
-                        .get(del_indices[j] as usize)
-                        .unwrap_or(&"")
-                        .to_string();
+                    let (left_display, left_no) =
+                        orig_line(&left_orig_lines, &left_map, del_indices[j]);
                     lines.push(DiffLine {
-                        left_line_no: Some(del_indices[j] + 1),
+                        left_line_no: Some(left_no),
                         right_line_no: None,
                         left_text: left_display,
                         right_text: String::new(),
@@ -159,13 +148,11 @@ pub fn compute_diff_with_options(
                 }
                 // Extra insertions → Added
                 for j in n_pairs..ins_indices.len() {
-                    let right_display = right_orig_lines
-                        .get(ins_indices[j] as usize)
-                        .unwrap_or(&"")
-                        .to_string();
+                    let (right_display, right_no) =
+                        orig_line(&right_orig_lines, &right_map, ins_indices[j]);
                     lines.push(DiffLine {
                         left_line_no: None,
-                        right_line_no: Some(ins_indices[j] + 1),
+                        right_line_no: Some(right_no),
                         left_text: String::new(),
                         right_text: right_display,
                         status: LineStatus::Added,
@@ -307,12 +294,19 @@ fn compile_substitution_filters(filters: &[(String, String)]) -> Vec<(Regex, Str
         .collect()
 }
 
-fn normalize_text(text: &str, options: &DiffOptions) -> String {
+/// Normalize `text` for comparison.
+///
+/// Returns the normalized text plus a map from each normalized line index to the
+/// 0-based line index it came from in `text`.  `ignore_blank_lines` and the line
+/// filters drop lines, so the two numbering schemes diverge and every lookup into
+/// the original text has to go through this map — see `orig_line`.
+fn normalize_text(text: &str, options: &DiffOptions) -> (String, Vec<usize>) {
     let line_filters = compile_line_filters(&options.line_filters);
     let sub_filters = compile_substitution_filters(&options.substitution_filters);
 
     let mut result = String::with_capacity(text.len());
-    for line in text.lines() {
+    let mut map: Vec<usize> = Vec::new();
+    for (orig_idx, line) in text.lines().enumerate() {
         let mut l = if options.ignore_eol {
             line.trim_end_matches(['\r', '\n']).to_string()
         } else {
@@ -337,8 +331,17 @@ fn normalize_text(text: &str, options: &DiffOptions) -> String {
         }
         result.push_str(&l);
         result.push('\n');
+        map.push(orig_idx);
     }
-    result
+    (result, map)
+}
+
+/// Resolve a normalized line index back to (original text, original 1-based line number).
+fn orig_line(orig_lines: &[&str], map: &[usize], norm_idx: u32) -> (String, u32) {
+    match map.get(norm_idx as usize) {
+        Some(&i) => (orig_lines.get(i).unwrap_or(&"").to_string(), i as u32 + 1),
+        None => (String::new(), norm_idx + 1),
+    }
 }
 
 #[cfg(test)]
@@ -519,5 +522,55 @@ mod tests {
         };
         let result = compute_diff_with_options("hello\n", "hello\n", &opts);
         assert_eq!(result.diff_count, 0, "Invalid regex should be skipped");
+    }
+
+    #[test]
+    fn test_ignore_blank_lines_keeps_original_text_and_line_numbers() {
+        let opts = DiffOptions {
+            ignore_blank_lines: true,
+            ..Default::default()
+        };
+        // The blank line is dropped from the comparison, so the left side's
+        // normalized line 2 is the original line 3.
+        let result = compute_diff_with_options("hello\n\nworld\n", "hello\nworld\n", &opts);
+        assert_eq!(result.diff_count, 0);
+        assert_eq!(result.lines.len(), 2);
+        assert_eq!(result.lines[1].left_text, "world");
+        assert_eq!(result.lines[1].right_text, "world");
+        assert_eq!(result.lines[1].left_line_no, Some(3));
+        assert_eq!(result.lines[1].right_line_no, Some(2));
+    }
+
+    #[test]
+    fn test_line_filter_keeps_original_text_and_line_numbers() {
+        let opts = DiffOptions {
+            line_filters: vec!["^#".to_string()],
+            ..Default::default()
+        };
+        let result = compute_diff_with_options("# note\nkeep\n", "keep\n", &opts);
+        assert_eq!(result.diff_count, 0);
+        assert_eq!(result.lines.len(), 1);
+        assert_eq!(result.lines[0].left_text, "keep");
+        assert_eq!(result.lines[0].left_line_no, Some(2));
+        assert_eq!(result.lines[0].right_line_no, Some(1));
+    }
+
+    #[test]
+    fn test_ignore_blank_lines_with_a_real_difference() {
+        let opts = DiffOptions {
+            ignore_blank_lines: true,
+            ..Default::default()
+        };
+        let result = compute_diff_with_options("a\n\nb\n", "a\nc\n", &opts);
+        assert_eq!(result.diff_count, 1);
+        let modified = result
+            .lines
+            .iter()
+            .find(|l| l.status == LineStatus::Modified)
+            .expect("expected a modified line");
+        assert_eq!(modified.left_text, "b");
+        assert_eq!(modified.left_line_no, Some(3));
+        assert_eq!(modified.right_text, "c");
+        assert_eq!(modified.right_line_no, Some(2));
     }
 }

--- a/src/diff/engine.rs
+++ b/src/diff/engine.rs
@@ -15,6 +15,11 @@ const WORD_DIFF_LINE_LIMIT: usize = 20_000;
 #[derive(Debug, Clone)]
 pub struct DiffOptions {
     pub ignore_whitespace: bool,
+    /// Upgrade `ignore_whitespace` from "ignore whitespace change" to "ignore all
+    /// whitespace" (WinMerge's /ignorews:2).  No effect on its own.
+    // ponytail: two bools instead of a three-state enum — the toolbar toggle, the
+    // settings file and the Slint property all stay plain bools that way.
+    pub ignore_whitespace_all: bool,
     pub ignore_case: bool,
     pub ignore_blank_lines: bool,
     pub ignore_eol: bool,
@@ -29,6 +34,7 @@ impl Default for DiffOptions {
     fn default() -> Self {
         Self {
             ignore_whitespace: false,
+            ignore_whitespace_all: false,
             ignore_case: false,
             ignore_blank_lines: false,
             ignore_eol: false,
@@ -323,7 +329,9 @@ fn normalize_text(text: &str, options: &DiffOptions) -> (String, Vec<usize>) {
         for (re, replacement) in &sub_filters {
             l = re.replace_all(&l, replacement.as_str()).to_string();
         }
-        if options.ignore_whitespace {
+        if options.ignore_whitespace && options.ignore_whitespace_all {
+            l.retain(|c| !c.is_whitespace());
+        } else if options.ignore_whitespace {
             l = l.split_whitespace().collect::<Vec<&str>>().join(" ");
         }
         if options.ignore_case {
@@ -386,6 +394,31 @@ mod tests {
             ..Default::default()
         };
         let result = compute_diff_with_options("hello   world\n", "hello world\n", &opts);
+        assert_eq!(result.diff_count, 0);
+    }
+
+    #[test]
+    fn test_ignore_whitespace_change_only() {
+        let opts = DiffOptions {
+            ignore_whitespace: true,
+            ..Default::default()
+        };
+        // Leading/trailing whitespace and run-length differences collapse.
+        let result = compute_diff_with_options("  a  b\n", "a b\n", &opts);
+        assert_eq!(result.diff_count, 0);
+        // But removing the inner whitespace entirely is still a difference.
+        let result = compute_diff_with_options("a b\n", "ab\n", &opts);
+        assert_eq!(result.diff_count, 1);
+    }
+
+    #[test]
+    fn test_ignore_whitespace_all() {
+        let opts = DiffOptions {
+            ignore_whitespace: true,
+            ignore_whitespace_all: true,
+            ..Default::default()
+        };
+        let result = compute_diff_with_options("a b\n", "ab\n", &opts);
         assert_eq!(result.diff_count, 0);
     }
 

--- a/src/diff/three_way.rs
+++ b/src/diff/three_way.rs
@@ -1,5 +1,7 @@
 use similar::TextDiff;
 
+use crate::diff::engine::{DiffOptions, normalize_text};
+
 /// OP_TYPE equivalent from WinMerge
 #[derive(Debug, Clone, PartialEq)]
 pub enum ThreeWayStatus {
@@ -88,32 +90,64 @@ fn extract_hunks(diff: &TextDiff<'_, '_, '_, str>) -> Vec<Hunk> {
 ///
 /// Runs base↔left and base↔right 2-way diffs, then merges the hunk lists
 /// by walking them in base line-number space, grouping overlapping hunks.
-pub fn compute_three_way_diff(
+/// `options` applies ignore-whitespace / ignore-case / ignore-eol and the
+/// substitution filters to the comparison.
+///
+/// `ignore_blank_lines` and the line filters are forced off before normalizing:
+/// they drop lines, which would desync the base/left/right line-index
+/// correspondence that `merge_hunks` and `build_result_lines` rely on for their
+/// lockstep walk. Supporting them here would need the same net-count
+/// re-mapping described in Gotcha 4 of CLAUDE.md. Only 1:1 per-line
+/// normalization (whitespace/case/eol/substitution) is applied.
+pub fn compute_three_way_diff_with_options(
     base_text: &str,
     left_text: &str,
     right_text: &str,
+    options: &DiffOptions,
 ) -> ThreeWayResult {
+    // Original lines, used for display so the panes always show unmodified text.
     let base_lines: Vec<&str> = base_text.lines().collect();
     let left_lines: Vec<&str> = left_text.lines().collect();
     let right_lines: Vec<&str> = right_text.lines().collect();
 
-    // Step 1: Two pairwise 2-way diffs (base is "old" in both)
-    let left_diff = TextDiff::from_lines(base_text, left_text);
-    let right_diff = TextDiff::from_lines(base_text, right_text);
+    // ponytail: ignore_blank_lines and line filters are not supported in 3-way —
+    // dropping lines would break the base/left/right line correspondence that
+    // merge_hunks and build_result_lines depend on for their lockstep walk.
+    // Supporting them would need the same net-count re-mapping as Gotcha 4.
+    // Force them off so normalization is a pure 1:1 per-line transform.
+    let opts = DiffOptions {
+        ignore_blank_lines: false,
+        line_filters: Vec::new(),
+        ..options.clone()
+    };
+    let (base_norm, _) = normalize_text(base_text, &opts);
+    let (left_norm, _) = normalize_text(left_text, &opts);
+    let (right_norm, _) = normalize_text(right_text, &opts);
+    let base_norm_lines: Vec<&str> = base_norm.lines().collect();
+    let left_norm_lines: Vec<&str> = left_norm.lines().collect();
+    let right_norm_lines: Vec<&str> = right_norm.lines().collect();
+
+    // Step 1: Two pairwise 2-way diffs (base is "old" in both), run on the
+    // normalized text so ignore-whitespace/case/eol take effect.
+    let left_diff = TextDiff::from_lines(&base_norm, &left_norm);
+    let right_diff = TextDiff::from_lines(&base_norm, &right_norm);
 
     let left_hunks = extract_hunks(&left_diff);
     let right_hunks = extract_hunks(&right_diff);
 
-    // Step 2: Merge hunks using Make3wayDiff-style overlap detection
+    // Step 2: Merge hunks using Make3wayDiff-style overlap detection. Uses the
+    // normalized slices — merge_hunks only compares them for left==right
+    // equality and clamps against their length.
     let blocks = merge_hunks(
         &left_hunks,
         &right_hunks,
-        &base_lines,
-        &left_lines,
-        &right_lines,
+        &base_norm_lines,
+        &left_norm_lines,
+        &right_norm_lines,
     );
 
-    // Step 3: Build output lines with ghost-line alignment
+    // Step 3: Build output lines with ghost-line alignment, using the original
+    // (non-normalized) lines so the panes display unmodified text.
     build_result_lines(&blocks, &base_lines, &left_lines, &right_lines)
 }
 
@@ -405,6 +439,12 @@ fn build_result_lines(
 
 /// Rebuild text for one pane from ThreeWayResult lines, skipping ghost lines.
 /// pane: 0=left, 1=base, 2=right.
+/// Default-options shorthand, used by the tests below.
+#[cfg(test)]
+fn compute_three_way_diff(base_text: &str, left_text: &str, right_text: &str) -> ThreeWayResult {
+    compute_three_way_diff_with_options(base_text, left_text, right_text, &DiffOptions::default())
+}
+
 #[cfg(test)]
 fn rebuild_pane_text(lines: &[ThreeWayLine], pane: i32) -> String {
     let mut out = Vec::new();
@@ -1053,5 +1093,80 @@ mod tests {
             assert_eq!(rebuilt_base, *base, "case {}: base mismatch", i);
             assert_eq!(rebuilt_right, *right, "case {}: right mismatch", i);
         }
+    }
+
+    #[test]
+    fn test_ignore_whitespace_no_conflict() {
+        let base = "x\n";
+        let left = "x \n";
+        let right = " x\n";
+
+        let default_result =
+            compute_three_way_diff_with_options(base, left, right, &DiffOptions::default());
+        assert_eq!(default_result.lines[0].status, ThreeWayStatus::Conflict);
+
+        let ignore_ws_result = compute_three_way_diff_with_options(
+            base,
+            left,
+            right,
+            &DiffOptions {
+                ignore_whitespace: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(ignore_ws_result.lines[0].status, ThreeWayStatus::Equal);
+    }
+
+    #[test]
+    fn test_ignore_case_no_conflict() {
+        let base = "abc\n";
+        let left = "ABC\n";
+        let right = "Abc\n";
+
+        let default_result =
+            compute_three_way_diff_with_options(base, left, right, &DiffOptions::default());
+        assert_eq!(default_result.lines[0].status, ThreeWayStatus::Conflict);
+
+        let ignore_case_result = compute_three_way_diff_with_options(
+            base,
+            left,
+            right,
+            &DiffOptions {
+                ignore_case: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(ignore_case_result.lines[0].status, ThreeWayStatus::Equal);
+    }
+
+    #[test]
+    fn test_ignore_blank_lines_is_noop_in_three_way() {
+        // 3-way diff does not support ignore_blank_lines (dropping lines would
+        // desync base/left/right line correspondence — see Gotcha 4). Passing
+        // it must not change the result at all.
+        let base = "a\n\nb\n";
+        let left = "a\n\nb\n";
+        let right = "a\nb\n";
+
+        let default_result =
+            compute_three_way_diff_with_options(base, left, right, &DiffOptions::default());
+        let ignore_blank_result = compute_three_way_diff_with_options(
+            base,
+            left,
+            right,
+            &DiffOptions {
+                ignore_blank_lines: true,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(default_result.lines.len(), ignore_blank_result.lines.len());
+        let default_statuses: Vec<_> = default_result.lines.iter().map(|l| &l.status).collect();
+        let ignore_blank_statuses: Vec<_> = ignore_blank_result
+            .lines
+            .iter()
+            .map(|l| &l.status)
+            .collect();
+        assert_eq!(default_statuses, ignore_blank_statuses);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,7 @@ fn main() {
     {
         let s = settings.borrow();
         window.set_ignore_whitespace(s.ignore_whitespace);
+        window.set_opt_ignore_whitespace_all(s.ignore_whitespace_all);
         window.set_ignore_case(s.ignore_case);
         window.set_show_toolbar(s.show_toolbar);
         window.set_opt_ignore_blank_lines(s.ignore_blank_lines);
@@ -191,6 +192,7 @@ fn main() {
         let mut app = state.borrow_mut();
         let tab = app.current_tab_mut();
         tab.diff_options.ignore_whitespace = s.ignore_whitespace;
+        tab.diff_options.ignore_whitespace_all = s.ignore_whitespace_all;
         tab.diff_options.ignore_case = s.ignore_case;
         tab.diff_options.ignore_blank_lines = s.ignore_blank_lines;
         tab.diff_options.ignore_eol = s.ignore_eol;
@@ -222,6 +224,9 @@ fn main() {
         if let Some(v) = cli.ignore_whitespace {
             tab.diff_options.ignore_whitespace = v;
         }
+        if let Some(v) = cli.ignore_whitespace_all {
+            tab.diff_options.ignore_whitespace_all = v;
+        }
         if let Some(v) = cli.ignore_case {
             tab.diff_options.ignore_case = v;
         }
@@ -245,6 +250,9 @@ fn main() {
         drop(s);
         if let Some(v) = cli.ignore_whitespace {
             window.set_ignore_whitespace(v);
+        }
+        if let Some(v) = cli.ignore_whitespace_all {
+            window.set_opt_ignore_whitespace_all(v);
         }
         if let Some(v) = cli.ignore_case {
             window.set_ignore_case(v);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -15,6 +15,8 @@ pub struct AppSettings {
     #[serde(default)]
     pub ignore_whitespace: bool,
     #[serde(default)]
+    pub ignore_whitespace_all: bool,
+    #[serde(default)]
     pub ignore_case: bool,
     #[serde(default)]
     pub ignore_blank_lines: bool,
@@ -181,6 +183,7 @@ impl Default for AppSettings {
             window_width: default_width(),
             window_height: default_height(),
             ignore_whitespace: false,
+            ignore_whitespace_all: false,
             ignore_case: false,
             ignore_blank_lines: false,
             ignore_eol: false,

--- a/ui/dialogs/options-dialog.slint
+++ b/ui/dialogs/options-dialog.slint
@@ -5,6 +5,7 @@ export component OptionsDialog inherits Rectangle {
 
     // Compare options
     in-out property <bool> opt-ignore-whitespace: false;
+    in-out property <bool> opt-ignore-whitespace-all: false;
     in-out property <bool> opt-ignore-case: false;
     in-out property <bool> opt-ignore-blank-lines: false;
     in-out property <bool> opt-ignore-eol: false;
@@ -146,6 +147,12 @@ export component OptionsDialog inherits Rectangle {
                     text: @tr("Ignore whitespace differences");
                     checked: root.opt-ignore-whitespace;
                     toggled => { root.opt-ignore-whitespace = self.checked; }
+                }
+                CheckBox {
+                    text: @tr("Ignore all whitespace (not just changes in amount)");
+                    enabled: root.opt-ignore-whitespace;
+                    checked: root.opt-ignore-whitespace-all;
+                    toggled => { root.opt-ignore-whitespace-all = self.checked; }
                 }
                 CheckBox {
                     text: @tr("Ignore case differences");

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -435,6 +435,7 @@ export component MainWindow inherits Window {
     // Options dialog state
     in-out property <bool> show-options-dialog: false;
     in-out property <bool> opt-ignore-blank-lines: false;
+    in-out property <bool> opt-ignore-whitespace-all: false;
     in-out property <bool> opt-ignore-eol: false;
     in-out property <bool> opt-detect-moved-lines: true;
     in-out property <bool> opt-show-line-numbers: true;
@@ -2096,6 +2097,7 @@ export component MainWindow inherits Window {
         height: 100%;
         visible-flag: root.show-options-dialog;
         opt-ignore-whitespace <=> root.ignore-whitespace;
+        opt-ignore-whitespace-all <=> root.opt-ignore-whitespace-all;
         opt-ignore-case <=> root.ignore-case;
         opt-ignore-blank-lines <=> root.opt-ignore-blank-lines;
         opt-ignore-eol <=> root.opt-ignore-eol;


### PR DESCRIPTION
Closes #50 の一部（「高」優先2件 + 「中」の word diff トークン化）。

## 変更

### `fix: map normalized line indices back to the original file`

**#50 に載っていなかった実バグ。** `compute_diff_with_options` が正規化後の行番号で元テキスト配列を引いていた。`ignore_blank_lines` と行フィルタは `normalize_text` で行を捨てるので、捨てた本数だけ添字がズレる。

再現（`ignore_blank_lines: true`、左 `"hello\n\nworld\n"` / 右 `"hello\nworld\n"`）:

```
Equal L="hello" R="hello"
Equal L=""      R="world"     ← 左ペインに空行のテキストが出て world が消える
```

同じ添字が表示行番号と `left_highlights`（元テキストから作られる構文ハイライト）にも使われるため、行番号もハイライトも同時にズレていた。`normalize_text` が「正規化行 → 元行」の添字マップを返すようにして解消。

### `feat: separate "ignore whitespace change" from "ignore all whitespace"`

WinMerge の Compare タブは Compare / Ignore change / Ignore all の3択だが、本アプリは Ignore change 相当の1種類しか持っていなかった。`/ignorews:1` と `:2` が同一扱いになり、最も厳しいモードに UI から到達できなかった。

`ignore_whitespace_all` を `ignore_whitespace` の修飾子として追加（単体では無効）。`DiffOptions` / `AppSettings` / オプションダイアログ / タブ単位の保存復元 / CLI パースに配線。

### `feat: apply DiffOptions to 3-way diff`

`compute_three_way_diff` が DiffOptions を一切受け取っておらず、「空白を無視」「大文字小文字を無視」が 3-way に全く効いていなかった。

正規化テキストで 2-way diff と `merge_hunks` を回し、`build_result_lines` には元テキストを渡す（表示は元のまま）。**`ignore_blank_lines` と行フィルタは 3-way では非対応**：行を落とすと base/left/right の行対応が崩れ、`merge_hunks` / `build_result_lines` の lockstep 走査が成立しない（CLAUDE.md Gotcha 4 と同種の再マッピングが必要になる）。正規化前に強制 off にし、理由をコメントで明記。

### `feat: tokenize word diff at word boundaries`

`compute_word_diff` が `diff_chars` だったため、`foo` → `foobar` の変更が識別子の途中で割れて（`foo`/`bar`）ハイライトが読みにくかった。`char_indices()` ベースの自前トークナイザ（識別子の連続 / 空白の連続 / それ以外1文字）+ `diff_slices` に置き換え。

`similar::TextDiff::diff_words` は不採用：`foo(bar)` が句読点で割れず、置き換え前の文字 diff より粗くなるため。

## 検証

- `cargo test --features desktop` → 50 passed / 0 failed（新規テスト7件）
- `cargo build --features desktop` → 警告ゼロ
- `cargo fmt -- --check` → OK

**手動 GUI 検証は未実施。** 特に以下は目視確認が必要:

- 空行が片側だけにあるファイル対を「空行を無視」ONで開き、左右のテキスト・行番号・構文ハイライトが揃うこと
- `/ignorews:0` / `:1` / `:2` の差、オプションダイアログの新チェックボックスが再起動後も保持されること
- 3-way で base に対し左が空白のみ変更・右が実質変更のとき、「空白を無視」ONで conflict にならないこと
- word diff のハイライトが識別子単位になっていること

## スコープ外（#50 に残す）

移動行のブロック単位検出と類似度 fuzzy マッチ、3-way conflict ブロック内の word diff、`/ignorecomments`、数値無視。

## 関連

- #63 — `ignore_blank_lines` / 行フィルタで無視した行が保存時にファイルから消える（本 PR の調査で発見。`LineStatus` に新バリアントが必要で網羅 match を全部触るため別対応）
- #65 — clippy 129 件（CI が `continue-on-error: true` で見逃していた既存の負債）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AmGSxYu2V8ZR4ZXQF7Dnw