### PR TITLE
Fix: check Excel formats before ZIP detection so .xlsx/.xlsm/.ods open the table view

### DIFF
--- a/src/app/diff_text.rs
+++ b/src/app/diff_text.rs
@@ -16,11 +16,9 @@ pub fn run_diff(window: &MainWindow, state: &mut AppState) {
         None => return,
     };
 
-    // ZIP archive comparison
-    if (is_zip_bytes(&left_bytes) || is_zip_path(&left_path))
-        && (is_zip_bytes(&right_bytes) || is_zip_path(&right_path))
-    {
-        run_zip_compare(
+    // Excel comparison (must be before zip detection; xlsx/xlsm/ods are zip containers)
+    if is_excel_path(&left_path) && is_excel_path(&right_path) {
+        run_excel_compare(
             window,
             state,
             &left_bytes,
@@ -31,9 +29,11 @@ pub fn run_diff(window: &MainWindow, state: &mut AppState) {
         return;
     }
 
-    // Excel comparison
-    if is_excel_path(&left_path) && is_excel_path(&right_path) {
-        run_excel_compare(
+    // ZIP archive comparison
+    if (is_zip_bytes(&left_bytes) || is_zip_path(&left_path))
+        && (is_zip_bytes(&right_bytes) || is_zip_path(&right_path))
+    {
+        run_zip_compare(
             window,
             state,
             &left_bytes,


### PR DESCRIPTION
Fixes #68 — see that issue for the full root-cause analysis, repro steps and before/after screenshots.

## Problem

`run_diff()` checks ZIP archives before Excel files. `is_zip_bytes()` matches any content starting with the `PK` magic, and `.xlsx` / `.xlsm` / `.ods` are all ZIP containers — so the Excel table-view branch is unreachable and every ZIP-based spreadsheet opens as an internal-XML folder view (`[ZIP] a.xlsx ↔ b.xlsx`).

## Fix

Reorder the dispatch so the extension-based Excel check runs before the ZIP check. Real `.zip` archives are unaffected; `.xls` (OLE container) is unaffected.

## Testing

- `cargo build --release --features desktop` on macOS 15.5 (Apple Silicon, Rust 1.98.1)
- Before: official v0.46.0 and a main@`d07440b` build both show `[ZIP] a.xlsx ↔ b.xlsx` for two .xlsx inputs (CLI, `git difftool`, and File → Open)
- After: same inputs show `[Excel] a.xlsx ↔ b.xlsx — 2 cells changed` with the table view, sheet selector and changed-cell highlights; a `.zip` pair still goes through the ZIP branch

Screenshots: [before](https://raw.githubusercontent.com/wickywe/winxmerge-issue-assets/main/before-zip-view.png) / [after](https://raw.githubusercontent.com/wickywe/winxmerge-issue-assets/main/after-excel-view.png)
